### PR TITLE
Split test environment into a dedicated wp-env config

### DIFF
--- a/.github/workflows/run-test-and-deploy.yml
+++ b/.github/workflows/run-test-and-deploy.yml
@@ -60,9 +60,9 @@ jobs:
 
       - name: Install WordPress
         run: |
-          WP_ENV_CORE=WordPress/${{ matrix.wp }} WP_ENV_PHP_VERSION=${{ matrix.php }} npm run wp-env start
-          npm run wp-env run cli wp core version
-          npm run wp-env run cli wp cli info
+          WP_ENV_CORE=WordPress/${{ matrix.wp }} WP_ENV_PHP_VERSION=${{ matrix.php }} npm run wp-env-test start
+          npm run wp-env-test run cli wp core version
+          npm run wp-env-test run cli wp cli info
 
       - name: Running e2e tests
         run: npm run test:e2e

--- a/.github/workflows/run-test.yml
+++ b/.github/workflows/run-test.yml
@@ -68,9 +68,9 @@ jobs:
 
       - name: Install WordPress
         run: |
-          WP_ENV_CORE=WordPress/${{ matrix.wp }} WP_ENV_PHP_VERSION=${{ matrix.php }} npm run wp-env start
-          npm run wp-env run cli wp core version
-          npm run wp-env run cli wp cli info
+          WP_ENV_CORE=WordPress/${{ matrix.wp }} WP_ENV_PHP_VERSION=${{ matrix.php }} npm run wp-env-test start
+          npm run wp-env-test run cli wp core version
+          npm run wp-env-test run cli wp cli info
 
       - name: Running e2e tests
         run: npm run test:e2e

--- a/.wp-env.test.json
+++ b/.wp-env.test.json
@@ -6,5 +6,10 @@
 		"https://downloads.wordpress.org/plugin/wp-downgrade.zip"
 	],
 	"testsEnvironment": false,
-	"phpmyadminPort": 9000
+	"port": 8889,
+	"phpmyadminPort": 9001,
+	"config": {
+		"WP_DEBUG": true,
+		"SCRIPT_DEBUG": true
+	}
 }

--- a/package.json
+++ b/package.json
@@ -40,7 +40,8 @@
 	},
 	"scripts": {
 		"wp-env": "wp-env",
-		"stop": "wp-env stop",
+		"wp-env-test": "wp-env --config .wp-env.test.json",
+		"stop": "wp-env stop && wp-env --config .wp-env.test.json stop",
 		"start": "npm run clean && npm run copy-lib && wp-scripts start src/admin src/block-editor src/classic-editor src/theme-plugin-editor --output-path build",
 		"build": "npm run clean && wp-scripts build src/admin src/block-editor src/classic-editor src/theme-plugin-editor --output-path build && npm run copy-lib",
 		"copy-lib": "cpx -C \"node_modules/monaco-editor/min/**\" \"build/vendor/monaco-editor/min\" && node bin/delete-sourcemaps.js",

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -11,6 +11,10 @@ const config = require( '@wordpress/scripts/config/playwright.config.js' );
 export default {
 	...config,
 	testDir: './test/e2e',
+	webServer: {
+		...config.webServer,
+		command: 'npm run wp-env-test -- start',
+	},
 	projects: [
 		{
 			name: 'chromium',


### PR DESCRIPTION
wp-env deprecated the dual-environment startup that ran development and tests together. Move the tests setup into .wp-env.test.json and set testsEnvironment: false so the default config starts only the development environment, loading the test environment on demand via the new wp-env-test script (used by Playwright and CI).