### PR TITLE
Add timeout-minutes to CI jobs

### DIFF
--- a/.github/workflows/run-test-and-deploy.yml
+++ b/.github/workflows/run-test-and-deploy.yml
@@ -8,6 +8,7 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     strategy:
       matrix:
         include:
@@ -70,6 +71,7 @@ jobs:
   deploy:
     name: Deploy to WP.org
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     needs: [test]
     steps:
       - name: Checkout

--- a/.github/workflows/run-test.yml
+++ b/.github/workflows/run-test.yml
@@ -16,6 +16,7 @@ concurrency:
 jobs:
   test:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     strategy:
       matrix:
         include:


### PR DESCRIPTION
Adds `timeout-minutes: 30` to the CI jobs (`test` in `run-test.yml`, and `test`/`deploy` in `run-test-and-deploy.yml`). Recently all matrix jobs hung indefinitely at the `Install Playwright dependencies` step and held the runner up to GitHub's default 6-hour limit. Setting a timeout makes such hangs fail fast and prevents long runner occupation. The Playwright install hang itself is a separate environment-related issue; this PR only mitigates the impact.
