### PR TITLE
Hide empty setting panels in search results

### DIFF
--- a/src/admin/editor-config/editor-options/accept-suggestion-on-enter.js
+++ b/src/admin/editor-config/editor-options/accept-suggestion-on-enter.js
@@ -30,29 +30,31 @@ export default function AcceptSuggestionOnEnter() {
 	};
 
 	return (
-		<HStack justify="start" align="start" wrap>
-			<ToggleControl
-				__nextHasNoMarginBottom
-				label={ title }
-				checked={ editorOptions.acceptSuggestionOnEnter }
-				onChange={ onChange }
-			/>
-			<ItemHelp
-				onChange={ onChange }
-				title={ title }
-				description={ createInterpolateElement(
-					__(
-						'Accept suggestions on <code>Enter</code> key in addition to <code>Tab</code> key.',
-						'custom-html-block-extension'
-					),
-					{
-						code: <code />,
-					}
-				) }
-				isToggle
-				defaultToggle
-				value={ editorOptions.acceptSuggestionOnEnter }
-			/>
-		</HStack>
+		<div className="chbe-admin-editor-config__setting-item">
+			<HStack justify="start" align="start" wrap>
+				<ToggleControl
+					__nextHasNoMarginBottom
+					label={ title }
+					checked={ editorOptions.acceptSuggestionOnEnter }
+					onChange={ onChange }
+				/>
+				<ItemHelp
+					onChange={ onChange }
+					title={ title }
+					description={ createInterpolateElement(
+						__(
+							'Accept suggestions on <code>Enter</code> key in addition to <code>Tab</code> key.',
+							'custom-html-block-extension'
+						),
+						{
+							code: <code />,
+						}
+					) }
+					isToggle
+					defaultToggle
+					value={ editorOptions.acceptSuggestionOnEnter }
+				/>
+			</HStack>
+		</div>
 	);
 }

--- a/src/admin/editor-config/editor-options/auto-closing-brackets.js
+++ b/src/admin/editor-config/editor-options/auto-closing-brackets.js
@@ -52,22 +52,24 @@ export default function AutoClosingBrackets() {
 	};
 
 	return (
-		<HStack justify="start" align="start" wrap>
-			<SelectControl
-				__next40pxDefaultSize
-				__nextHasNoMarginBottom
-				label={ title }
-				value={ editorOptions.autoClosingBrackets }
-				options={ items.map( ( { label, value } ) => ( { label, value } ) ) }
-				onChange={ onChange }
-			/>
-			<ItemHelp
-				onChange={ onChange }
-				title={ title }
-				items={ items }
-				colCount="3"
-				value={ editorOptions.autoClosingBrackets }
-			/>
-		</HStack>
+		<div className="chbe-admin-editor-config__setting-item">
+			<HStack justify="start" align="start" wrap>
+				<SelectControl
+					__next40pxDefaultSize
+					__nextHasNoMarginBottom
+					label={ title }
+					value={ editorOptions.autoClosingBrackets }
+					options={ items.map( ( { label, value } ) => ( { label, value } ) ) }
+					onChange={ onChange }
+				/>
+				<ItemHelp
+					onChange={ onChange }
+					title={ title }
+					items={ items }
+					colCount="3"
+					value={ editorOptions.autoClosingBrackets }
+				/>
+			</HStack>
+		</div>
 	);
 }

--- a/src/admin/editor-config/editor-options/auto-closing-quotes.js
+++ b/src/admin/editor-config/editor-options/auto-closing-quotes.js
@@ -52,22 +52,24 @@ export default function AutoClosingQuotes() {
 	};
 
 	return (
-		<HStack justify="start" align="start" wrap>
-			<SelectControl
-				__next40pxDefaultSize
-				__nextHasNoMarginBottom
-				label={ title }
-				value={ editorOptions.autoClosingQuotes }
-				options={ items.map( ( { label, value } ) => ( { label, value } ) ) }
-				onChange={ onChange }
-			/>
-			<ItemHelp
-				onChange={ onChange }
-				title={ title }
-				items={ items }
-				colCount="3"
-				value={ editorOptions.autoClosingQuotes }
-			/>
-		</HStack>
+		<div className="chbe-admin-editor-config__setting-item">
+			<HStack justify="start" align="start" wrap>
+				<SelectControl
+					__next40pxDefaultSize
+					__nextHasNoMarginBottom
+					label={ title }
+					value={ editorOptions.autoClosingQuotes }
+					options={ items.map( ( { label, value } ) => ( { label, value } ) ) }
+					onChange={ onChange }
+				/>
+				<ItemHelp
+					onChange={ onChange }
+					title={ title }
+					items={ items }
+					colCount="3"
+					value={ editorOptions.autoClosingQuotes }
+				/>
+			</HStack>
+		</div>
 	);
 }

--- a/src/admin/editor-config/editor-options/auto-indent.js
+++ b/src/admin/editor-config/editor-options/auto-indent.js
@@ -51,22 +51,24 @@ export default function AutoIndent() {
 	};
 
 	return (
-		<HStack justify="start" align="start" wrap>
-			<SelectControl
-				__next40pxDefaultSize
-				__nextHasNoMarginBottom
-				label={ title }
-				value={ editorOptions.autoIndent }
-				options={ items.map( ( { label, value } ) => ( { label, value } ) ) }
-				onChange={ onChange }
-			/>
-			<ItemHelp
-				onChange={ onChange }
-				title={ title }
-				items={ items }
-				colCount="3"
-				value={ editorOptions.autoIndent }
-			/>
-		</HStack>
+		<div className="chbe-admin-editor-config__setting-item">
+			<HStack justify="start" align="start" wrap>
+				<SelectControl
+					__next40pxDefaultSize
+					__nextHasNoMarginBottom
+					label={ title }
+					value={ editorOptions.autoIndent }
+					options={ items.map( ( { label, value } ) => ( { label, value } ) ) }
+					onChange={ onChange }
+				/>
+				<ItemHelp
+					onChange={ onChange }
+					title={ title }
+					items={ items }
+					colCount="3"
+					value={ editorOptions.autoIndent }
+				/>
+			</HStack>
+		</div>
 	);
 }

--- a/src/admin/editor-config/editor-options/auto-surround.js
+++ b/src/admin/editor-config/editor-options/auto-surround.js
@@ -57,21 +57,23 @@ export default function AutoSurround() {
 	};
 
 	return (
-		<HStack justify="start" align="start" wrap>
-			<SelectControl
-				__next40pxDefaultSize
-				__nextHasNoMarginBottom
-				label={ title }
-				value={ editorOptions.autoSurround }
-				options={ items.map( ( { label, value } ) => ( { label, value } ) ) }
-				onChange={ onChange }
-			/>
-			<ItemHelp
-				onChange={ onChange }
-				title={ title }
-				items={ items }
-				value={ editorOptions.autoSurround }
-			/>
-		</HStack>
+		<div className="chbe-admin-editor-config__setting-item">
+			<HStack justify="start" align="start" wrap>
+				<SelectControl
+					__next40pxDefaultSize
+					__nextHasNoMarginBottom
+					label={ title }
+					value={ editorOptions.autoSurround }
+					options={ items.map( ( { label, value } ) => ( { label, value } ) ) }
+					onChange={ onChange }
+				/>
+				<ItemHelp
+					onChange={ onChange }
+					title={ title }
+					items={ items }
+					value={ editorOptions.autoSurround }
+				/>
+			</HStack>
+		</div>
 	);
 }

--- a/src/admin/editor-config/editor-options/column-selection.js
+++ b/src/admin/editor-config/editor-options/column-selection.js
@@ -34,55 +34,57 @@ export default function ColumnSelection() {
 	};
 
 	return (
-		<HStack justify="start" align="start" wrap>
-			<ToggleControl
-				__nextHasNoMarginBottom
-				label={ __( 'Enable column selection', 'custom-html-block-extension' ) }
-				checked={ editorOptions.columnSelection }
-				onChange={ onChange }
-			/>
-			<ItemHelp
-				onChange={ onChange }
-				title={ title }
-				description={
-					<>
-						<Text as="p">
-							{ __(
-								'Always enable column selection. Following command can be used to select column selection even when disabled.',
-								'custom-html-block-extension'
-							) }
-						</Text>
-						<ul>
-							<li>
-								{ createInterpolateElement(
-									__(
-										'Windows: <code>Shift</code> + <code>Alt</code> + drag mouse, or "<code>Ctrl</code> + <code>Shift</code> + <code>Alt</code> + arrow key',
-										'custom-html-block-extension'
-									),
-									{
-										code: <code />,
-									}
+		<div className="chbe-admin-editor-config__setting-item">
+			<HStack justify="start" align="start" wrap>
+				<ToggleControl
+					__nextHasNoMarginBottom
+					label={ __( 'Enable column selection', 'custom-html-block-extension' ) }
+					checked={ editorOptions.columnSelection }
+					onChange={ onChange }
+				/>
+				<ItemHelp
+					onChange={ onChange }
+					title={ title }
+					description={
+						<>
+							<Text as="p">
+								{ __(
+									'Always enable column selection. Following command can be used to select column selection even when disabled.',
+									'custom-html-block-extension'
 								) }
-							</li>
-							<li>
-								{ createInterpolateElement(
-									__(
-										'macOS: <code>Shift</code> + <code>Option</code> + drag mouse, or <code>Shift</code> + <code>Option</code> + <code>Command</code> + arrow key',
-										'custom-html-block-extension'
-									),
-									{
-										code: <code />,
-									}
-								) }
-							</li>
-						</ul>
-					</>
-				}
-				isToggle
-				defaultToggle={ false }
-				image="editor-options/column-selection.gif"
-				value={ editorOptions.columnSelection }
-			/>
-		</HStack>
+							</Text>
+							<ul>
+								<li>
+									{ createInterpolateElement(
+										__(
+											'Windows: <code>Shift</code> + <code>Alt</code> + drag mouse, or "<code>Ctrl</code> + <code>Shift</code> + <code>Alt</code> + arrow key',
+											'custom-html-block-extension'
+										),
+										{
+											code: <code />,
+										}
+									) }
+								</li>
+								<li>
+									{ createInterpolateElement(
+										__(
+											'macOS: <code>Shift</code> + <code>Option</code> + drag mouse, or <code>Shift</code> + <code>Option</code> + <code>Command</code> + arrow key',
+											'custom-html-block-extension'
+										),
+										{
+											code: <code />,
+										}
+									) }
+								</li>
+							</ul>
+						</>
+					}
+					isToggle
+					defaultToggle={ false }
+					image="editor-options/column-selection.gif"
+					value={ editorOptions.columnSelection }
+				/>
+			</HStack>
+		</div>
 	);
 }

--- a/src/admin/editor-config/editor-options/comments/insert-space.js
+++ b/src/admin/editor-config/editor-options/comments/insert-space.js
@@ -33,35 +33,37 @@ export default function CommentsInsertSpace() {
 	};
 
 	return (
-		<HStack justify="start" align="start" wrap>
-			<ToggleControl
-				__nextHasNoMarginBottom
-				label={ title }
-				checked={ editorOptions.comments.insertSpace }
-				onChange={ onChange }
-			/>
-			<ItemHelp
-				onChange={ onChange }
-				title={ title }
-				description={ __(
-					'Insert whitespace inside the comment tokens when comment out using the keyboard shortcut.',
-					'custom-html-block-extension'
-				) }
-				items={ [
-					{
-						label: __( 'Enable', 'custom-html-block-extension' ),
-						value: true,
-						image: 'editor-options/comments_insert-space_1.jpg',
-						isDefault: true,
-					},
-					{
-						label: __( 'Disable', 'custom-html-block-extension' ),
-						value: false,
-						image: 'editor-options/comments_insert-space_2.jpg',
-					},
-				] }
-				value={ editorOptions.comments.insertSpace }
-			/>
-		</HStack>
+		<div className="chbe-admin-editor-config__setting-item">
+			<HStack justify="start" align="start" wrap>
+				<ToggleControl
+					__nextHasNoMarginBottom
+					label={ title }
+					checked={ editorOptions.comments.insertSpace }
+					onChange={ onChange }
+				/>
+				<ItemHelp
+					onChange={ onChange }
+					title={ title }
+					description={ __(
+						'Insert whitespace inside the comment tokens when comment out using the keyboard shortcut.',
+						'custom-html-block-extension'
+					) }
+					items={ [
+						{
+							label: __( 'Enable', 'custom-html-block-extension' ),
+							value: true,
+							image: 'editor-options/comments_insert-space_1.jpg',
+							isDefault: true,
+						},
+						{
+							label: __( 'Disable', 'custom-html-block-extension' ),
+							value: false,
+							image: 'editor-options/comments_insert-space_2.jpg',
+						},
+					] }
+					value={ editorOptions.comments.insertSpace }
+				/>
+			</HStack>
+		</div>
 	);
 }

--- a/src/admin/editor-config/editor-options/contextmenu.js
+++ b/src/admin/editor-config/editor-options/contextmenu.js
@@ -30,37 +30,39 @@ export default function Contextmenu() {
 	};
 
 	return (
-		<HStack justify="start" align="start" wrap>
-			<ToggleControl
-				__nextHasNoMarginBottom
-				label={ title }
-				checked={ editorOptions.contextmenu }
-				onChange={ onChange }
-			/>
-			<ItemHelp
-				onChange={ onChange }
-				title={ title }
-				description={ __(
-					'Sets the context menu when right-click in the editor.',
-					'custom-html-block-extension'
-				) }
-				items={ [
-					{
-						label: __( 'Enable', 'custom-html-block-extension' ),
-						value: true,
-						image: 'editor-options/contextmenu_1.jpg',
-						isDefault: true,
-						description: __( 'Show the editor context menu.', 'custom-html-block-extension' ),
-					},
-					{
-						label: __( 'Disable', 'custom-html-block-extension' ),
-						value: false,
-						image: 'editor-options/contextmenu_2.jpg',
-						description: __( 'Show the browser context menu.', 'custom-html-block-extension' ),
-					},
-				] }
-				value={ editorOptions.contextmenu }
-			/>
-		</HStack>
+		<div className="chbe-admin-editor-config__setting-item">
+			<HStack justify="start" align="start" wrap>
+				<ToggleControl
+					__nextHasNoMarginBottom
+					label={ title }
+					checked={ editorOptions.contextmenu }
+					onChange={ onChange }
+				/>
+				<ItemHelp
+					onChange={ onChange }
+					title={ title }
+					description={ __(
+						'Sets the context menu when right-click in the editor.',
+						'custom-html-block-extension'
+					) }
+					items={ [
+						{
+							label: __( 'Enable', 'custom-html-block-extension' ),
+							value: true,
+							image: 'editor-options/contextmenu_1.jpg',
+							isDefault: true,
+							description: __( 'Show the editor context menu.', 'custom-html-block-extension' ),
+						},
+						{
+							label: __( 'Disable', 'custom-html-block-extension' ),
+							value: false,
+							image: 'editor-options/contextmenu_2.jpg',
+							description: __( 'Show the browser context menu.', 'custom-html-block-extension' ),
+						},
+					] }
+					value={ editorOptions.contextmenu }
+				/>
+			</HStack>
+		</div>
 	);
 }

--- a/src/admin/editor-config/editor-options/copy-with-syntax-highlighting.js
+++ b/src/admin/editor-config/editor-options/copy-with-syntax-highlighting.js
@@ -30,35 +30,37 @@ export default function CopyWithSyntaxHighlighting() {
 	};
 
 	return (
-		<HStack justify="start" align="start" wrap>
-			<ToggleControl
-				__nextHasNoMarginBottom
-				label={ title }
-				checked={ editorOptions.copyWithSyntaxHighlighting }
-				onChange={ onChange }
-			/>
-			<ItemHelp
-				onChange={ onChange }
-				title={ title }
-				description={ __(
-					'Example: How it looks when pasted into Microsoft Word',
-					'custom-html-block-extension'
-				) }
-				items={ [
-					{
-						label: __( 'Enable', 'custom-html-block-extension' ),
-						value: true,
-						image: 'editor-options/copy-with-syntax-highlighting_1.jpg',
-						isDefault: true,
-					},
-					{
-						label: __( 'Disable', 'custom-html-block-extension' ),
-						value: false,
-						image: 'editor-options/copy-with-syntax-highlighting_2.jpg',
-					},
-				] }
-				value={ editorOptions.copyWithSyntaxHighlighting }
-			/>
-		</HStack>
+		<div className="chbe-admin-editor-config__setting-item">
+			<HStack justify="start" align="start" wrap>
+				<ToggleControl
+					__nextHasNoMarginBottom
+					label={ title }
+					checked={ editorOptions.copyWithSyntaxHighlighting }
+					onChange={ onChange }
+				/>
+				<ItemHelp
+					onChange={ onChange }
+					title={ title }
+					description={ __(
+						'Example: How it looks when pasted into Microsoft Word',
+						'custom-html-block-extension'
+					) }
+					items={ [
+						{
+							label: __( 'Enable', 'custom-html-block-extension' ),
+							value: true,
+							image: 'editor-options/copy-with-syntax-highlighting_1.jpg',
+							isDefault: true,
+						},
+						{
+							label: __( 'Disable', 'custom-html-block-extension' ),
+							value: false,
+							image: 'editor-options/copy-with-syntax-highlighting_2.jpg',
+						},
+					] }
+					value={ editorOptions.copyWithSyntaxHighlighting }
+				/>
+			</HStack>
+		</div>
 	);
 }

--- a/src/admin/editor-config/editor-options/cursor-blinking.js
+++ b/src/admin/editor-config/editor-options/cursor-blinking.js
@@ -59,22 +59,24 @@ export default function CursorBlinking() {
 	};
 
 	return (
-		<HStack justify="start" align="start" wrap>
-			<SelectControl
-				__next40pxDefaultSize
-				__nextHasNoMarginBottom
-				label={ title }
-				value={ editorOptions.cursorBlinking }
-				options={ items.map( ( { label, value } ) => ( { label, value } ) ) }
-				onChange={ onChange }
-			/>
-			<ItemHelp
-				onChange={ onChange }
-				title={ title }
-				items={ items }
-				colCount="5"
-				value={ editorOptions.cursorBlinking }
-			/>
-		</HStack>
+		<div className="chbe-admin-editor-config__setting-item">
+			<HStack justify="start" align="start" wrap>
+				<SelectControl
+					__next40pxDefaultSize
+					__nextHasNoMarginBottom
+					label={ title }
+					value={ editorOptions.cursorBlinking }
+					options={ items.map( ( { label, value } ) => ( { label, value } ) ) }
+					onChange={ onChange }
+				/>
+				<ItemHelp
+					onChange={ onChange }
+					title={ title }
+					items={ items }
+					colCount="5"
+					value={ editorOptions.cursorBlinking }
+				/>
+			</HStack>
+		</div>
 	);
 }

--- a/src/admin/editor-config/editor-options/cursor-smooth-caret-animation.js
+++ b/src/admin/editor-config/editor-options/cursor-smooth-caret-animation.js
@@ -30,31 +30,33 @@ export default function CursorSmoothCaretAnimation() {
 	};
 
 	return (
-		<HStack justify="start" align="start" wrap>
-			<ToggleControl
-				__nextHasNoMarginBottom
-				label={ title }
-				checked={ editorOptions.cursorSmoothCaretAnimation }
-				onChange={ onChange }
-			/>
-			<ItemHelp
-				onChange={ onChange }
-				title={ title }
-				items={ [
-					{
-						label: __( 'Enable', 'custom-html-block-extension' ),
-						value: true,
-						image: 'editor-options/cursor-smooth-caret-animation_1.gif',
-					},
-					{
-						label: __( 'Disable', 'custom-html-block-extension' ),
-						value: false,
-						image: 'editor-options/cursor-smooth-caret-animation_2.gif',
-						isDefault: true,
-					},
-				] }
-				value={ editorOptions.cursorSmoothCaretAnimation }
-			/>
-		</HStack>
+		<div className="chbe-admin-editor-config__setting-item">
+			<HStack justify="start" align="start" wrap>
+				<ToggleControl
+					__nextHasNoMarginBottom
+					label={ title }
+					checked={ editorOptions.cursorSmoothCaretAnimation }
+					onChange={ onChange }
+				/>
+				<ItemHelp
+					onChange={ onChange }
+					title={ title }
+					items={ [
+						{
+							label: __( 'Enable', 'custom-html-block-extension' ),
+							value: true,
+							image: 'editor-options/cursor-smooth-caret-animation_1.gif',
+						},
+						{
+							label: __( 'Disable', 'custom-html-block-extension' ),
+							value: false,
+							image: 'editor-options/cursor-smooth-caret-animation_2.gif',
+							isDefault: true,
+						},
+					] }
+					value={ editorOptions.cursorSmoothCaretAnimation }
+				/>
+			</HStack>
+		</div>
 	);
 }

--- a/src/admin/editor-config/editor-options/cursor-style.js
+++ b/src/admin/editor-config/editor-options/cursor-style.js
@@ -64,22 +64,24 @@ export default function CursorStyle() {
 	};
 
 	return (
-		<HStack justify="start" align="start" wrap>
-			<SelectControl
-				__next40pxDefaultSize
-				__nextHasNoMarginBottom
-				label={ title }
-				value={ editorOptions.cursorStyle }
-				options={ items.map( ( { label, value } ) => ( { label, value } ) ) }
-				onChange={ onChange }
-			/>
-			<ItemHelp
-				onChange={ onChange }
-				title={ title }
-				items={ items }
-				colCount="3"
-				value={ editorOptions.cursorStyle }
-			/>
-		</HStack>
+		<div className="chbe-admin-editor-config__setting-item">
+			<HStack justify="start" align="start" wrap>
+				<SelectControl
+					__next40pxDefaultSize
+					__nextHasNoMarginBottom
+					label={ title }
+					value={ editorOptions.cursorStyle }
+					options={ items.map( ( { label, value } ) => ( { label, value } ) ) }
+					onChange={ onChange }
+				/>
+				<ItemHelp
+					onChange={ onChange }
+					title={ title }
+					items={ items }
+					colCount="3"
+					value={ editorOptions.cursorStyle }
+				/>
+			</HStack>
+		</div>
 	);
 }

--- a/src/admin/editor-config/editor-options/cursor-surrounding-lines-style.js
+++ b/src/admin/editor-config/editor-options/cursor-surrounding-lines-style.js
@@ -33,35 +33,37 @@ export default function CursorSurroundingLinesStyle() {
 	};
 
 	return (
-		<HStack justify="start" align="start" wrap>
-			<ToggleControl
-				__nextHasNoMarginBottom
-				label={ title }
-				checked={ 'all' === editorOptions.cursorSurroundingLinesStyle }
-				onChange={ onChange }
-			/>
-			<ItemHelp
-				onChange={ onChange }
-				title={ title }
-				description={ __(
-					'Sets the context menu when right-click in the editor.',
-					'custom-html-block-extension'
-				) }
-				items={ [
-					{
-						label: __( 'Enable', 'custom-html-block-extension' ),
-						value: true,
-						image: 'editor-options/cursor-surrounding-lines-style_1.gif',
-					},
-					{
-						label: __( 'Disable', 'custom-html-block-extension' ),
-						value: false,
-						image: 'editor-options/cursor-surrounding-lines-style_2.gif',
-						isDefault: true,
-					},
-				] }
-				value={ 'all' === editorOptions.cursorSurroundingLinesStyle }
-			/>
-		</HStack>
+		<div className="chbe-admin-editor-config__setting-item">
+			<HStack justify="start" align="start" wrap>
+				<ToggleControl
+					__nextHasNoMarginBottom
+					label={ title }
+					checked={ 'all' === editorOptions.cursorSurroundingLinesStyle }
+					onChange={ onChange }
+				/>
+				<ItemHelp
+					onChange={ onChange }
+					title={ title }
+					description={ __(
+						'Sets the context menu when right-click in the editor.',
+						'custom-html-block-extension'
+					) }
+					items={ [
+						{
+							label: __( 'Enable', 'custom-html-block-extension' ),
+							value: true,
+							image: 'editor-options/cursor-surrounding-lines-style_1.gif',
+						},
+						{
+							label: __( 'Disable', 'custom-html-block-extension' ),
+							value: false,
+							image: 'editor-options/cursor-surrounding-lines-style_2.gif',
+							isDefault: true,
+						},
+					] }
+					value={ 'all' === editorOptions.cursorSurroundingLinesStyle }
+				/>
+			</HStack>
+		</div>
 	);
 }

--- a/src/admin/editor-config/editor-options/cursor-surrounding-lines.js
+++ b/src/admin/editor-config/editor-options/cursor-surrounding-lines.js
@@ -34,46 +34,48 @@ export default function CursorSurroundingLines() {
 	};
 
 	return (
-		<HStack justify="start" align="start" wrap>
-			<RangeControl
-				__next40pxDefaultSize
-				__nextHasNoMarginBottom
-				label={ title }
-				value={ editorOptions.cursorSurroundingLines }
-				min={ 0 }
-				max={ 20 }
-				allowReset
-				onChange={ onChange }
-			/>
-			<ItemHelp
-				onChange={ onChange }
-				title={ title }
-				description={ __(
-					'Sets the number of lines to keep before and after the cursor when the cursor is moved up and down.',
-					'custom-html-block-extension'
-				) }
-				items={ [
-					{
-						label: sprintf(
-							/* translators: %s is replaced with the number. */
-							__( 'Example: Set the value to %s', 'custom-html-block-extension' ),
-							0
-						),
-						image: 'editor-options/cursor-surrounding-lines_1.gif',
-						value: 0,
-					},
-					{
-						label: sprintf(
-							/* translators: %s is replaced with the number. */
-							__( 'Example: Set the value to %s', 'custom-html-block-extension' ),
-							5
-						),
-						image: 'editor-options/cursor-surrounding-lines_2.gif',
-						value: 5,
-					},
-				] }
-				value={ editorOptions.cursorSurroundingLines }
-			/>
-		</HStack>
+		<div className="chbe-admin-editor-config__setting-item">
+			<HStack justify="start" align="start" wrap>
+				<RangeControl
+					__next40pxDefaultSize
+					__nextHasNoMarginBottom
+					label={ title }
+					value={ editorOptions.cursorSurroundingLines }
+					min={ 0 }
+					max={ 20 }
+					allowReset
+					onChange={ onChange }
+				/>
+				<ItemHelp
+					onChange={ onChange }
+					title={ title }
+					description={ __(
+						'Sets the number of lines to keep before and after the cursor when the cursor is moved up and down.',
+						'custom-html-block-extension'
+					) }
+					items={ [
+						{
+							label: sprintf(
+								/* translators: %s is replaced with the number. */
+								__( 'Example: Set the value to %s', 'custom-html-block-extension' ),
+								0
+							),
+							image: 'editor-options/cursor-surrounding-lines_1.gif',
+							value: 0,
+						},
+						{
+							label: sprintf(
+								/* translators: %s is replaced with the number. */
+								__( 'Example: Set the value to %s', 'custom-html-block-extension' ),
+								5
+							),
+							image: 'editor-options/cursor-surrounding-lines_2.gif',
+							value: 5,
+						},
+					] }
+					value={ editorOptions.cursorSurroundingLines }
+				/>
+			</HStack>
+		</div>
 	);
 }

--- a/src/admin/editor-config/editor-options/cursor-width.js
+++ b/src/admin/editor-config/editor-options/cursor-width.js
@@ -30,15 +30,17 @@ export default function CursorWidth() {
 	};
 
 	return (
-		<RangeControl
-			__next40pxDefaultSize
-			__nextHasNoMarginBottom
-			label={ title }
-			value={ editorOptions.cursorWidth }
-			min={ 2 }
-			max={ 10 }
-			allowReset
-			onChange={ onChange }
-		/>
+		<div className="chbe-admin-editor-config__setting-item">
+			<RangeControl
+				__next40pxDefaultSize
+				__nextHasNoMarginBottom
+				label={ title }
+				value={ editorOptions.cursorWidth }
+				min={ 2 }
+				max={ 10 }
+				allowReset
+				onChange={ onChange }
+			/>
+		</div>
 	);
 }

--- a/src/admin/editor-config/editor-options/drag-and-drop.js
+++ b/src/admin/editor-config/editor-options/drag-and-drop.js
@@ -30,21 +30,23 @@ export default function DragAndDrop() {
 	};
 
 	return (
-		<HStack justify="start" align="start" wrap>
-			<ToggleControl
-				__nextHasNoMarginBottom
-				label={ title }
-				checked={ editorOptions.dragAndDrop }
-				onChange={ onChange }
-			/>
-			<ItemHelp
-				onChange={ onChange }
-				title={ title }
-				isToggle
-				defaultToggle={ false }
-				image="editor-options/drag-and-drop.gif"
-				value={ editorOptions.dragAndDrop }
-			/>
-		</HStack>
+		<div className="chbe-admin-editor-config__setting-item">
+			<HStack justify="start" align="start" wrap>
+				<ToggleControl
+					__nextHasNoMarginBottom
+					label={ title }
+					checked={ editorOptions.dragAndDrop }
+					onChange={ onChange }
+				/>
+				<ItemHelp
+					onChange={ onChange }
+					title={ title }
+					isToggle
+					defaultToggle={ false }
+					image="editor-options/drag-and-drop.gif"
+					value={ editorOptions.dragAndDrop }
+				/>
+			</HStack>
+		</div>
 	);
 }

--- a/src/admin/editor-config/editor-options/empty-selection-clipboard.js
+++ b/src/admin/editor-config/editor-options/empty-selection-clipboard.js
@@ -30,21 +30,23 @@ export default function EmptySelectionClipboard() {
 	};
 
 	return (
-		<HStack justify="start" align="start" wrap>
-			<ToggleControl
-				__nextHasNoMarginBottom
-				label={ title }
-				checked={ editorOptions.emptySelectionClipboard }
-				onChange={ onChange }
-			/>
-			<ItemHelp
-				onChange={ onChange }
-				title={ title }
-				isToggle
-				defaultToggle
-				image="editor-options/empty-selection-clipboard.gif"
-				value={ editorOptions.emptySelectionClipboard }
-			/>
-		</HStack>
+		<div className="chbe-admin-editor-config__setting-item">
+			<HStack justify="start" align="start" wrap>
+				<ToggleControl
+					__nextHasNoMarginBottom
+					label={ title }
+					checked={ editorOptions.emptySelectionClipboard }
+					onChange={ onChange }
+				/>
+				<ItemHelp
+					onChange={ onChange }
+					title={ title }
+					isToggle
+					defaultToggle
+					image="editor-options/empty-selection-clipboard.gif"
+					value={ editorOptions.emptySelectionClipboard }
+				/>
+			</HStack>
+		</div>
 	);
 }

--- a/src/admin/editor-config/editor-options/fast-scroll-sensitivity.js
+++ b/src/admin/editor-config/editor-options/fast-scroll-sensitivity.js
@@ -33,15 +33,17 @@ export default function FastScrollSensitivity() {
 	};
 
 	return (
-		<RangeControl
-			__next40pxDefaultSize
-			__nextHasNoMarginBottom
-			label={ title }
-			min={ 1 }
-			max={ 10 }
-			value={ editorOptions.fastScrollSensitivity }
-			allowReset
-			onChange={ onChange }
-		/>
+		<div className="chbe-admin-editor-config__setting-item">
+			<RangeControl
+				__next40pxDefaultSize
+				__nextHasNoMarginBottom
+				label={ title }
+				min={ 1 }
+				max={ 10 }
+				value={ editorOptions.fastScrollSensitivity }
+				allowReset
+				onChange={ onChange }
+			/>
+		</div>
 	);
 }

--- a/src/admin/editor-config/editor-options/find/addextra-space-on-top.js
+++ b/src/admin/editor-config/editor-options/find/addextra-space-on-top.js
@@ -33,31 +33,33 @@ export default function FindAddExtraSpaceOnTop() {
 	};
 
 	return (
-		<HStack justify="start" align="start" wrap>
-			<ToggleControl
-				__nextHasNoMarginBottom
-				label={ title }
-				checked={ editorOptions.find.addExtraSpaceOnTop }
-				onChange={ onChange }
-			/>
-			<ItemHelp
-				onChange={ onChange }
-				title={ title }
-				items={ [
-					{
-						label: __( 'Enable', 'custom-html-block-extension' ),
-						value: true,
-						image: 'editor-options/find/addextra-space-on-top_1.jpg',
-						isDefault: true,
-					},
-					{
-						label: __( 'Disable', 'custom-html-block-extension' ),
-						value: false,
-						image: 'editor-options/find/addextra-space-on-top_2.jpg',
-					},
-				] }
-				value={ editorOptions.find.addExtraSpaceOnTop }
-			/>
-		</HStack>
+		<div className="chbe-admin-editor-config__setting-item">
+			<HStack justify="start" align="start" wrap>
+				<ToggleControl
+					__nextHasNoMarginBottom
+					label={ title }
+					checked={ editorOptions.find.addExtraSpaceOnTop }
+					onChange={ onChange }
+				/>
+				<ItemHelp
+					onChange={ onChange }
+					title={ title }
+					items={ [
+						{
+							label: __( 'Enable', 'custom-html-block-extension' ),
+							value: true,
+							image: 'editor-options/find/addextra-space-on-top_1.jpg',
+							isDefault: true,
+						},
+						{
+							label: __( 'Disable', 'custom-html-block-extension' ),
+							value: false,
+							image: 'editor-options/find/addextra-space-on-top_2.jpg',
+						},
+					] }
+					value={ editorOptions.find.addExtraSpaceOnTop }
+				/>
+			</HStack>
+		</div>
 	);
 }

--- a/src/admin/editor-config/editor-options/find/loop.js
+++ b/src/admin/editor-config/editor-options/find/loop.js
@@ -33,25 +33,27 @@ export default function FindLoop() {
 	};
 
 	return (
-		<HStack justify="start" align="start" wrap>
-			<ToggleControl
-				__nextHasNoMarginBottom
-				label={ title }
-				checked={ editorOptions.find.loop }
-				onChange={ onChange }
-			/>
-			<ItemHelp
-				onChange={ onChange }
-				title={ title }
-				description={ __(
-					'Automatically restart the search from the beginning (or end) when no more matches are found.',
-					'custom-html-block-extension'
-				) }
-				isToggle
-				defaultToggle
-				image="editor-options/find/loop.gif"
-				value={ editorOptions.find.loop }
-			/>
-		</HStack>
+		<div className="chbe-admin-editor-config__setting-item">
+			<HStack justify="start" align="start" wrap>
+				<ToggleControl
+					__nextHasNoMarginBottom
+					label={ title }
+					checked={ editorOptions.find.loop }
+					onChange={ onChange }
+				/>
+				<ItemHelp
+					onChange={ onChange }
+					title={ title }
+					description={ __(
+						'Automatically restart the search from the beginning (or end) when no more matches are found.',
+						'custom-html-block-extension'
+					) }
+					isToggle
+					defaultToggle
+					image="editor-options/find/loop.gif"
+					value={ editorOptions.find.loop }
+				/>
+			</HStack>
+		</div>
 	);
 }

--- a/src/admin/editor-config/editor-options/find/seed-search-string-from-selection.js
+++ b/src/admin/editor-config/editor-options/find/seed-search-string-from-selection.js
@@ -33,21 +33,23 @@ export default function FindSeedSearchStringFromSelection() {
 	};
 
 	return (
-		<HStack justify="start" align="start" wrap>
-			<ToggleControl
-				__nextHasNoMarginBottom
-				label={ title }
-				checked={ editorOptions.find.seedSearchStringFromSelection }
-				onChange={ onChange }
-			/>
-			<ItemHelp
-				onChange={ onChange }
-				title={ title }
-				isToggle
-				defaultToggle
-				image="editor-options/find/seed-search-string-from-selection.gif"
-				value={ editorOptions.find.seedSearchStringFromSelection }
-			/>
-		</HStack>
+		<div className="chbe-admin-editor-config__setting-item">
+			<HStack justify="start" align="start" wrap>
+				<ToggleControl
+					__nextHasNoMarginBottom
+					label={ title }
+					checked={ editorOptions.find.seedSearchStringFromSelection }
+					onChange={ onChange }
+				/>
+				<ItemHelp
+					onChange={ onChange }
+					title={ title }
+					isToggle
+					defaultToggle
+					image="editor-options/find/seed-search-string-from-selection.gif"
+					value={ editorOptions.find.seedSearchStringFromSelection }
+				/>
+			</HStack>
+		</div>
 	);
 }

--- a/src/admin/editor-config/editor-options/folding-highlight.js
+++ b/src/admin/editor-config/editor-options/folding-highlight.js
@@ -30,31 +30,33 @@ export default function FoldingHighlight() {
 	};
 
 	return (
-		<HStack justify="start" align="start" wrap>
-			<ToggleControl
-				__nextHasNoMarginBottom
-				label={ title }
-				checked={ editorOptions.foldingHighlight }
-				onChange={ onChange }
-			/>
-			<ItemHelp
-				onChange={ onChange }
-				title={ title }
-				items={ [
-					{
-						label: __( 'Enable', 'custom-html-block-extension' ),
-						value: true,
-						image: 'editor-options/folding-highlight_1.jpg',
-						isDefault: true,
-					},
-					{
-						label: __( 'Disable', 'custom-html-block-extension' ),
-						value: false,
-						image: 'editor-options/folding-highlight_2.jpg',
-					},
-				] }
-				value={ editorOptions.foldingHighlight }
-			/>
-		</HStack>
+		<div className="chbe-admin-editor-config__setting-item">
+			<HStack justify="start" align="start" wrap>
+				<ToggleControl
+					__nextHasNoMarginBottom
+					label={ title }
+					checked={ editorOptions.foldingHighlight }
+					onChange={ onChange }
+				/>
+				<ItemHelp
+					onChange={ onChange }
+					title={ title }
+					items={ [
+						{
+							label: __( 'Enable', 'custom-html-block-extension' ),
+							value: true,
+							image: 'editor-options/folding-highlight_1.jpg',
+							isDefault: true,
+						},
+						{
+							label: __( 'Disable', 'custom-html-block-extension' ),
+							value: false,
+							image: 'editor-options/folding-highlight_2.jpg',
+						},
+					] }
+					value={ editorOptions.foldingHighlight }
+				/>
+			</HStack>
+		</div>
 	);
 }

--- a/src/admin/editor-config/editor-options/folding-strategy.js
+++ b/src/admin/editor-config/editor-options/folding-strategy.js
@@ -48,21 +48,23 @@ export default function FoldingStrategy() {
 	};
 
 	return (
-		<HStack justify="start" align="start" wrap>
-			<SelectControl
-				__next40pxDefaultSize
-				__nextHasNoMarginBottom
-				label={ title }
-				value={ editorOptions.foldingStrategy }
-				options={ items.map( ( { label, value } ) => ( { label, value } ) ) }
-				onChange={ onChange }
-			/>
-			<ItemHelp
-				onChange={ onChange }
-				title={ title }
-				items={ items }
-				value={ editorOptions.foldingStrategy }
-			/>
-		</HStack>
+		<div className="chbe-admin-editor-config__setting-item">
+			<HStack justify="start" align="start" wrap>
+				<SelectControl
+					__next40pxDefaultSize
+					__nextHasNoMarginBottom
+					label={ title }
+					value={ editorOptions.foldingStrategy }
+					options={ items.map( ( { label, value } ) => ( { label, value } ) ) }
+					onChange={ onChange }
+				/>
+				<ItemHelp
+					onChange={ onChange }
+					title={ title }
+					items={ items }
+					value={ editorOptions.foldingStrategy }
+				/>
+			</HStack>
+		</div>
 	);
 }

--- a/src/admin/editor-config/editor-options/folding.js
+++ b/src/admin/editor-config/editor-options/folding.js
@@ -30,25 +30,27 @@ export default function Folding() {
 	};
 
 	return (
-		<HStack justify="start" align="start" wrap>
-			<ToggleControl
-				__nextHasNoMarginBottom
-				label={ title }
-				checked={ editorOptions.folding }
-				onChange={ onChange }
-			/>
-			<ItemHelp
-				onChange={ onChange }
-				title={ title }
-				description={ __(
-					'You can fold regions of source code using the folding icons between line numbers and line start. Move the mouse over the folding icon and click to fold and unfold regions. Use Shift + Click on the folding icon to fold or unfold the region and all regions inside.',
-					'custom-html-block-extension'
-				) }
-				isToggle
-				defaultToggle
-				image="editor-options/folding.gif"
-				value={ editorOptions.folding }
-			/>
-		</HStack>
+		<div className="chbe-admin-editor-config__setting-item">
+			<HStack justify="start" align="start" wrap>
+				<ToggleControl
+					__nextHasNoMarginBottom
+					label={ title }
+					checked={ editorOptions.folding }
+					onChange={ onChange }
+				/>
+				<ItemHelp
+					onChange={ onChange }
+					title={ title }
+					description={ __(
+						'You can fold regions of source code using the folding icons between line numbers and line start. Move the mouse over the folding icon and click to fold and unfold regions. Use Shift + Click on the folding icon to fold or unfold the region and all regions inside.',
+						'custom-html-block-extension'
+					) }
+					isToggle
+					defaultToggle
+					image="editor-options/folding.gif"
+					value={ editorOptions.folding }
+				/>
+			</HStack>
+		</div>
 	);
 }

--- a/src/admin/editor-config/editor-options/font-family.js
+++ b/src/admin/editor-config/editor-options/font-family.js
@@ -35,47 +35,49 @@ export default function FontFamily() {
 	};
 
 	return (
-		<HStack justify="start" align="start" wrap>
-			<SelectControl
-				__next40pxDefaultSize
-				__nextHasNoMarginBottom
-				label={ title }
-				value={ editorOptions.fontFamily }
-				options={ [
-					...window.chbeObj.fontFamily.map( ( { label, name } ) => ( {
-						label,
-						value: name,
-					} ) ),
-					{
-						label: __( 'Monospace', 'custom-html-block-extension' ),
-						value: 'monospace',
-					},
-				] }
-				onChange={ onChange }
-			/>
-			<ItemHelp
-				title={ title }
-				description={
-					<>
-						<Text as="p">
-							{ __(
-								'You can use your own favorite fonts in addition to the default fonts. Please refer to the following document for instructions on how to add custom fonts.',
-								'custom-html-block-extension'
-							) }
-						</Text>
-						<Text as="p">
-							<ExternalLink
-								href={ __(
-									'https://github.com/t-hamano/custom-html-block-extension#add-custom-fonts',
+		<div className="chbe-admin-editor-config__setting-item">
+			<HStack justify="start" align="start" wrap>
+				<SelectControl
+					__next40pxDefaultSize
+					__nextHasNoMarginBottom
+					label={ title }
+					value={ editorOptions.fontFamily }
+					options={ [
+						...window.chbeObj.fontFamily.map( ( { label, name } ) => ( {
+							label,
+							value: name,
+						} ) ),
+						{
+							label: __( 'Monospace', 'custom-html-block-extension' ),
+							value: 'monospace',
+						},
+					] }
+					onChange={ onChange }
+				/>
+				<ItemHelp
+					title={ title }
+					description={
+						<>
+							<Text as="p">
+								{ __(
+									'You can use your own favorite fonts in addition to the default fonts. Please refer to the following document for instructions on how to add custom fonts.',
 									'custom-html-block-extension'
 								) }
-							>
-								{ __( 'GitHub project page', 'custom-html-block-extension' ) }
-							</ExternalLink>
-						</Text>
-					</>
-				}
-			/>
-		</HStack>
+							</Text>
+							<Text as="p">
+								<ExternalLink
+									href={ __(
+										'https://github.com/t-hamano/custom-html-block-extension#add-custom-fonts',
+										'custom-html-block-extension'
+									) }
+								>
+									{ __( 'GitHub project page', 'custom-html-block-extension' ) }
+								</ExternalLink>
+							</Text>
+						</>
+					}
+				/>
+			</HStack>
+		</div>
 	);
 }

--- a/src/admin/editor-config/editor-options/font-ligatures.js
+++ b/src/admin/editor-config/editor-options/font-ligatures.js
@@ -30,35 +30,37 @@ export default function FontLigatures() {
 	};
 
 	return (
-		<HStack justify="start" align="start" wrap>
-			<ToggleControl
-				__nextHasNoMarginBottom
-				label={ title }
-				checked={ editorOptions.fontLigatures }
-				onChange={ onChange }
-			/>
-			<ItemHelp
-				onChange={ onChange }
-				title={ title }
-				description={ __(
-					'Ligatures are special characters in a font that combine two or more characters into one. Only Fira Code font supports ligatures.',
-					'custom-html-block-extension'
-				) }
-				items={ [
-					{
-						label: __( 'Enable', 'custom-html-block-extension' ),
-						value: true,
-						image: 'editor-options/font-ligatures_1.jpg',
-						isDefault: true,
-					},
-					{
-						label: __( 'Disable', 'custom-html-block-extension' ),
-						value: false,
-						image: 'editor-options/font-ligatures_2.jpg',
-					},
-				] }
-				value={ editorOptions.fontLigatures }
-			/>
-		</HStack>
+		<div className="chbe-admin-editor-config__setting-item">
+			<HStack justify="start" align="start" wrap>
+				<ToggleControl
+					__nextHasNoMarginBottom
+					label={ title }
+					checked={ editorOptions.fontLigatures }
+					onChange={ onChange }
+				/>
+				<ItemHelp
+					onChange={ onChange }
+					title={ title }
+					description={ __(
+						'Ligatures are special characters in a font that combine two or more characters into one. Only Fira Code font supports ligatures.',
+						'custom-html-block-extension'
+					) }
+					items={ [
+						{
+							label: __( 'Enable', 'custom-html-block-extension' ),
+							value: true,
+							image: 'editor-options/font-ligatures_1.jpg',
+							isDefault: true,
+						},
+						{
+							label: __( 'Disable', 'custom-html-block-extension' ),
+							value: false,
+							image: 'editor-options/font-ligatures_2.jpg',
+						},
+					] }
+					value={ editorOptions.fontLigatures }
+				/>
+			</HStack>
+		</div>
 	);
 }

--- a/src/admin/editor-config/editor-options/font-size.js
+++ b/src/admin/editor-config/editor-options/font-size.js
@@ -30,15 +30,17 @@ export default function FontSize() {
 	};
 
 	return (
-		<RangeControl
-			__next40pxDefaultSize
-			__nextHasNoMarginBottom
-			label={ title }
-			value={ editorOptions.fontSize }
-			min={ 10 }
-			max={ 30 }
-			allowReset
-			onChange={ onChange }
-		/>
+		<div className="chbe-admin-editor-config__setting-item">
+			<RangeControl
+				__next40pxDefaultSize
+				__nextHasNoMarginBottom
+				label={ title }
+				value={ editorOptions.fontSize }
+				min={ 10 }
+				max={ 30 }
+				allowReset
+				onChange={ onChange }
+			/>
+		</div>
 	);
 }

--- a/src/admin/editor-config/editor-options/font-weight.js
+++ b/src/admin/editor-config/editor-options/font-weight.js
@@ -29,18 +29,20 @@ export default function FontWeight( { fontWeights } ) {
 	};
 
 	return (
-		<HStack>
-			<SelectControl
-				__next40pxDefaultSize
-				__nextHasNoMarginBottom
-				label={ title }
-				value={ Number( editorOptions.fontWeight ) }
-				options={ fontWeights.map( ( fontWeight ) => ( {
-					label: fontWeight,
-					value: fontWeight,
-				} ) ) }
-				onChange={ onChange }
-			/>
-		</HStack>
+		<div className="chbe-admin-editor-config__setting-item">
+			<HStack>
+				<SelectControl
+					__next40pxDefaultSize
+					__nextHasNoMarginBottom
+					label={ title }
+					value={ Number( editorOptions.fontWeight ) }
+					options={ fontWeights.map( ( fontWeight ) => ( {
+						label: fontWeight,
+						value: fontWeight,
+					} ) ) }
+					onChange={ onChange }
+				/>
+			</HStack>
+		</div>
 	);
 }

--- a/src/admin/editor-config/editor-options/format-on-paste.js
+++ b/src/admin/editor-config/editor-options/format-on-paste.js
@@ -30,31 +30,33 @@ export default function FormatOnPaste() {
 	};
 
 	return (
-		<HStack justify="start" align="start" wrap>
-			<ToggleControl
-				__nextHasNoMarginBottom
-				label={ title }
-				checked={ editorOptions.formatOnPaste }
-				onChange={ onChange }
-			/>
-			<ItemHelp
-				onChange={ onChange }
-				title={ title }
-				items={ [
-					{
-						label: __( 'Enable', 'custom-html-block-extension' ),
-						value: true,
-						image: 'editor-options/format-on-paste_1.gif',
-					},
-					{
-						label: __( 'Disable', 'custom-html-block-extension' ),
-						value: false,
-						isDefault: true,
-						image: 'editor-options/format-on-paste_2.gif',
-					},
-				] }
-				value={ editorOptions.formatOnPaste }
-			/>
-		</HStack>
+		<div className="chbe-admin-editor-config__setting-item">
+			<HStack justify="start" align="start" wrap>
+				<ToggleControl
+					__nextHasNoMarginBottom
+					label={ title }
+					checked={ editorOptions.formatOnPaste }
+					onChange={ onChange }
+				/>
+				<ItemHelp
+					onChange={ onChange }
+					title={ title }
+					items={ [
+						{
+							label: __( 'Enable', 'custom-html-block-extension' ),
+							value: true,
+							image: 'editor-options/format-on-paste_1.gif',
+						},
+						{
+							label: __( 'Disable', 'custom-html-block-extension' ),
+							value: false,
+							isDefault: true,
+							image: 'editor-options/format-on-paste_2.gif',
+						},
+					] }
+					value={ editorOptions.formatOnPaste }
+				/>
+			</HStack>
+		</div>
 	);
 }

--- a/src/admin/editor-config/editor-options/glyph-margin.js
+++ b/src/admin/editor-config/editor-options/glyph-margin.js
@@ -30,35 +30,37 @@ export default function GlyphMargin() {
 	};
 
 	return (
-		<HStack justify="start" align="start" wrap>
-			<ToggleControl
-				__nextHasNoMarginBottom
-				label={ title }
-				checked={ editorOptions.glyphMargin }
-				onChange={ onChange }
-			/>
-			<ItemHelp
-				onChange={ onChange }
-				title={ title }
-				description={ __(
-					'Margin at the left edge of the editor.',
-					'custom-html-block-extension'
-				) }
-				items={ [
-					{
-						label: __( 'Enable', 'custom-html-block-extension' ),
-						value: true,
-						image: 'editor-options/glyph-margin_1.jpg',
-					},
-					{
-						label: __( 'Disable', 'custom-html-block-extension' ),
-						value: false,
-						image: 'editor-options/glyph-margin_2.jpg',
-						isDefault: true,
-					},
-				] }
-				value={ editorOptions.glyphMargin }
-			/>
-		</HStack>
+		<div className="chbe-admin-editor-config__setting-item">
+			<HStack justify="start" align="start" wrap>
+				<ToggleControl
+					__nextHasNoMarginBottom
+					label={ title }
+					checked={ editorOptions.glyphMargin }
+					onChange={ onChange }
+				/>
+				<ItemHelp
+					onChange={ onChange }
+					title={ title }
+					description={ __(
+						'Margin at the left edge of the editor.',
+						'custom-html-block-extension'
+					) }
+					items={ [
+						{
+							label: __( 'Enable', 'custom-html-block-extension' ),
+							value: true,
+							image: 'editor-options/glyph-margin_1.jpg',
+						},
+						{
+							label: __( 'Disable', 'custom-html-block-extension' ),
+							value: false,
+							image: 'editor-options/glyph-margin_2.jpg',
+							isDefault: true,
+						},
+					] }
+					value={ editorOptions.glyphMargin }
+				/>
+			</HStack>
+		</div>
 	);
 }

--- a/src/admin/editor-config/editor-options/hide-cursor-in-overview-ruler.js
+++ b/src/admin/editor-config/editor-options/hide-cursor-in-overview-ruler.js
@@ -30,31 +30,33 @@ export default function HideCursorInOverviewRuler() {
 	};
 
 	return (
-		<HStack justify="start" align="start" wrap>
-			<ToggleControl
-				__nextHasNoMarginBottom
-				label={ title }
-				checked={ editorOptions.hideCursorInOverviewRuler }
-				onChange={ onChange }
-			/>
-			<ItemHelp
-				onChange={ onChange }
-				title={ title }
-				items={ [
-					{
-						label: __( 'Enable', 'custom-html-block-extension' ),
-						value: true,
-						image: 'editor-options/hide-cursor-in-overview-ruler_1.jpg',
-					},
-					{
-						label: __( 'Disable', 'custom-html-block-extension' ),
-						value: false,
-						image: 'editor-options/hide-cursor-in-overview-ruler_2.jpg',
-						isDefault: true,
-					},
-				] }
-				value={ editorOptions.hideCursorInOverviewRuler }
-			/>
-		</HStack>
+		<div className="chbe-admin-editor-config__setting-item">
+			<HStack justify="start" align="start" wrap>
+				<ToggleControl
+					__nextHasNoMarginBottom
+					label={ title }
+					checked={ editorOptions.hideCursorInOverviewRuler }
+					onChange={ onChange }
+				/>
+				<ItemHelp
+					onChange={ onChange }
+					title={ title }
+					items={ [
+						{
+							label: __( 'Enable', 'custom-html-block-extension' ),
+							value: true,
+							image: 'editor-options/hide-cursor-in-overview-ruler_1.jpg',
+						},
+						{
+							label: __( 'Disable', 'custom-html-block-extension' ),
+							value: false,
+							image: 'editor-options/hide-cursor-in-overview-ruler_2.jpg',
+							isDefault: true,
+						},
+					] }
+					value={ editorOptions.hideCursorInOverviewRuler }
+				/>
+			</HStack>
+		</div>
 	);
 }

--- a/src/admin/editor-config/editor-options/highlight-active-indent-guide.js
+++ b/src/admin/editor-config/editor-options/highlight-active-indent-guide.js
@@ -30,31 +30,33 @@ export default function HighlightActiveIndentGuide() {
 	};
 
 	return (
-		<HStack justify="start" align="start" wrap>
-			<ToggleControl
-				__nextHasNoMarginBottom
-				label={ title }
-				checked={ editorOptions.highlightActiveIndentGuide }
-				onChange={ onChange }
-			/>
-			<ItemHelp
-				onChange={ onChange }
-				title={ title }
-				items={ [
-					{
-						label: __( 'Enable', 'custom-html-block-extension' ),
-						value: true,
-						image: 'editor-options/highlight-active-indent-guide_1.gif',
-						isDefault: true,
-					},
-					{
-						label: __( 'Disable', 'custom-html-block-extension' ),
-						value: false,
-						image: 'editor-options/highlight-active-indent-guide_2.gif',
-					},
-				] }
-				value={ editorOptions.highlightActiveIndentGuide }
-			/>
-		</HStack>
+		<div className="chbe-admin-editor-config__setting-item">
+			<HStack justify="start" align="start" wrap>
+				<ToggleControl
+					__nextHasNoMarginBottom
+					label={ title }
+					checked={ editorOptions.highlightActiveIndentGuide }
+					onChange={ onChange }
+				/>
+				<ItemHelp
+					onChange={ onChange }
+					title={ title }
+					items={ [
+						{
+							label: __( 'Enable', 'custom-html-block-extension' ),
+							value: true,
+							image: 'editor-options/highlight-active-indent-guide_1.gif',
+							isDefault: true,
+						},
+						{
+							label: __( 'Disable', 'custom-html-block-extension' ),
+							value: false,
+							image: 'editor-options/highlight-active-indent-guide_2.gif',
+						},
+					] }
+					value={ editorOptions.highlightActiveIndentGuide }
+				/>
+			</HStack>
+		</div>
 	);
 }

--- a/src/admin/editor-config/editor-options/hover.js
+++ b/src/admin/editor-config/editor-options/hover.js
@@ -30,21 +30,23 @@ export default function Hover() {
 	};
 
 	return (
-		<HStack justify="start" align="start" wrap>
-			<ToggleControl
-				__nextHasNoMarginBottom
-				label={ title }
-				checked={ editorOptions.hover }
-				onChange={ onChange }
-			/>
-			<ItemHelp
-				onChange={ onChange }
-				title={ title }
-				isToggle
-				defaultToggle
-				image="editor-options/hover.gif"
-				value={ editorOptions.hover }
-			/>
-		</HStack>
+		<div className="chbe-admin-editor-config__setting-item">
+			<HStack justify="start" align="start" wrap>
+				<ToggleControl
+					__nextHasNoMarginBottom
+					label={ title }
+					checked={ editorOptions.hover }
+					onChange={ onChange }
+				/>
+				<ItemHelp
+					onChange={ onChange }
+					title={ title }
+					isToggle
+					defaultToggle
+					image="editor-options/hover.gif"
+					value={ editorOptions.hover }
+				/>
+			</HStack>
+		</div>
 	);
 }

--- a/src/admin/editor-config/editor-options/letter-spacing.js
+++ b/src/admin/editor-config/editor-options/letter-spacing.js
@@ -30,16 +30,18 @@ export default function LetterSpacing() {
 	};
 
 	return (
-		<RangeControl
-			__next40pxDefaultSize
-			__nextHasNoMarginBottom
-			label={ title }
-			value={ editorOptions.letterSpacing }
-			min={ -2 }
-			max={ 2 }
-			step={ 0.1 }
-			allowReset
-			onChange={ onChange }
-		/>
+		<div className="chbe-admin-editor-config__setting-item">
+			<RangeControl
+				__next40pxDefaultSize
+				__nextHasNoMarginBottom
+				label={ title }
+				value={ editorOptions.letterSpacing }
+				min={ -2 }
+				max={ 2 }
+				step={ 0.1 }
+				allowReset
+				onChange={ onChange }
+			/>
+		</div>
 	);
 }

--- a/src/admin/editor-config/editor-options/line-decorations-width.js
+++ b/src/admin/editor-config/editor-options/line-decorations-width.js
@@ -31,23 +31,25 @@ export default function LineDecorationsWidth() {
 	};
 
 	return (
-		<HStack justify="start" align="start" wrap>
-			<RangeControl
-				__next40pxDefaultSize
-				__nextHasNoMarginBottom
-				label={ title }
-				value={ editorOptions.lineDecorationsWidth }
-				min={ 0 }
-				max={ 30 }
-				allowReset
-				onChange={ onChange }
-			/>
-			<ItemHelp
-				onChange={ onChange }
-				title={ title }
-				image="editor-options/line-decorations-width.gif"
-				value={ editorOptions.lineDecorationsWidth }
-			/>
-		</HStack>
+		<div className="chbe-admin-editor-config__setting-item">
+			<HStack justify="start" align="start" wrap>
+				<RangeControl
+					__next40pxDefaultSize
+					__nextHasNoMarginBottom
+					label={ title }
+					value={ editorOptions.lineDecorationsWidth }
+					min={ 0 }
+					max={ 30 }
+					allowReset
+					onChange={ onChange }
+				/>
+				<ItemHelp
+					onChange={ onChange }
+					title={ title }
+					image="editor-options/line-decorations-width.gif"
+					value={ editorOptions.lineDecorationsWidth }
+				/>
+			</HStack>
+		</div>
 	);
 }

--- a/src/admin/editor-config/editor-options/line-height.js
+++ b/src/admin/editor-config/editor-options/line-height.js
@@ -30,15 +30,17 @@ export default function LineHeight() {
 	};
 
 	return (
-		<RangeControl
-			__next40pxDefaultSize
-			__nextHasNoMarginBottom
-			label={ title }
-			value={ editorOptions.lineHeight }
-			min={ 10 }
-			max={ 60 }
-			allowReset
-			onChange={ onChange }
-		/>
+		<div className="chbe-admin-editor-config__setting-item">
+			<RangeControl
+				__next40pxDefaultSize
+				__nextHasNoMarginBottom
+				label={ title }
+				value={ editorOptions.lineHeight }
+				min={ 10 }
+				max={ 60 }
+				allowReset
+				onChange={ onChange }
+			/>
+		</div>
 	);
 }

--- a/src/admin/editor-config/editor-options/line-numbers-min-chars.js
+++ b/src/admin/editor-config/editor-options/line-numbers-min-chars.js
@@ -31,18 +31,20 @@ export default function LineNumbersMinChars() {
 	};
 
 	return (
-		<HStack justify="start" align="start" wrap>
-			<RangeControl
-				__next40pxDefaultSize
-				__nextHasNoMarginBottom
-				label={ title }
-				value={ editorOptions.lineNumbersMinChars }
-				min={ 1 }
-				max={ 10 }
-				allowReset
-				onChange={ onChange }
-			/>
-			<ItemHelp title={ title } image="editor-options/line-numbers-min-chars.gif" />
-		</HStack>
+		<div className="chbe-admin-editor-config__setting-item">
+			<HStack justify="start" align="start" wrap>
+				<RangeControl
+					__next40pxDefaultSize
+					__nextHasNoMarginBottom
+					label={ title }
+					value={ editorOptions.lineNumbersMinChars }
+					min={ 1 }
+					max={ 10 }
+					allowReset
+					onChange={ onChange }
+				/>
+				<ItemHelp title={ title } image="editor-options/line-numbers-min-chars.gif" />
+			</HStack>
+		</div>
 	);
 }

--- a/src/admin/editor-config/editor-options/line-numbers.js
+++ b/src/admin/editor-config/editor-options/line-numbers.js
@@ -54,22 +54,24 @@ export default function LineNumbers() {
 	};
 
 	return (
-		<HStack justify="start" align="start" wrap>
-			<SelectControl
-				__next40pxDefaultSize
-				__nextHasNoMarginBottom
-				label={ title }
-				value={ editorOptions.lineNumbers }
-				options={ items.map( ( { label, value } ) => ( { label, value } ) ) }
-				onChange={ onChange }
-			/>
-			<ItemHelp
-				onChange={ onChange }
-				title={ title }
-				items={ items }
-				colCount="4"
-				value={ editorOptions.lineNumbers }
-			/>
-		</HStack>
+		<div className="chbe-admin-editor-config__setting-item">
+			<HStack justify="start" align="start" wrap>
+				<SelectControl
+					__next40pxDefaultSize
+					__nextHasNoMarginBottom
+					label={ title }
+					value={ editorOptions.lineNumbers }
+					options={ items.map( ( { label, value } ) => ( { label, value } ) ) }
+					onChange={ onChange }
+				/>
+				<ItemHelp
+					onChange={ onChange }
+					title={ title }
+					items={ items }
+					colCount="4"
+					value={ editorOptions.lineNumbers }
+				/>
+			</HStack>
+		</div>
 	);
 }

--- a/src/admin/editor-config/editor-options/links.js
+++ b/src/admin/editor-config/editor-options/links.js
@@ -33,31 +33,33 @@ export default function Links() {
 	};
 
 	return (
-		<HStack justify="start" align="start" wrap>
-			<ToggleControl
-				__nextHasNoMarginBottom
-				label={ title }
-				checked={ editorOptions.links }
-				onChange={ onChange }
-			/>
-			<ItemHelp
-				onChange={ onChange }
-				title={ title }
-				items={ [
-					{
-						label: __( 'Enable', 'custom-html-block-extension' ),
-						image: 'editor-options/links_1.jpg',
-						value: true,
-						isDefault: true,
-					},
-					{
-						label: __( 'Disable', 'custom-html-block-extension' ),
-						image: 'editor-options/links_2.jpg',
-						value: false,
-					},
-				] }
-				value={ editorOptions.links }
-			/>
-		</HStack>
+		<div className="chbe-admin-editor-config__setting-item">
+			<HStack justify="start" align="start" wrap>
+				<ToggleControl
+					__nextHasNoMarginBottom
+					label={ title }
+					checked={ editorOptions.links }
+					onChange={ onChange }
+				/>
+				<ItemHelp
+					onChange={ onChange }
+					title={ title }
+					items={ [
+						{
+							label: __( 'Enable', 'custom-html-block-extension' ),
+							image: 'editor-options/links_1.jpg',
+							value: true,
+							isDefault: true,
+						},
+						{
+							label: __( 'Disable', 'custom-html-block-extension' ),
+							image: 'editor-options/links_2.jpg',
+							value: false,
+						},
+					] }
+					value={ editorOptions.links }
+				/>
+			</HStack>
+		</div>
 	);
 }

--- a/src/admin/editor-config/editor-options/match-brackets.js
+++ b/src/admin/editor-config/editor-options/match-brackets.js
@@ -49,22 +49,24 @@ export default function MatchBrackets() {
 	};
 
 	return (
-		<HStack justify="start" align="start" wrap>
-			<SelectControl
-				__next40pxDefaultSize
-				__nextHasNoMarginBottom
-				label={ title }
-				value={ editorOptions.matchBrackets }
-				options={ items.map( ( { label, value } ) => ( { label, value } ) ) }
-				onChange={ onChange }
-			/>
-			<ItemHelp
-				onChange={ onChange }
-				title={ title }
-				items={ items }
-				colCount="3"
-				value={ editorOptions.matchBrackets }
-			/>
-		</HStack>
+		<div className="chbe-admin-editor-config__setting-item">
+			<HStack justify="start" align="start" wrap>
+				<SelectControl
+					__next40pxDefaultSize
+					__nextHasNoMarginBottom
+					label={ title }
+					value={ editorOptions.matchBrackets }
+					options={ items.map( ( { label, value } ) => ( { label, value } ) ) }
+					onChange={ onChange }
+				/>
+				<ItemHelp
+					onChange={ onChange }
+					title={ title }
+					items={ items }
+					colCount="3"
+					value={ editorOptions.matchBrackets }
+				/>
+			</HStack>
+		</div>
 	);
 }

--- a/src/admin/editor-config/editor-options/minimap/enabled.js
+++ b/src/admin/editor-config/editor-options/minimap/enabled.js
@@ -33,25 +33,27 @@ export default function MinimapEnabled() {
 	};
 
 	return (
-		<HStack justify="start" align="start" wrap>
-			<ToggleControl
-				__nextHasNoMarginBottom
-				label={ title }
-				checked={ editorOptions.minimap.enabled }
-				onChange={ onChange }
-			/>
-			<ItemHelp
-				onChange={ onChange }
-				title={ title }
-				description={ __(
-					'Minimap gives you a high-level overview of your source code, which is useful for quick navigation and code understanding. You can click or drag the shaded area to quickly jump to different sections.',
-					'custom-html-block-extension'
-				) }
-				isToggle
-				defaultToggle
-				image="editor-options/minimap/enabled.gif"
-				value={ editorOptions.minimap.enabled }
-			/>
-		</HStack>
+		<div className="chbe-admin-editor-config__setting-item">
+			<HStack justify="start" align="start" wrap>
+				<ToggleControl
+					__nextHasNoMarginBottom
+					label={ title }
+					checked={ editorOptions.minimap.enabled }
+					onChange={ onChange }
+				/>
+				<ItemHelp
+					onChange={ onChange }
+					title={ title }
+					description={ __(
+						'Minimap gives you a high-level overview of your source code, which is useful for quick navigation and code understanding. You can click or drag the shaded area to quickly jump to different sections.',
+						'custom-html-block-extension'
+					) }
+					isToggle
+					defaultToggle
+					image="editor-options/minimap/enabled.gif"
+					value={ editorOptions.minimap.enabled }
+				/>
+			</HStack>
+		</div>
 	);
 }

--- a/src/admin/editor-config/editor-options/minimap/max-column.js
+++ b/src/admin/editor-config/editor-options/minimap/max-column.js
@@ -34,18 +34,20 @@ export default function MinimapMaxColumn() {
 	};
 
 	return (
-		<HStack justify="start" align="start" wrap>
-			<RangeControl
-				__next40pxDefaultSize
-				__nextHasNoMarginBottom
-				label={ title }
-				value={ editorOptions.minimap.maxColumn }
-				min={ 10 }
-				max={ 60 }
-				allowReset
-				onChange={ onChange }
-			/>
-			<ItemHelp title={ title } image="editor-options/minimap/max-column.gif" />
-		</HStack>
+		<div className="chbe-admin-editor-config__setting-item">
+			<HStack justify="start" align="start" wrap>
+				<RangeControl
+					__next40pxDefaultSize
+					__nextHasNoMarginBottom
+					label={ title }
+					value={ editorOptions.minimap.maxColumn }
+					min={ 10 }
+					max={ 60 }
+					allowReset
+					onChange={ onChange }
+				/>
+				<ItemHelp title={ title } image="editor-options/minimap/max-column.gif" />
+			</HStack>
+		</div>
 	);
 }

--- a/src/admin/editor-config/editor-options/minimap/render-characters.js
+++ b/src/admin/editor-config/editor-options/minimap/render-characters.js
@@ -33,37 +33,39 @@ export default function MinimapRenderCharacters() {
 	};
 
 	return (
-		<HStack justify="start" align="start" wrap>
-			<ToggleControl
-				__nextHasNoMarginBottom
-				label={ title }
-				checked={ editorOptions.minimap.renderCharacters }
-				onChange={ onChange }
-			/>
-			<ItemHelp
-				onChange={ onChange }
-				title={ title }
-				description={ __(
-					'By default, the minimap shows blocks. You can change this to show actual characters.',
-					'custom-html-block-extension'
-				) }
-				items={ [
-					{
-						label: __( 'Enable', 'custom-html-block-extension' ),
-						value: true,
-						description: __( 'Show characters.', 'custom-html-block-extension' ),
-						image: 'editor-options/minimap/render-characters_1.jpg',
-						isDefault: true,
-					},
-					{
-						label: __( 'Disable', 'custom-html-block-extension' ),
-						value: false,
-						description: __( 'Show blocks.', 'custom-html-block-extension' ),
-						image: 'editor-options/minimap/render-characters_2.jpg',
-					},
-				] }
-				value={ editorOptions.minimap.renderCharacters }
-			/>
-		</HStack>
+		<div className="chbe-admin-editor-config__setting-item">
+			<HStack justify="start" align="start" wrap>
+				<ToggleControl
+					__nextHasNoMarginBottom
+					label={ title }
+					checked={ editorOptions.minimap.renderCharacters }
+					onChange={ onChange }
+				/>
+				<ItemHelp
+					onChange={ onChange }
+					title={ title }
+					description={ __(
+						'By default, the minimap shows blocks. You can change this to show actual characters.',
+						'custom-html-block-extension'
+					) }
+					items={ [
+						{
+							label: __( 'Enable', 'custom-html-block-extension' ),
+							value: true,
+							description: __( 'Show characters.', 'custom-html-block-extension' ),
+							image: 'editor-options/minimap/render-characters_1.jpg',
+							isDefault: true,
+						},
+						{
+							label: __( 'Disable', 'custom-html-block-extension' ),
+							value: false,
+							description: __( 'Show blocks.', 'custom-html-block-extension' ),
+							image: 'editor-options/minimap/render-characters_2.jpg',
+						},
+					] }
+					value={ editorOptions.minimap.renderCharacters }
+				/>
+			</HStack>
+		</div>
 	);
 }

--- a/src/admin/editor-config/editor-options/minimap/scale.js
+++ b/src/admin/editor-config/editor-options/minimap/scale.js
@@ -34,23 +34,25 @@ export default function MinimapScale() {
 	};
 
 	return (
-		<HStack justify="start" align="start" wrap>
-			<RangeControl
-				__next40pxDefaultSize
-				__nextHasNoMarginBottom
-				label={ title }
-				value={ editorOptions.minimap.scale }
-				min={ 1 }
-				max={ 3 }
-				allowReset
-				onChange={ onChange }
-			/>
-			<ItemHelp
-				onChange={ onChange }
-				title={ title }
-				image="editor-options/minimap/scale.gif"
-				value={ editorOptions.minimap.scale }
-			/>
-		</HStack>
+		<div className="chbe-admin-editor-config__setting-item">
+			<HStack justify="start" align="start" wrap>
+				<RangeControl
+					__next40pxDefaultSize
+					__nextHasNoMarginBottom
+					label={ title }
+					value={ editorOptions.minimap.scale }
+					min={ 1 }
+					max={ 3 }
+					allowReset
+					onChange={ onChange }
+				/>
+				<ItemHelp
+					onChange={ onChange }
+					title={ title }
+					image="editor-options/minimap/scale.gif"
+					value={ editorOptions.minimap.scale }
+				/>
+			</HStack>
+		</div>
 	);
 }

--- a/src/admin/editor-config/editor-options/minimap/show-slider.js
+++ b/src/admin/editor-config/editor-options/minimap/show-slider.js
@@ -47,21 +47,23 @@ export default function MinimapShowSlider() {
 	};
 
 	return (
-		<HStack justify="start" align="start" wrap>
-			<SelectControl
-				__next40pxDefaultSize
-				__nextHasNoMarginBottom
-				label={ title }
-				value={ editorOptions.minimap.showSlider }
-				options={ items.map( ( { label, value } ) => ( { label, value } ) ) }
-				onChange={ onChange }
-			/>
-			<ItemHelp
-				onChange={ onChange }
-				title={ title }
-				items={ items }
-				value={ editorOptions.minimap.showSlider }
-			/>
-		</HStack>
+		<div className="chbe-admin-editor-config__setting-item">
+			<HStack justify="start" align="start" wrap>
+				<SelectControl
+					__next40pxDefaultSize
+					__nextHasNoMarginBottom
+					label={ title }
+					value={ editorOptions.minimap.showSlider }
+					options={ items.map( ( { label, value } ) => ( { label, value } ) ) }
+					onChange={ onChange }
+				/>
+				<ItemHelp
+					onChange={ onChange }
+					title={ title }
+					items={ items }
+					value={ editorOptions.minimap.showSlider }
+				/>
+			</HStack>
+		</div>
 	);
 }

--- a/src/admin/editor-config/editor-options/minimap/side.js
+++ b/src/admin/editor-config/editor-options/minimap/side.js
@@ -51,25 +51,31 @@ export default function MinimapSide() {
 	};
 
 	return (
-		<HStack justify="start" align="start" wrap>
-			<ToggleGroupControl
-				__nextHasNoMarginBottom
-				size="__unstable-large"
-				label={ title }
-				value={ editorOptions.minimap.side }
-				onChange={ onChange }
-				isBlock
-			>
-				{ items.map( ( item ) => (
-					<ToggleGroupControlOption key={ item.value } value={ item.value } label={ item.label } />
-				) ) }
-			</ToggleGroupControl>
-			<ItemHelp
-				onChange={ onChange }
-				title={ title }
-				items={ items }
-				value={ editorOptions.minimap.side }
-			/>
-		</HStack>
+		<div className="chbe-admin-editor-config__setting-item">
+			<HStack justify="start" align="start" wrap>
+				<ToggleGroupControl
+					__nextHasNoMarginBottom
+					size="__unstable-large"
+					label={ title }
+					value={ editorOptions.minimap.side }
+					onChange={ onChange }
+					isBlock
+				>
+					{ items.map( ( item ) => (
+						<ToggleGroupControlOption
+							key={ item.value }
+							value={ item.value }
+							label={ item.label }
+						/>
+					) ) }
+				</ToggleGroupControl>
+				<ItemHelp
+					onChange={ onChange }
+					title={ title }
+					items={ items }
+					value={ editorOptions.minimap.side }
+				/>
+			</HStack>
+		</div>
 	);
 }

--- a/src/admin/editor-config/editor-options/minimap/size.js
+++ b/src/admin/editor-config/editor-options/minimap/size.js
@@ -64,22 +64,24 @@ export default function MinimapSize() {
 	};
 
 	return (
-		<HStack justify="start" align="start" wrap>
-			<SelectControl
-				__next40pxDefaultSize
-				__nextHasNoMarginBottom
-				label={ title }
-				value={ editorOptions.minimap.size }
-				options={ items.map( ( { label, value } ) => ( { label, value } ) ) }
-				onChange={ onChange }
-			/>
-			<ItemHelp
-				onChange={ onChange }
-				title={ title }
-				items={ items }
-				colCount="3"
-				value={ editorOptions.minimap.size }
-			/>
-		</HStack>
+		<div className="chbe-admin-editor-config__setting-item">
+			<HStack justify="start" align="start" wrap>
+				<SelectControl
+					__next40pxDefaultSize
+					__nextHasNoMarginBottom
+					label={ title }
+					value={ editorOptions.minimap.size }
+					options={ items.map( ( { label, value } ) => ( { label, value } ) ) }
+					onChange={ onChange }
+				/>
+				<ItemHelp
+					onChange={ onChange }
+					title={ title }
+					items={ items }
+					colCount="3"
+					value={ editorOptions.minimap.size }
+				/>
+			</HStack>
+		</div>
 	);
 }

--- a/src/admin/editor-config/editor-options/mouse-wheel-scroll-sensitivity.js
+++ b/src/admin/editor-config/editor-options/mouse-wheel-scroll-sensitivity.js
@@ -30,15 +30,17 @@ export default function MouseWheelScrollSensitivity() {
 	};
 
 	return (
-		<RangeControl
-			__next40pxDefaultSize
-			__nextHasNoMarginBottom
-			label={ title }
-			min={ 1 }
-			max={ 10 }
-			value={ editorOptions.mouseWheelScrollSensitivity }
-			allowReset
-			onChange={ onChange }
-		/>
+		<div className="chbe-admin-editor-config__setting-item">
+			<RangeControl
+				__next40pxDefaultSize
+				__nextHasNoMarginBottom
+				label={ title }
+				min={ 1 }
+				max={ 10 }
+				value={ editorOptions.mouseWheelScrollSensitivity }
+				allowReset
+				onChange={ onChange }
+			/>
+		</div>
 	);
 }

--- a/src/admin/editor-config/editor-options/mouse-wheel-zoom.js
+++ b/src/admin/editor-config/editor-options/mouse-wheel-zoom.js
@@ -30,21 +30,23 @@ export default function MouseWheelZoom() {
 	};
 
 	return (
-		<HStack justify="start" align="start" wrap>
-			<ToggleControl
-				__nextHasNoMarginBottom
-				label={ title }
-				checked={ editorOptions.mouseWheelZoom }
-				onChange={ onChange }
-			/>
-			<ItemHelp
-				onChange={ onChange }
-				title={ title }
-				isToggle
-				defaultToggle={ false }
-				image="editor-options/mouse-wheel-zoom.gif"
-				value={ editorOptions.mouseWheelZoom }
-			/>
-		</HStack>
+		<div className="chbe-admin-editor-config__setting-item">
+			<HStack justify="start" align="start" wrap>
+				<ToggleControl
+					__nextHasNoMarginBottom
+					label={ title }
+					checked={ editorOptions.mouseWheelZoom }
+					onChange={ onChange }
+				/>
+				<ItemHelp
+					onChange={ onChange }
+					title={ title }
+					isToggle
+					defaultToggle={ false }
+					image="editor-options/mouse-wheel-zoom.gif"
+					value={ editorOptions.mouseWheelZoom }
+				/>
+			</HStack>
+		</div>
 	);
 }

--- a/src/admin/editor-config/editor-options/multi-cursor-modifier.js
+++ b/src/admin/editor-config/editor-options/multi-cursor-modifier.js
@@ -51,28 +51,34 @@ export default function MultiCursorModifier() {
 	};
 
 	return (
-		<HStack justify="start" align="start" wrap>
-			<ToggleGroupControl
-				__nextHasNoMarginBottom
-				size="__unstable-large"
-				label={ title }
-				value={ editorOptions.multiCursorModifier }
-				onChange={ onChange }
-				isBlock
-			>
-				{ items.map( ( item ) => (
-					<ToggleGroupControlOption key={ item.value } value={ item.value } label={ item.label } />
-				) ) }
-			</ToggleGroupControl>
-			<ItemHelp
-				onChange={ onChange }
-				title={ title }
-				description={ __(
-					'You can use multiple cursors for faster editing. Sets the key for applying multiple cursors with modifier key + Click.',
-					'custom-html-block-extension'
-				) }
-				image="editor-options/multi-cursor-modifier.gif"
-			/>
-		</HStack>
+		<div className="chbe-admin-editor-config__setting-item">
+			<HStack justify="start" align="start" wrap>
+				<ToggleGroupControl
+					__nextHasNoMarginBottom
+					size="__unstable-large"
+					label={ title }
+					value={ editorOptions.multiCursorModifier }
+					onChange={ onChange }
+					isBlock
+				>
+					{ items.map( ( item ) => (
+						<ToggleGroupControlOption
+							key={ item.value }
+							value={ item.value }
+							label={ item.label }
+						/>
+					) ) }
+				</ToggleGroupControl>
+				<ItemHelp
+					onChange={ onChange }
+					title={ title }
+					description={ __(
+						'You can use multiple cursors for faster editing. Sets the key for applying multiple cursors with modifier key + Click.',
+						'custom-html-block-extension'
+					) }
+					image="editor-options/multi-cursor-modifier.gif"
+				/>
+			</HStack>
+		</div>
 	);
 }

--- a/src/admin/editor-config/editor-options/multi-cursor-paste.js
+++ b/src/admin/editor-config/editor-options/multi-cursor-paste.js
@@ -51,25 +51,31 @@ export default function MultiCursorPaste() {
 	};
 
 	return (
-		<HStack justify="start" align="start" wrap>
-			<ToggleGroupControl
-				__nextHasNoMarginBottom
-				size="__unstable-large"
-				label={ title }
-				value={ editorOptions.multiCursorPaste }
-				onChange={ onChange }
-				isBlock
-			>
-				{ items.map( ( item ) => (
-					<ToggleGroupControlOption key={ item.value } value={ item.value } label={ item.label } />
-				) ) }
-			</ToggleGroupControl>
-			<ItemHelp
-				onChange={ onChange }
-				title={ title }
-				items={ items }
-				value={ editorOptions.multiCursorPaste }
-			/>
-		</HStack>
+		<div className="chbe-admin-editor-config__setting-item">
+			<HStack justify="start" align="start" wrap>
+				<ToggleGroupControl
+					__nextHasNoMarginBottom
+					size="__unstable-large"
+					label={ title }
+					value={ editorOptions.multiCursorPaste }
+					onChange={ onChange }
+					isBlock
+				>
+					{ items.map( ( item ) => (
+						<ToggleGroupControlOption
+							key={ item.value }
+							value={ item.value }
+							label={ item.label }
+						/>
+					) ) }
+				</ToggleGroupControl>
+				<ItemHelp
+					onChange={ onChange }
+					title={ title }
+					items={ items }
+					value={ editorOptions.multiCursorPaste }
+				/>
+			</HStack>
+		</div>
 	);
 }

--- a/src/admin/editor-config/editor-options/occurrences-highlight.js
+++ b/src/admin/editor-config/editor-options/occurrences-highlight.js
@@ -30,31 +30,33 @@ export default function OccurrencesHighlight() {
 	};
 
 	return (
-		<HStack justify="start" align="start" wrap>
-			<ToggleControl
-				__nextHasNoMarginBottom
-				label={ title }
-				checked={ editorOptions.occurrencesHighlight }
-				onChange={ onChange }
-			/>
-			<ItemHelp
-				onChange={ onChange }
-				title={ title }
-				items={ [
-					{
-						label: __( 'Enable', 'custom-html-block-extension' ),
-						value: true,
-						image: 'editor-options/occurrences-highlight_1.jpg',
-						isDefault: true,
-					},
-					{
-						label: __( 'Disable', 'custom-html-block-extension' ),
-						value: false,
-						image: 'editor-options/occurrences-highlight_2.jpg',
-					},
-				] }
-				value={ editorOptions.occurrencesHighlight }
-			/>
-		</HStack>
+		<div className="chbe-admin-editor-config__setting-item">
+			<HStack justify="start" align="start" wrap>
+				<ToggleControl
+					__nextHasNoMarginBottom
+					label={ title }
+					checked={ editorOptions.occurrencesHighlight }
+					onChange={ onChange }
+				/>
+				<ItemHelp
+					onChange={ onChange }
+					title={ title }
+					items={ [
+						{
+							label: __( 'Enable', 'custom-html-block-extension' ),
+							value: true,
+							image: 'editor-options/occurrences-highlight_1.jpg',
+							isDefault: true,
+						},
+						{
+							label: __( 'Disable', 'custom-html-block-extension' ),
+							value: false,
+							image: 'editor-options/occurrences-highlight_2.jpg',
+						},
+					] }
+					value={ editorOptions.occurrencesHighlight }
+				/>
+			</HStack>
+		</div>
 	);
 }

--- a/src/admin/editor-config/editor-options/overview-ruler-border.js
+++ b/src/admin/editor-config/editor-options/overview-ruler-border.js
@@ -30,31 +30,33 @@ export default function OverviewRulerBorder() {
 	};
 
 	return (
-		<HStack justify="start" align="start" wrap>
-			<ToggleControl
-				__nextHasNoMarginBottom
-				label={ title }
-				checked={ editorOptions.overviewRulerBorder }
-				onChange={ onChange }
-			/>
-			<ItemHelp
-				onChange={ onChange }
-				title={ title }
-				items={ [
-					{
-						label: __( 'Enable', 'custom-html-block-extension' ),
-						image: 'editor-options/overview-ruler-border_1.jpg',
-						value: true,
-						isDefault: true,
-					},
-					{
-						label: __( 'Disable', 'custom-html-block-extension' ),
-						image: 'editor-options/overview-ruler-border_2.jpg',
-						value: false,
-					},
-				] }
-				value={ editorOptions.overviewRulerBorder }
-			/>
-		</HStack>
+		<div className="chbe-admin-editor-config__setting-item">
+			<HStack justify="start" align="start" wrap>
+				<ToggleControl
+					__nextHasNoMarginBottom
+					label={ title }
+					checked={ editorOptions.overviewRulerBorder }
+					onChange={ onChange }
+				/>
+				<ItemHelp
+					onChange={ onChange }
+					title={ title }
+					items={ [
+						{
+							label: __( 'Enable', 'custom-html-block-extension' ),
+							image: 'editor-options/overview-ruler-border_1.jpg',
+							value: true,
+							isDefault: true,
+						},
+						{
+							label: __( 'Disable', 'custom-html-block-extension' ),
+							image: 'editor-options/overview-ruler-border_2.jpg',
+							value: false,
+						},
+					] }
+					value={ editorOptions.overviewRulerBorder }
+				/>
+			</HStack>
+		</div>
 	);
 }

--- a/src/admin/editor-config/editor-options/padding/bottom.js
+++ b/src/admin/editor-config/editor-options/padding/bottom.js
@@ -35,26 +35,28 @@ export default function PaddingBottom() {
 	};
 
 	return (
-		<HStack justify="start" align="start" wrap>
-			<RangeControl
-				__next40pxDefaultSize
-				__nextHasNoMarginBottom
-				label={ title }
-				value={ editorOptions.padding.bottom }
-				min={ 0 }
-				max={ 50 }
-				allowReset
-				onChange={ onChange }
-			/>
-			<ItemHelp
-				onChange={ onChange }
-				title={ title }
-				description={ __(
-					'Spacing between bottom edge of editor and last line. This setting will not work if "Scroll past the last line" is enabled in "Mouse and Scroll" category.',
-					'custom-html-block-extension'
-				) }
-				image="editor-options/padding/bottom.gif"
-			/>
-		</HStack>
+		<div className="chbe-admin-editor-config__setting-item">
+			<HStack justify="start" align="start" wrap>
+				<RangeControl
+					__next40pxDefaultSize
+					__nextHasNoMarginBottom
+					label={ title }
+					value={ editorOptions.padding.bottom }
+					min={ 0 }
+					max={ 50 }
+					allowReset
+					onChange={ onChange }
+				/>
+				<ItemHelp
+					onChange={ onChange }
+					title={ title }
+					description={ __(
+						'Spacing between bottom edge of editor and last line. This setting will not work if "Scroll past the last line" is enabled in "Mouse and Scroll" category.',
+						'custom-html-block-extension'
+					) }
+					image="editor-options/padding/bottom.gif"
+				/>
+			</HStack>
+		</div>
 	);
 }

--- a/src/admin/editor-config/editor-options/padding/top.js
+++ b/src/admin/editor-config/editor-options/padding/top.js
@@ -35,26 +35,28 @@ export default function PaddingTop() {
 	};
 
 	return (
-		<HStack justify="start" align="start" wrap>
-			<RangeControl
-				__next40pxDefaultSize
-				__nextHasNoMarginBottom
-				label={ title }
-				value={ editorOptions.padding.top }
-				min={ 0 }
-				max={ 50 }
-				allowReset
-				onChange={ onChange }
-			/>
-			<ItemHelp
-				onChange={ onChange }
-				title={ title }
-				description={ __(
-					'Spacing between top edge of editor and first line.',
-					'custom-html-block-extension'
-				) }
-				image="editor-options/padding/top.gif"
-			/>
-		</HStack>
+		<div className="chbe-admin-editor-config__setting-item">
+			<HStack justify="start" align="start" wrap>
+				<RangeControl
+					__next40pxDefaultSize
+					__nextHasNoMarginBottom
+					label={ title }
+					value={ editorOptions.padding.top }
+					min={ 0 }
+					max={ 50 }
+					allowReset
+					onChange={ onChange }
+				/>
+				<ItemHelp
+					onChange={ onChange }
+					title={ title }
+					description={ __(
+						'Spacing between top edge of editor and first line.',
+						'custom-html-block-extension'
+					) }
+					image="editor-options/padding/top.gif"
+				/>
+			</HStack>
+		</div>
 	);
 }

--- a/src/admin/editor-config/editor-options/quick-suggestions-delay.js
+++ b/src/admin/editor-config/editor-options/quick-suggestions-delay.js
@@ -31,42 +31,44 @@ export default function QuickSuggestionsDelay() {
 	};
 
 	return (
-		<HStack justify="start" align="start" wrap>
-			<RangeControl
-				__next40pxDefaultSize
-				__nextHasNoMarginBottom
-				label={ title }
-				value={ editorOptions.quickSuggestionsDelay }
-				min={ 0 }
-				max={ 1000 }
-				allowReset
-				onChange={ onChange }
-			/>
-			<ItemHelp
-				onChange={ onChange }
-				title={ title }
-				items={ [
-					{
-						label: sprintf(
-							/* translators: %s is replaced with the number. */
-							__( 'Example: Set the value to %s', 'custom-html-block-extension' ),
-							10
-						),
-						image: 'editor-options/quick-suggestions-delay_1.gif',
-						value: 10,
-					},
-					{
-						label: sprintf(
-							/* translators: %s is replaced with the number. */
-							__( 'Example: Set the value to %s', 'custom-html-block-extension' ),
-							1000
-						),
-						image: 'editor-options/quick-suggestions-delay_2.gif',
-						value: 1000,
-					},
-				] }
-				value={ editorOptions.quickSuggestionsDelay }
-			/>
-		</HStack>
+		<div className="chbe-admin-editor-config__setting-item">
+			<HStack justify="start" align="start" wrap>
+				<RangeControl
+					__next40pxDefaultSize
+					__nextHasNoMarginBottom
+					label={ title }
+					value={ editorOptions.quickSuggestionsDelay }
+					min={ 0 }
+					max={ 1000 }
+					allowReset
+					onChange={ onChange }
+				/>
+				<ItemHelp
+					onChange={ onChange }
+					title={ title }
+					items={ [
+						{
+							label: sprintf(
+								/* translators: %s is replaced with the number. */
+								__( 'Example: Set the value to %s', 'custom-html-block-extension' ),
+								10
+							),
+							image: 'editor-options/quick-suggestions-delay_1.gif',
+							value: 10,
+						},
+						{
+							label: sprintf(
+								/* translators: %s is replaced with the number. */
+								__( 'Example: Set the value to %s', 'custom-html-block-extension' ),
+								1000
+							),
+							image: 'editor-options/quick-suggestions-delay_2.gif',
+							value: 1000,
+						},
+					] }
+					value={ editorOptions.quickSuggestionsDelay }
+				/>
+			</HStack>
+		</div>
 	);
 }

--- a/src/admin/editor-config/editor-options/quick-suggestions.js
+++ b/src/admin/editor-config/editor-options/quick-suggestions.js
@@ -31,25 +31,27 @@ export default function QuickSuggestions() {
 	};
 
 	return (
-		<HStack justify="start" align="start" wrap>
-			<ToggleControl
-				__nextHasNoMarginBottom
-				label={ title }
-				checked={ editorOptions.quickSuggestions }
-				onChange={ onChange }
-			/>
-			<ItemHelp
-				onChange={ onChange }
-				title={ title }
-				description={ __(
-					'Get suggestions as you type codes. Accepting suggestions will autocomplete code and help faster coding.',
-					'custom-html-block-extension'
-				) }
-				isToggle
-				defaultToggle
-				image="editor-options/quick-suggestions.gif"
-				value={ editorOptions.quickSuggestions }
-			/>
-		</HStack>
+		<div className="chbe-admin-editor-config__setting-item">
+			<HStack justify="start" align="start" wrap>
+				<ToggleControl
+					__nextHasNoMarginBottom
+					label={ title }
+					checked={ editorOptions.quickSuggestions }
+					onChange={ onChange }
+				/>
+				<ItemHelp
+					onChange={ onChange }
+					title={ title }
+					description={ __(
+						'Get suggestions as you type codes. Accepting suggestions will autocomplete code and help faster coding.',
+						'custom-html-block-extension'
+					) }
+					isToggle
+					defaultToggle
+					image="editor-options/quick-suggestions.gif"
+					value={ editorOptions.quickSuggestions }
+				/>
+			</HStack>
+		</div>
 	);
 }

--- a/src/admin/editor-config/editor-options/render-control-characters.js
+++ b/src/admin/editor-config/editor-options/render-control-characters.js
@@ -30,31 +30,33 @@ export default function RenderControlCharacters() {
 	};
 
 	return (
-		<HStack justify="start" align="start" wrap>
-			<ToggleControl
-				__nextHasNoMarginBottom
-				label={ title }
-				checked={ editorOptions.renderControlCharacters }
-				onChange={ onChange }
-			/>
-			<ItemHelp
-				onChange={ onChange }
-				title={ title }
-				items={ [
-					{
-						label: __( 'Enable', 'custom-html-block-extension' ),
-						value: true,
-						image: 'editor-options/render-control-characters_1.jpg',
-					},
-					{
-						label: __( 'Disable', 'custom-html-block-extension' ),
-						value: false,
-						image: 'editor-options/render-control-characters_2.jpg',
-						isDefault: true,
-					},
-				] }
-				value={ editorOptions.renderControlCharacters }
-			/>
-		</HStack>
+		<div className="chbe-admin-editor-config__setting-item">
+			<HStack justify="start" align="start" wrap>
+				<ToggleControl
+					__nextHasNoMarginBottom
+					label={ title }
+					checked={ editorOptions.renderControlCharacters }
+					onChange={ onChange }
+				/>
+				<ItemHelp
+					onChange={ onChange }
+					title={ title }
+					items={ [
+						{
+							label: __( 'Enable', 'custom-html-block-extension' ),
+							value: true,
+							image: 'editor-options/render-control-characters_1.jpg',
+						},
+						{
+							label: __( 'Disable', 'custom-html-block-extension' ),
+							value: false,
+							image: 'editor-options/render-control-characters_2.jpg',
+							isDefault: true,
+						},
+					] }
+					value={ editorOptions.renderControlCharacters }
+				/>
+			</HStack>
+		</div>
 	);
 }

--- a/src/admin/editor-config/editor-options/render-final-newline.js
+++ b/src/admin/editor-config/editor-options/render-final-newline.js
@@ -33,31 +33,33 @@ export default function RenderFinalNewline() {
 	};
 
 	return (
-		<HStack justify="start" align="start" wrap>
-			<ToggleControl
-				__nextHasNoMarginBottom
-				label={ title }
-				checked={ editorOptions.renderFinalNewline }
-				onChange={ onChange }
-			/>
-			<ItemHelp
-				onChange={ onChange }
-				title={ title }
-				items={ [
-					{
-						label: __( 'Enable', 'custom-html-block-extension' ),
-						value: true,
-						image: 'editor-options/render-final-newline_1.jpg',
-						isDefault: true,
-					},
-					{
-						label: __( 'Disable', 'custom-html-block-extension' ),
-						value: false,
-						image: 'editor-options/render-final-newline_2.jpg',
-					},
-				] }
-				value={ editorOptions.renderFinalNewline }
-			/>
-		</HStack>
+		<div className="chbe-admin-editor-config__setting-item">
+			<HStack justify="start" align="start" wrap>
+				<ToggleControl
+					__nextHasNoMarginBottom
+					label={ title }
+					checked={ editorOptions.renderFinalNewline }
+					onChange={ onChange }
+				/>
+				<ItemHelp
+					onChange={ onChange }
+					title={ title }
+					items={ [
+						{
+							label: __( 'Enable', 'custom-html-block-extension' ),
+							value: true,
+							image: 'editor-options/render-final-newline_1.jpg',
+							isDefault: true,
+						},
+						{
+							label: __( 'Disable', 'custom-html-block-extension' ),
+							value: false,
+							image: 'editor-options/render-final-newline_2.jpg',
+						},
+					] }
+					value={ editorOptions.renderFinalNewline }
+				/>
+			</HStack>
+		</div>
 	);
 }

--- a/src/admin/editor-config/editor-options/render-indent-guides.js
+++ b/src/admin/editor-config/editor-options/render-indent-guides.js
@@ -30,31 +30,33 @@ export default function RenderIndentGuides() {
 	};
 
 	return (
-		<HStack justify="start" align="start" wrap>
-			<ToggleControl
-				__nextHasNoMarginBottom
-				label={ title }
-				checked={ editorOptions.renderIndentGuides }
-				onChange={ onChange }
-			/>
-			<ItemHelp
-				onChange={ onChange }
-				title={ title }
-				items={ [
-					{
-						label: __( 'Enable', 'custom-html-block-extension' ),
-						value: true,
-						image: 'editor-options/render-indent-guides_1.jpg',
-						isDefault: true,
-					},
-					{
-						label: __( 'Disable', 'custom-html-block-extension' ),
-						value: false,
-						image: 'editor-options/render-indent-guides_2.jpg',
-					},
-				] }
-				value={ editorOptions.renderIndentGuides }
-			/>
-		</HStack>
+		<div className="chbe-admin-editor-config__setting-item">
+			<HStack justify="start" align="start" wrap>
+				<ToggleControl
+					__nextHasNoMarginBottom
+					label={ title }
+					checked={ editorOptions.renderIndentGuides }
+					onChange={ onChange }
+				/>
+				<ItemHelp
+					onChange={ onChange }
+					title={ title }
+					items={ [
+						{
+							label: __( 'Enable', 'custom-html-block-extension' ),
+							value: true,
+							image: 'editor-options/render-indent-guides_1.jpg',
+							isDefault: true,
+						},
+						{
+							label: __( 'Disable', 'custom-html-block-extension' ),
+							value: false,
+							image: 'editor-options/render-indent-guides_2.jpg',
+						},
+					] }
+					value={ editorOptions.renderIndentGuides }
+				/>
+			</HStack>
+		</div>
 	);
 }

--- a/src/admin/editor-config/editor-options/render-line-highlight-only-when-focus.js
+++ b/src/admin/editor-config/editor-options/render-line-highlight-only-when-focus.js
@@ -33,31 +33,33 @@ export default function RenderLineHighlightOnlyWhenFocus() {
 	};
 
 	return (
-		<HStack justify="start" align="start" wrap>
-			<ToggleControl
-				__nextHasNoMarginBottom
-				label={ title }
-				checked={ editorOptions.renderLineHighlightOnlyWhenFocus }
-				onChange={ onChange }
-			/>
-			<ItemHelp
-				onChange={ onChange }
-				title={ title }
-				items={ [
-					{
-						label: __( 'Enable', 'custom-html-block-extension' ),
-						value: true,
-						image: 'editor-options/render-line-highlight-only-when-focus_1.gif',
-					},
-					{
-						label: __( 'Disable', 'custom-html-block-extension' ),
-						value: false,
-						image: 'editor-options/render-line-highlight-only-when-focus_2.gif',
-						isDefault: true,
-					},
-				] }
-				value={ editorOptions.renderLineHighlightOnlyWhenFocus }
-			/>
-		</HStack>
+		<div className="chbe-admin-editor-config__setting-item">
+			<HStack justify="start" align="start" wrap>
+				<ToggleControl
+					__nextHasNoMarginBottom
+					label={ title }
+					checked={ editorOptions.renderLineHighlightOnlyWhenFocus }
+					onChange={ onChange }
+				/>
+				<ItemHelp
+					onChange={ onChange }
+					title={ title }
+					items={ [
+						{
+							label: __( 'Enable', 'custom-html-block-extension' ),
+							value: true,
+							image: 'editor-options/render-line-highlight-only-when-focus_1.gif',
+						},
+						{
+							label: __( 'Disable', 'custom-html-block-extension' ),
+							value: false,
+							image: 'editor-options/render-line-highlight-only-when-focus_2.gif',
+							isDefault: true,
+						},
+					] }
+					value={ editorOptions.renderLineHighlightOnlyWhenFocus }
+				/>
+			</HStack>
+		</div>
 	);
 }

--- a/src/admin/editor-config/editor-options/render-line-highlight.js
+++ b/src/admin/editor-config/editor-options/render-line-highlight.js
@@ -54,29 +54,34 @@ export default function RenderLineHighlight() {
 	};
 
 	return (
-		<HStack justify="start" align="start" wrap>
-			<SelectControl
-				__next40pxDefaultSize
-				__nextHasNoMarginBottom
-				label={ title }
-				value={ editorOptions.renderLineHighlight }
-				options={ [
-					{
-						label: __( 'Line numbers and the editor content', 'custom-html-block-extension' ),
-						value: 'all',
-					},
-					{ label: __( 'Only the editor content', 'custom-html-block-extension' ), value: 'line' },
-					{ label: __( 'Only line numbers', 'custom-html-block-extension' ), value: 'gutter' },
-					{ label: __( 'None', 'custom-html-block-extension' ), value: 'none' },
-				] }
-				onChange={ onChange }
-			/>
-			<ItemHelp
-				onChange={ onChange }
-				title={ title }
-				items={ items }
-				value={ editorOptions.renderLineHighlight }
-			/>
-		</HStack>
+		<div className="chbe-admin-editor-config__setting-item">
+			<HStack justify="start" align="start" wrap>
+				<SelectControl
+					__next40pxDefaultSize
+					__nextHasNoMarginBottom
+					label={ title }
+					value={ editorOptions.renderLineHighlight }
+					options={ [
+						{
+							label: __( 'Line numbers and the editor content', 'custom-html-block-extension' ),
+							value: 'all',
+						},
+						{
+							label: __( 'Only the editor content', 'custom-html-block-extension' ),
+							value: 'line',
+						},
+						{ label: __( 'Only line numbers', 'custom-html-block-extension' ), value: 'gutter' },
+						{ label: __( 'None', 'custom-html-block-extension' ), value: 'none' },
+					] }
+					onChange={ onChange }
+				/>
+				<ItemHelp
+					onChange={ onChange }
+					title={ title }
+					items={ items }
+					value={ editorOptions.renderLineHighlight }
+				/>
+			</HStack>
+		</div>
 	);
 }

--- a/src/admin/editor-config/editor-options/render-whitespace.js
+++ b/src/admin/editor-config/editor-options/render-whitespace.js
@@ -62,21 +62,23 @@ export default function RenderWhitespace() {
 	};
 
 	return (
-		<HStack justify="start" align="start" wrap>
-			<SelectControl
-				__next40pxDefaultSize
-				__nextHasNoMarginBottom
-				label={ title }
-				value={ editorOptions.renderWhitespace }
-				options={ items.map( ( { label, value } ) => ( { label, value } ) ) }
-				onChange={ onChange }
-			/>
-			<ItemHelp
-				onChange={ onChange }
-				title={ title }
-				items={ items }
-				value={ editorOptions.renderWhitespace }
-			/>
-		</HStack>
+		<div className="chbe-admin-editor-config__setting-item">
+			<HStack justify="start" align="start" wrap>
+				<SelectControl
+					__next40pxDefaultSize
+					__nextHasNoMarginBottom
+					label={ title }
+					value={ editorOptions.renderWhitespace }
+					options={ items.map( ( { label, value } ) => ( { label, value } ) ) }
+					onChange={ onChange }
+				/>
+				<ItemHelp
+					onChange={ onChange }
+					title={ title }
+					items={ items }
+					value={ editorOptions.renderWhitespace }
+				/>
+			</HStack>
+		</div>
 	);
 }

--- a/src/admin/editor-config/editor-options/rounded-selection.js
+++ b/src/admin/editor-config/editor-options/rounded-selection.js
@@ -30,31 +30,33 @@ export default function RoundedSelection() {
 	};
 
 	return (
-		<HStack justify="start" align="start" wrap>
-			<ToggleControl
-				__nextHasNoMarginBottom
-				label={ title }
-				checked={ editorOptions.roundedSelection }
-				onChange={ onChange }
-			/>
-			<ItemHelp
-				onChange={ onChange }
-				title={ title }
-				items={ [
-					{
-						label: __( 'Enable', 'custom-html-block-extension' ),
-						value: true,
-						image: 'editor-options/rounded-selection_1.jpg',
-					},
-					{
-						label: __( 'Disable', 'custom-html-block-extension' ),
-						value: false,
-						isDefault: true,
-						image: 'editor-options/rounded-selection_2.jpg',
-					},
-				] }
-				value={ editorOptions.roundedSelection }
-			/>
-		</HStack>
+		<div className="chbe-admin-editor-config__setting-item">
+			<HStack justify="start" align="start" wrap>
+				<ToggleControl
+					__nextHasNoMarginBottom
+					label={ title }
+					checked={ editorOptions.roundedSelection }
+					onChange={ onChange }
+				/>
+				<ItemHelp
+					onChange={ onChange }
+					title={ title }
+					items={ [
+						{
+							label: __( 'Enable', 'custom-html-block-extension' ),
+							value: true,
+							image: 'editor-options/rounded-selection_1.jpg',
+						},
+						{
+							label: __( 'Disable', 'custom-html-block-extension' ),
+							value: false,
+							isDefault: true,
+							image: 'editor-options/rounded-selection_2.jpg',
+						},
+					] }
+					value={ editorOptions.roundedSelection }
+				/>
+			</HStack>
+		</div>
 	);
 }

--- a/src/admin/editor-config/editor-options/rulers.js
+++ b/src/admin/editor-config/editor-options/rulers.js
@@ -31,18 +31,20 @@ export default function Rulers() {
 	};
 
 	return (
-		<HStack justify="start" align="start" wrap>
-			<RangeControl
-				__next40pxDefaultSize
-				__nextHasNoMarginBottom
-				label={ title }
-				value={ editorOptions.rulers.length ? editorOptions.rulers[ 0 ] : 0 }
-				min={ 0 }
-				max={ 80 }
-				allowReset
-				onChange={ onChange }
-			/>
-			<ItemHelp onChange={ onChange } title={ title } image="editor-options/rulers.gif" />
-		</HStack>
+		<div className="chbe-admin-editor-config__setting-item">
+			<HStack justify="start" align="start" wrap>
+				<RangeControl
+					__next40pxDefaultSize
+					__nextHasNoMarginBottom
+					label={ title }
+					value={ editorOptions.rulers.length ? editorOptions.rulers[ 0 ] : 0 }
+					min={ 0 }
+					max={ 80 }
+					allowReset
+					onChange={ onChange }
+				/>
+				<ItemHelp onChange={ onChange } title={ title } image="editor-options/rulers.gif" />
+			</HStack>
+		</div>
 	);
 }

--- a/src/admin/editor-config/editor-options/scroll-beyond-last-column.js
+++ b/src/admin/editor-config/editor-options/scroll-beyond-last-column.js
@@ -34,42 +34,44 @@ export default function ScrollBeyondLastColumn() {
 	};
 
 	return (
-		<HStack justify="start" align="start" wrap>
-			<RangeControl
-				__next40pxDefaultSize
-				__nextHasNoMarginBottom
-				label={ title }
-				value={ editorOptions.scrollBeyondLastColumn }
-				min={ 0 }
-				max={ 20 }
-				allowReset
-				onChange={ onChange }
-			/>
-			<ItemHelp
-				onChange={ onChange }
-				title={ title }
-				items={ [
-					{
-						label: sprintf(
-							/* translators: %s is replaced with the number. */
-							__( 'Example: Set the value to %s', 'custom-html-block-extension' ),
-							0
-						),
-						image: 'editor-options/suggest-line-height_1.jpg',
-						value: 0,
-					},
-					{
-						label: sprintf(
-							/* translators: %s is replaced with the number. */
-							__( 'Example: Set the value to %s', 'custom-html-block-extension' ),
-							20
-						),
-						image: 'editor-options/suggest-line-height_2.jpg',
-						value: 20,
-					},
-				] }
-				value={ editorOptions.scrollBeyondLastColumn }
-			/>
-		</HStack>
+		<div className="chbe-admin-editor-config__setting-item">
+			<HStack justify="start" align="start" wrap>
+				<RangeControl
+					__next40pxDefaultSize
+					__nextHasNoMarginBottom
+					label={ title }
+					value={ editorOptions.scrollBeyondLastColumn }
+					min={ 0 }
+					max={ 20 }
+					allowReset
+					onChange={ onChange }
+				/>
+				<ItemHelp
+					onChange={ onChange }
+					title={ title }
+					items={ [
+						{
+							label: sprintf(
+								/* translators: %s is replaced with the number. */
+								__( 'Example: Set the value to %s', 'custom-html-block-extension' ),
+								0
+							),
+							image: 'editor-options/suggest-line-height_1.jpg',
+							value: 0,
+						},
+						{
+							label: sprintf(
+								/* translators: %s is replaced with the number. */
+								__( 'Example: Set the value to %s', 'custom-html-block-extension' ),
+								20
+							),
+							image: 'editor-options/suggest-line-height_2.jpg',
+							value: 20,
+						},
+					] }
+					value={ editorOptions.scrollBeyondLastColumn }
+				/>
+			</HStack>
+		</div>
 	);
 }

--- a/src/admin/editor-config/editor-options/scroll-beyond-last-line.js
+++ b/src/admin/editor-config/editor-options/scroll-beyond-last-line.js
@@ -30,31 +30,33 @@ export default function ScrollBeyondLastLine() {
 	};
 
 	return (
-		<HStack justify="start" align="start" wrap>
-			<ToggleControl
-				__nextHasNoMarginBottom
-				label={ title }
-				checked={ editorOptions.scrollBeyondLastLine }
-				onChange={ onChange }
-			/>
-			<ItemHelp
-				onChange={ onChange }
-				title={ title }
-				items={ [
-					{
-						label: __( 'Enable', 'custom-html-block-extension' ),
-						value: true,
-						image: 'editor-options/scroll-beyond-last-line_1.gif',
-						isDefault: true,
-					},
-					{
-						label: __( 'Disable', 'custom-html-block-extension' ),
-						value: false,
-						image: 'editor-options/scroll-beyond-last-line_2.gif',
-					},
-				] }
-				value={ editorOptions.scrollBeyondLastLine }
-			/>
-		</HStack>
+		<div className="chbe-admin-editor-config__setting-item">
+			<HStack justify="start" align="start" wrap>
+				<ToggleControl
+					__nextHasNoMarginBottom
+					label={ title }
+					checked={ editorOptions.scrollBeyondLastLine }
+					onChange={ onChange }
+				/>
+				<ItemHelp
+					onChange={ onChange }
+					title={ title }
+					items={ [
+						{
+							label: __( 'Enable', 'custom-html-block-extension' ),
+							value: true,
+							image: 'editor-options/scroll-beyond-last-line_1.gif',
+							isDefault: true,
+						},
+						{
+							label: __( 'Disable', 'custom-html-block-extension' ),
+							value: false,
+							image: 'editor-options/scroll-beyond-last-line_2.gif',
+						},
+					] }
+					value={ editorOptions.scrollBeyondLastLine }
+				/>
+			</HStack>
+		</div>
 	);
 }

--- a/src/admin/editor-config/editor-options/scrollbar/always-consume-mouse-wheel.js
+++ b/src/admin/editor-config/editor-options/scrollbar/always-consume-mouse-wheel.js
@@ -35,39 +35,41 @@ export default function ScrollbarAlwaysConsumeMouseWheel() {
 	};
 
 	return (
-		<HStack justify="start" align="start" wrap>
-			<ToggleControl
-				__nextHasNoMarginBottom
-				label={ title }
-				checked={ editorOptions.scrollbar.alwaysConsumeMouseWheel }
-				onChange={ onChange }
-			/>
-			<ItemHelp
-				onChange={ onChange }
-				title={ title }
-				items={ [
-					{
-						label: __( 'Enable', 'custom-html-block-extension' ),
-						value: true,
-						isDefault: true,
-						description: __(
-							'Browser does not scroll when mouse wheel reaches the beginning or end.',
-							'custom-html-block-extension'
-						),
-						image: 'editor-options/scrollbar/always-consume-mouse-wheel_1.gif',
-					},
-					{
-						label: __( 'Disable', 'custom-html-block-extension' ),
-						value: false,
-						description: __(
-							'Browser will scroll when mouse wheel reaches the beginning or end.',
-							'custom-html-block-extension'
-						),
-						image: 'editor-options/scrollbar/always-consume-mouse-wheel_2.gif',
-					},
-				] }
-				value={ editorOptions.scrollbar.alwaysConsumeMouseWheel }
-			/>
-		</HStack>
+		<div className="chbe-admin-editor-config__setting-item">
+			<HStack justify="start" align="start" wrap>
+				<ToggleControl
+					__nextHasNoMarginBottom
+					label={ title }
+					checked={ editorOptions.scrollbar.alwaysConsumeMouseWheel }
+					onChange={ onChange }
+				/>
+				<ItemHelp
+					onChange={ onChange }
+					title={ title }
+					items={ [
+						{
+							label: __( 'Enable', 'custom-html-block-extension' ),
+							value: true,
+							isDefault: true,
+							description: __(
+								'Browser does not scroll when mouse wheel reaches the beginning or end.',
+								'custom-html-block-extension'
+							),
+							image: 'editor-options/scrollbar/always-consume-mouse-wheel_1.gif',
+						},
+						{
+							label: __( 'Disable', 'custom-html-block-extension' ),
+							value: false,
+							description: __(
+								'Browser will scroll when mouse wheel reaches the beginning or end.',
+								'custom-html-block-extension'
+							),
+							image: 'editor-options/scrollbar/always-consume-mouse-wheel_2.gif',
+						},
+					] }
+					value={ editorOptions.scrollbar.alwaysConsumeMouseWheel }
+				/>
+			</HStack>
+		</div>
 	);
 }

--- a/src/admin/editor-config/editor-options/scrollbar/arrow-size.js
+++ b/src/admin/editor-config/editor-options/scrollbar/arrow-size.js
@@ -49,42 +49,44 @@ export default function ScrollbarArrowSize() {
 	};
 
 	return (
-		<HStack justify="start" align="start" wrap>
-			<RangeControl
-				__next40pxDefaultSize
-				__nextHasNoMarginBottom
-				label={ title }
-				value={ value }
-				min={ 5 }
-				max={ 50 }
-				allowReset
-				onChange={ onChange }
-			/>
-			<ItemHelp
-				onChange={ onChange }
-				title={ title }
-				items={ [
-					{
-						label: sprintf(
-							/* translators: %s is replaced with the number. */
-							__( 'Example: Set the value to %s', 'custom-html-block-extension' ),
-							10
-						),
-						image: 'editor-options/scrollbar/arrow-size_1.jpg',
-						value: 10,
-					},
-					{
-						label: sprintf(
-							/* translators: %s is replaced with the number. */
-							__( 'Example: Set the value to %s', 'custom-html-block-extension' ),
-							30
-						),
-						image: 'editor-options/scrollbar/arrow-size_2.jpg',
-						value: 30,
-					},
-				] }
-				value={ value }
-			/>
-		</HStack>
+		<div className="chbe-admin-editor-config__setting-item">
+			<HStack justify="start" align="start" wrap>
+				<RangeControl
+					__next40pxDefaultSize
+					__nextHasNoMarginBottom
+					label={ title }
+					value={ value }
+					min={ 5 }
+					max={ 50 }
+					allowReset
+					onChange={ onChange }
+				/>
+				<ItemHelp
+					onChange={ onChange }
+					title={ title }
+					items={ [
+						{
+							label: sprintf(
+								/* translators: %s is replaced with the number. */
+								__( 'Example: Set the value to %s', 'custom-html-block-extension' ),
+								10
+							),
+							image: 'editor-options/scrollbar/arrow-size_1.jpg',
+							value: 10,
+						},
+						{
+							label: sprintf(
+								/* translators: %s is replaced with the number. */
+								__( 'Example: Set the value to %s', 'custom-html-block-extension' ),
+								30
+							),
+							image: 'editor-options/scrollbar/arrow-size_2.jpg',
+							value: 30,
+						},
+					] }
+					value={ value }
+				/>
+			</HStack>
+		</div>
 	);
 }

--- a/src/admin/editor-config/editor-options/scrollbar/horizontal-has-arrows.js
+++ b/src/admin/editor-config/editor-options/scrollbar/horizontal-has-arrows.js
@@ -35,31 +35,33 @@ export default function ScrollbarHorizontalHasArrows() {
 	};
 
 	return (
-		<HStack justify="start" align="start" wrap>
-			<ToggleControl
-				__nextHasNoMarginBottom
-				label={ title }
-				checked={ editorOptions.scrollbar.horizontalHasArrows }
-				onChange={ onChange }
-			/>
-			<ItemHelp
-				onChange={ onChange }
-				title={ title }
-				items={ [
-					{
-						label: __( 'Enable', 'custom-html-block-extension' ),
-						image: 'editor-options/scrollbar/horizontal-has-arrows_1.jpg',
-						value: true,
-					},
-					{
-						label: __( 'Disable', 'custom-html-block-extension' ),
-						image: 'editor-options/scrollbar/horizontal-has-arrows_2.jpg',
-						value: false,
-						isDefault: true,
-					},
-				] }
-				value={ editorOptions.scrollbar.horizontalHasArrows }
-			/>
-		</HStack>
+		<div className="chbe-admin-editor-config__setting-item">
+			<HStack justify="start" align="start" wrap>
+				<ToggleControl
+					__nextHasNoMarginBottom
+					label={ title }
+					checked={ editorOptions.scrollbar.horizontalHasArrows }
+					onChange={ onChange }
+				/>
+				<ItemHelp
+					onChange={ onChange }
+					title={ title }
+					items={ [
+						{
+							label: __( 'Enable', 'custom-html-block-extension' ),
+							image: 'editor-options/scrollbar/horizontal-has-arrows_1.jpg',
+							value: true,
+						},
+						{
+							label: __( 'Disable', 'custom-html-block-extension' ),
+							image: 'editor-options/scrollbar/horizontal-has-arrows_2.jpg',
+							value: false,
+							isDefault: true,
+						},
+					] }
+					value={ editorOptions.scrollbar.horizontalHasArrows }
+				/>
+			</HStack>
+		</div>
 	);
 }

--- a/src/admin/editor-config/editor-options/scrollbar/horizontal-scrollbar-size.js
+++ b/src/admin/editor-config/editor-options/scrollbar/horizontal-scrollbar-size.js
@@ -49,42 +49,44 @@ export default function ScrollbarHorizontalScrollbarSize() {
 	};
 
 	return (
-		<HStack justify="start" align="start" wrap>
-			<RangeControl
-				__next40pxDefaultSize
-				__nextHasNoMarginBottom
-				label={ title }
-				value={ value }
-				min={ 5 }
-				max={ 30 }
-				allowReset
-				onChange={ onChange }
-			/>
-			<ItemHelp
-				onChange={ onChange }
-				title={ title }
-				items={ [
-					{
-						label: sprintf(
-							/* translators: %s is replaced with the number. */
-							__( 'Example: Set the value to %s', 'custom-html-block-extension' ),
-							10
-						),
-						image: 'editor-options/scrollbar/horizontal-scrollbar-size_1.jpg',
-						value: 10,
-					},
-					{
-						label: sprintf(
-							/* translators: %s is replaced with the number. */
-							__( 'Example: Set the value to %s', 'custom-html-block-extension' ),
-							30
-						),
-						image: 'editor-options/scrollbar/horizontal-scrollbar-size_2.jpg',
-						value: 30,
-					},
-				] }
-				value={ value }
-			/>
-		</HStack>
+		<div className="chbe-admin-editor-config__setting-item">
+			<HStack justify="start" align="start" wrap>
+				<RangeControl
+					__next40pxDefaultSize
+					__nextHasNoMarginBottom
+					label={ title }
+					value={ value }
+					min={ 5 }
+					max={ 30 }
+					allowReset
+					onChange={ onChange }
+				/>
+				<ItemHelp
+					onChange={ onChange }
+					title={ title }
+					items={ [
+						{
+							label: sprintf(
+								/* translators: %s is replaced with the number. */
+								__( 'Example: Set the value to %s', 'custom-html-block-extension' ),
+								10
+							),
+							image: 'editor-options/scrollbar/horizontal-scrollbar-size_1.jpg',
+							value: 10,
+						},
+						{
+							label: sprintf(
+								/* translators: %s is replaced with the number. */
+								__( 'Example: Set the value to %s', 'custom-html-block-extension' ),
+								30
+							),
+							image: 'editor-options/scrollbar/horizontal-scrollbar-size_2.jpg',
+							value: 30,
+						},
+					] }
+					value={ value }
+				/>
+			</HStack>
+		</div>
 	);
 }

--- a/src/admin/editor-config/editor-options/scrollbar/horizontal.js
+++ b/src/admin/editor-config/editor-options/scrollbar/horizontal.js
@@ -54,22 +54,24 @@ export default function ScrollbarHorizontal() {
 	};
 
 	return (
-		<HStack justify="start" align="start" wrap>
-			<SelectControl
-				__next40pxDefaultSize
-				__nextHasNoMarginBottom
-				label={ title }
-				value={ editorOptions.scrollbar.horizontal }
-				options={ items.map( ( { label, value } ) => ( { label, value } ) ) }
-				onChange={ onChange }
-			/>
-			<ItemHelp
-				onChange={ onChange }
-				title={ title }
-				items={ items }
-				colCount="3"
-				value={ editorOptions.scrollbar.horizontal }
-			/>
-		</HStack>
+		<div className="chbe-admin-editor-config__setting-item">
+			<HStack justify="start" align="start" wrap>
+				<SelectControl
+					__next40pxDefaultSize
+					__nextHasNoMarginBottom
+					label={ title }
+					value={ editorOptions.scrollbar.horizontal }
+					options={ items.map( ( { label, value } ) => ( { label, value } ) ) }
+					onChange={ onChange }
+				/>
+				<ItemHelp
+					onChange={ onChange }
+					title={ title }
+					items={ items }
+					colCount="3"
+					value={ editorOptions.scrollbar.horizontal }
+				/>
+			</HStack>
+		</div>
 	);
 }

--- a/src/admin/editor-config/editor-options/scrollbar/scroll-by-page.js
+++ b/src/admin/editor-config/editor-options/scrollbar/scroll-by-page.js
@@ -35,25 +35,27 @@ export default function ScrollbarScrollByPage() {
 	};
 
 	return (
-		<HStack justify="start" align="start" wrap>
-			<ToggleControl
-				__nextHasNoMarginBottom
-				label={ title }
-				checked={ editorOptions.scrollbar.scrollByPage }
-				onChange={ onChange }
-			/>
-			<ItemHelp
-				onChange={ onChange }
-				title={ title }
-				description={ __(
-					'Scroll by page when the scroll bar is clicked.',
-					'custom-html-block-extension'
-				) }
-				isToggle
-				defaultToggle={ false }
-				image="editor-options/scrollbar/scroll-by-page.gif"
-				value={ editorOptions.scrollbar.scrollByPage }
-			/>
-		</HStack>
+		<div className="chbe-admin-editor-config__setting-item">
+			<HStack justify="start" align="start" wrap>
+				<ToggleControl
+					__nextHasNoMarginBottom
+					label={ title }
+					checked={ editorOptions.scrollbar.scrollByPage }
+					onChange={ onChange }
+				/>
+				<ItemHelp
+					onChange={ onChange }
+					title={ title }
+					description={ __(
+						'Scroll by page when the scroll bar is clicked.',
+						'custom-html-block-extension'
+					) }
+					isToggle
+					defaultToggle={ false }
+					image="editor-options/scrollbar/scroll-by-page.gif"
+					value={ editorOptions.scrollbar.scrollByPage }
+				/>
+			</HStack>
+		</div>
 	);
 }

--- a/src/admin/editor-config/editor-options/scrollbar/use-shadows.js
+++ b/src/admin/editor-config/editor-options/scrollbar/use-shadows.js
@@ -33,31 +33,33 @@ export default function ScrollbarUseShadows() {
 	};
 
 	return (
-		<HStack justify="start" align="start" wrap>
-			<ToggleControl
-				__nextHasNoMarginBottom
-				label={ title }
-				checked={ editorOptions.scrollbar.useShadows }
-				onChange={ onChange }
-			/>
-			<ItemHelp
-				onChange={ onChange }
-				title={ title }
-				items={ [
-					{
-						label: __( 'Enable', 'custom-html-block-extension' ),
-						image: 'editor-options/scrollbar/use-shadows_1.jpg',
-						value: true,
-						isDefault: true,
-					},
-					{
-						label: __( 'Disable', 'custom-html-block-extension' ),
-						image: 'editor-options/scrollbar/use-shadows_2.jpg',
-						value: false,
-					},
-				] }
-				value={ editorOptions.scrollbar.useShadows }
-			/>
-		</HStack>
+		<div className="chbe-admin-editor-config__setting-item">
+			<HStack justify="start" align="start" wrap>
+				<ToggleControl
+					__nextHasNoMarginBottom
+					label={ title }
+					checked={ editorOptions.scrollbar.useShadows }
+					onChange={ onChange }
+				/>
+				<ItemHelp
+					onChange={ onChange }
+					title={ title }
+					items={ [
+						{
+							label: __( 'Enable', 'custom-html-block-extension' ),
+							image: 'editor-options/scrollbar/use-shadows_1.jpg',
+							value: true,
+							isDefault: true,
+						},
+						{
+							label: __( 'Disable', 'custom-html-block-extension' ),
+							image: 'editor-options/scrollbar/use-shadows_2.jpg',
+							value: false,
+						},
+					] }
+					value={ editorOptions.scrollbar.useShadows }
+				/>
+			</HStack>
+		</div>
 	);
 }

--- a/src/admin/editor-config/editor-options/scrollbar/vertical-has-arrows.js
+++ b/src/admin/editor-config/editor-options/scrollbar/vertical-has-arrows.js
@@ -35,31 +35,33 @@ export default function ScrollbarVerticalHasArrows() {
 	};
 
 	return (
-		<HStack justify="start" align="start" wrap>
-			<ToggleControl
-				__nextHasNoMarginBottom
-				label={ title }
-				checked={ editorOptions.scrollbar.verticalHasArrows }
-				onChange={ onChange }
-			/>
-			<ItemHelp
-				onChange={ onChange }
-				title={ title }
-				items={ [
-					{
-						label: __( 'Enable', 'custom-html-block-extension' ),
-						image: 'editor-options/scrollbar/vertical-has-arrows_1.jpg',
-						value: true,
-					},
-					{
-						label: __( 'Disable', 'custom-html-block-extension' ),
-						image: 'editor-options/scrollbar/vertical-has-arrows_2.jpg',
-						value: false,
-						isDefault: true,
-					},
-				] }
-				value={ editorOptions.scrollbar.verticalHasArrows }
-			/>
-		</HStack>
+		<div className="chbe-admin-editor-config__setting-item">
+			<HStack justify="start" align="start" wrap>
+				<ToggleControl
+					__nextHasNoMarginBottom
+					label={ title }
+					checked={ editorOptions.scrollbar.verticalHasArrows }
+					onChange={ onChange }
+				/>
+				<ItemHelp
+					onChange={ onChange }
+					title={ title }
+					items={ [
+						{
+							label: __( 'Enable', 'custom-html-block-extension' ),
+							image: 'editor-options/scrollbar/vertical-has-arrows_1.jpg',
+							value: true,
+						},
+						{
+							label: __( 'Disable', 'custom-html-block-extension' ),
+							image: 'editor-options/scrollbar/vertical-has-arrows_2.jpg',
+							value: false,
+							isDefault: true,
+						},
+					] }
+					value={ editorOptions.scrollbar.verticalHasArrows }
+				/>
+			</HStack>
+		</div>
 	);
 }

--- a/src/admin/editor-config/editor-options/scrollbar/vertical-scrollbar-size.js
+++ b/src/admin/editor-config/editor-options/scrollbar/vertical-scrollbar-size.js
@@ -49,42 +49,44 @@ export default function ScrollbarVerticalScrollbarSize() {
 	};
 
 	return (
-		<HStack justify="start" align="start" wrap>
-			<RangeControl
-				__next40pxDefaultSize
-				__nextHasNoMarginBottom
-				label={ title }
-				value={ value }
-				min={ 5 }
-				max={ 30 }
-				allowReset
-				onChange={ onChange }
-			/>
-			<ItemHelp
-				onChange={ onChange }
-				title={ title }
-				items={ [
-					{
-						label: sprintf(
-							/* translators: %s is replaced with the number. */
-							__( 'Example: Set the value to %s', 'custom-html-block-extension' ),
-							10
-						),
-						image: 'editor-options/scrollbar/vertical-scrollbar-size_1.jpg',
-						value: 10,
-					},
-					{
-						label: sprintf(
-							/* translators: %s is replaced with the number. */
-							__( 'Example: Set the value to %s', 'custom-html-block-extension' ),
-							30
-						),
-						image: 'editor-options/scrollbar/vertical-scrollbar-size_2.jpg',
-						value: 30,
-					},
-				] }
-				value={ value }
-			/>
-		</HStack>
+		<div className="chbe-admin-editor-config__setting-item">
+			<HStack justify="start" align="start" wrap>
+				<RangeControl
+					__next40pxDefaultSize
+					__nextHasNoMarginBottom
+					label={ title }
+					value={ value }
+					min={ 5 }
+					max={ 30 }
+					allowReset
+					onChange={ onChange }
+				/>
+				<ItemHelp
+					onChange={ onChange }
+					title={ title }
+					items={ [
+						{
+							label: sprintf(
+								/* translators: %s is replaced with the number. */
+								__( 'Example: Set the value to %s', 'custom-html-block-extension' ),
+								10
+							),
+							image: 'editor-options/scrollbar/vertical-scrollbar-size_1.jpg',
+							value: 10,
+						},
+						{
+							label: sprintf(
+								/* translators: %s is replaced with the number. */
+								__( 'Example: Set the value to %s', 'custom-html-block-extension' ),
+								30
+							),
+							image: 'editor-options/scrollbar/vertical-scrollbar-size_2.jpg',
+							value: 30,
+						},
+					] }
+					value={ value }
+				/>
+			</HStack>
+		</div>
 	);
 }

--- a/src/admin/editor-config/editor-options/scrollbar/vertical.js
+++ b/src/admin/editor-config/editor-options/scrollbar/vertical.js
@@ -54,22 +54,24 @@ export default function ScrollbarVertical() {
 	};
 
 	return (
-		<HStack justify="start" align="start" wrap>
-			<SelectControl
-				__next40pxDefaultSize
-				__nextHasNoMarginBottom
-				label={ title }
-				value={ editorOptions.scrollbar.vertical }
-				options={ items.map( ( { label, value } ) => ( { label, value } ) ) }
-				onChange={ onChange }
-			/>
-			<ItemHelp
-				onChange={ onChange }
-				title={ title }
-				items={ items }
-				colCount="3"
-				value={ editorOptions.scrollbar.vertical }
-			/>
-		</HStack>
+		<div className="chbe-admin-editor-config__setting-item">
+			<HStack justify="start" align="start" wrap>
+				<SelectControl
+					__next40pxDefaultSize
+					__nextHasNoMarginBottom
+					label={ title }
+					value={ editorOptions.scrollbar.vertical }
+					options={ items.map( ( { label, value } ) => ( { label, value } ) ) }
+					onChange={ onChange }
+				/>
+				<ItemHelp
+					onChange={ onChange }
+					title={ title }
+					items={ items }
+					colCount="3"
+					value={ editorOptions.scrollbar.vertical }
+				/>
+			</HStack>
+		</div>
 	);
 }

--- a/src/admin/editor-config/editor-options/select-on-line-numbers.js
+++ b/src/admin/editor-config/editor-options/select-on-line-numbers.js
@@ -33,31 +33,33 @@ export default function SelectOnLineNumbers() {
 	};
 
 	return (
-		<HStack justify="start" align="start" wrap>
-			<ToggleControl
-				__nextHasNoMarginBottom
-				label={ title }
-				checked={ editorOptions.selectOnLineNumbers }
-				onChange={ onChange }
-			/>
-			<ItemHelp
-				onChange={ onChange }
-				title={ title }
-				items={ [
-					{
-						label: __( 'Enable', 'custom-html-block-extension' ),
-						value: true,
-						image: 'editor-options/select-on-line-numbers_1.gif',
-						isDefault: true,
-					},
-					{
-						label: __( 'Disable', 'custom-html-block-extension' ),
-						value: false,
-						image: 'editor-options/select-on-line-numbers_2.gif',
-					},
-				] }
-				value={ editorOptions.selectOnLineNumbers }
-			/>
-		</HStack>
+		<div className="chbe-admin-editor-config__setting-item">
+			<HStack justify="start" align="start" wrap>
+				<ToggleControl
+					__nextHasNoMarginBottom
+					label={ title }
+					checked={ editorOptions.selectOnLineNumbers }
+					onChange={ onChange }
+				/>
+				<ItemHelp
+					onChange={ onChange }
+					title={ title }
+					items={ [
+						{
+							label: __( 'Enable', 'custom-html-block-extension' ),
+							value: true,
+							image: 'editor-options/select-on-line-numbers_1.gif',
+							isDefault: true,
+						},
+						{
+							label: __( 'Disable', 'custom-html-block-extension' ),
+							value: false,
+							image: 'editor-options/select-on-line-numbers_2.gif',
+						},
+					] }
+					value={ editorOptions.selectOnLineNumbers }
+				/>
+			</HStack>
+		</div>
 	);
 }

--- a/src/admin/editor-config/editor-options/selection-highlight.js
+++ b/src/admin/editor-config/editor-options/selection-highlight.js
@@ -30,31 +30,33 @@ export default function SelectionHighlight() {
 	};
 
 	return (
-		<HStack justify="start" align="start" wrap>
-			<ToggleControl
-				__nextHasNoMarginBottom
-				label={ title }
-				checked={ editorOptions.selectionHighlight }
-				onChange={ onChange }
-			/>
-			<ItemHelp
-				onChange={ onChange }
-				title={ title }
-				items={ [
-					{
-						label: __( 'Enable', 'custom-html-block-extension' ),
-						value: true,
-						image: 'editor-options/selection-highlight_1.jpg',
-						isDefault: true,
-					},
-					{
-						label: __( 'Disable', 'custom-html-block-extension' ),
-						value: false,
-						image: 'editor-options/selection-highlight_2.jpg',
-					},
-				] }
-				value={ editorOptions.selectionHighlight }
-			/>
-		</HStack>
+		<div className="chbe-admin-editor-config__setting-item">
+			<HStack justify="start" align="start" wrap>
+				<ToggleControl
+					__nextHasNoMarginBottom
+					label={ title }
+					checked={ editorOptions.selectionHighlight }
+					onChange={ onChange }
+				/>
+				<ItemHelp
+					onChange={ onChange }
+					title={ title }
+					items={ [
+						{
+							label: __( 'Enable', 'custom-html-block-extension' ),
+							value: true,
+							image: 'editor-options/selection-highlight_1.jpg',
+							isDefault: true,
+						},
+						{
+							label: __( 'Disable', 'custom-html-block-extension' ),
+							value: false,
+							image: 'editor-options/selection-highlight_2.jpg',
+						},
+					] }
+					value={ editorOptions.selectionHighlight }
+				/>
+			</HStack>
+		</div>
 	);
 }

--- a/src/admin/editor-config/editor-options/show-folding-controls.js
+++ b/src/admin/editor-config/editor-options/show-folding-controls.js
@@ -44,21 +44,23 @@ export default function ShowFoldingControls() {
 	};
 
 	return (
-		<HStack justify="start" align="start" wrap>
-			<SelectControl
-				__next40pxDefaultSize
-				__nextHasNoMarginBottom
-				label={ title }
-				value={ editorOptions.showFoldingControls }
-				options={ items.map( ( { label, value } ) => ( { label, value } ) ) }
-				onChange={ onChange }
-			/>
-			<ItemHelp
-				onChange={ onChange }
-				title={ title }
-				items={ items }
-				value={ editorOptions.showFoldingControls }
-			/>
-		</HStack>
+		<div className="chbe-admin-editor-config__setting-item">
+			<HStack justify="start" align="start" wrap>
+				<SelectControl
+					__next40pxDefaultSize
+					__nextHasNoMarginBottom
+					label={ title }
+					value={ editorOptions.showFoldingControls }
+					options={ items.map( ( { label, value } ) => ( { label, value } ) ) }
+					onChange={ onChange }
+				/>
+				<ItemHelp
+					onChange={ onChange }
+					title={ title }
+					items={ items }
+					value={ editorOptions.showFoldingControls }
+				/>
+			</HStack>
+		</div>
 	);
 }

--- a/src/admin/editor-config/editor-options/smooth-scrolling.js
+++ b/src/admin/editor-config/editor-options/smooth-scrolling.js
@@ -30,31 +30,33 @@ export default function SmoothScrolling() {
 	};
 
 	return (
-		<HStack justify="start" align="start" wrap>
-			<ToggleControl
-				__nextHasNoMarginBottom
-				label={ title }
-				checked={ editorOptions.smoothScrolling }
-				onChange={ onChange }
-			/>
-			<ItemHelp
-				onChange={ onChange }
-				title={ title }
-				items={ [
-					{
-						label: __( 'Enable', 'custom-html-block-extension' ),
-						value: true,
-						image: 'editor-options/smooth-scrolling_1.gif',
-					},
-					{
-						label: __( 'Disable', 'custom-html-block-extension' ),
-						value: false,
-						image: 'editor-options/smooth-scrolling_2.gif',
-						isDefault: true,
-					},
-				] }
-				value={ editorOptions.smoothScrolling }
-			/>
-		</HStack>
+		<div className="chbe-admin-editor-config__setting-item">
+			<HStack justify="start" align="start" wrap>
+				<ToggleControl
+					__nextHasNoMarginBottom
+					label={ title }
+					checked={ editorOptions.smoothScrolling }
+					onChange={ onChange }
+				/>
+				<ItemHelp
+					onChange={ onChange }
+					title={ title }
+					items={ [
+						{
+							label: __( 'Enable', 'custom-html-block-extension' ),
+							value: true,
+							image: 'editor-options/smooth-scrolling_1.gif',
+						},
+						{
+							label: __( 'Disable', 'custom-html-block-extension' ),
+							value: false,
+							image: 'editor-options/smooth-scrolling_2.gif',
+							isDefault: true,
+						},
+					] }
+					value={ editorOptions.smoothScrolling }
+				/>
+			</HStack>
+		</div>
 	);
 }

--- a/src/admin/editor-config/editor-options/sticky-tab-stops.js
+++ b/src/admin/editor-config/editor-options/sticky-tab-stops.js
@@ -30,31 +30,33 @@ export default function StickyTabStops() {
 	};
 
 	return (
-		<HStack justify="start" align="start" wrap>
-			<ToggleControl
-				__nextHasNoMarginBottom
-				label={ title }
-				checked={ editorOptions.stickyTabStops }
-				onChange={ onChange }
-			/>
-			<ItemHelp
-				onChange={ onChange }
-				title={ title }
-				items={ [
-					{
-						label: __( 'Enable', 'custom-html-block-extension' ),
-						value: true,
-						image: 'editor-options/sticky-tab-stops_1.gif',
-					},
-					{
-						label: __( 'Disable', 'custom-html-block-extension' ),
-						value: false,
-						image: 'editor-options/sticky-tab-stops_2.gif',
-						isDefault: true,
-					},
-				] }
-				value={ editorOptions.stickyTabStops }
-			/>
-		</HStack>
+		<div className="chbe-admin-editor-config__setting-item">
+			<HStack justify="start" align="start" wrap>
+				<ToggleControl
+					__nextHasNoMarginBottom
+					label={ title }
+					checked={ editorOptions.stickyTabStops }
+					onChange={ onChange }
+				/>
+				<ItemHelp
+					onChange={ onChange }
+					title={ title }
+					items={ [
+						{
+							label: __( 'Enable', 'custom-html-block-extension' ),
+							value: true,
+							image: 'editor-options/sticky-tab-stops_1.gif',
+						},
+						{
+							label: __( 'Disable', 'custom-html-block-extension' ),
+							value: false,
+							image: 'editor-options/sticky-tab-stops_2.gif',
+							isDefault: true,
+						},
+					] }
+					value={ editorOptions.stickyTabStops }
+				/>
+			</HStack>
+		</div>
 	);
 }

--- a/src/admin/editor-config/editor-options/suggest-font-size.js
+++ b/src/admin/editor-config/editor-options/suggest-font-size.js
@@ -31,42 +31,44 @@ export default function SuggestFontSize() {
 	};
 
 	return (
-		<HStack justify="start" align="start" wrap>
-			<RangeControl
-				__next40pxDefaultSize
-				__nextHasNoMarginBottom
-				label={ title }
-				value={ editorOptions.suggestFontSize }
-				min={ 10 }
-				max={ 30 }
-				allowReset
-				onChange={ onChange }
-			/>
-			<ItemHelp
-				onChange={ onChange }
-				title={ title }
-				items={ [
-					{
-						label: sprintf(
-							/* translators: %s is replaced with the number. */
-							__( 'Example: Set the value to %s', 'custom-html-block-extension' ),
-							10
-						),
-						image: 'editor-options/suggest-font-size_1.jpg',
-						value: 10,
-					},
-					{
-						label: sprintf(
-							/* translators: %s is replaced with the number. */
-							__( 'Example: Set the value to %s', 'custom-html-block-extension' ),
-							30
-						),
-						image: 'editor-options/suggest-font-size_2.jpg',
-						value: 30,
-					},
-				] }
-				value={ editorOptions.suggestFontSize }
-			/>
-		</HStack>
+		<div className="chbe-admin-editor-config__setting-item">
+			<HStack justify="start" align="start" wrap>
+				<RangeControl
+					__next40pxDefaultSize
+					__nextHasNoMarginBottom
+					label={ title }
+					value={ editorOptions.suggestFontSize }
+					min={ 10 }
+					max={ 30 }
+					allowReset
+					onChange={ onChange }
+				/>
+				<ItemHelp
+					onChange={ onChange }
+					title={ title }
+					items={ [
+						{
+							label: sprintf(
+								/* translators: %s is replaced with the number. */
+								__( 'Example: Set the value to %s', 'custom-html-block-extension' ),
+								10
+							),
+							image: 'editor-options/suggest-font-size_1.jpg',
+							value: 10,
+						},
+						{
+							label: sprintf(
+								/* translators: %s is replaced with the number. */
+								__( 'Example: Set the value to %s', 'custom-html-block-extension' ),
+								30
+							),
+							image: 'editor-options/suggest-font-size_2.jpg',
+							value: 30,
+						},
+					] }
+					value={ editorOptions.suggestFontSize }
+				/>
+			</HStack>
+		</div>
 	);
 }

--- a/src/admin/editor-config/editor-options/suggest-line-height.js
+++ b/src/admin/editor-config/editor-options/suggest-line-height.js
@@ -31,42 +31,44 @@ export default function SuggestLineHeight() {
 	};
 
 	return (
-		<HStack justify="start" align="start" wrap>
-			<RangeControl
-				__next40pxDefaultSize
-				__nextHasNoMarginBottom
-				label={ title }
-				value={ editorOptions.suggestLineHeight }
-				min={ 10 }
-				max={ 60 }
-				allowReset
-				onChange={ onChange }
-			/>
-			<ItemHelp
-				onChange={ onChange }
-				title={ title }
-				items={ [
-					{
-						label: sprintf(
-							/* translators: %s is replaced with the number. */
-							__( 'Example: Set the value to %s', 'custom-html-block-extension' ),
-							10
-						),
-						image: 'editor-options/suggest-line-height_1.jpg',
-						value: 10,
-					},
-					{
-						label: sprintf(
-							/* translators: %s is replaced with the number. */
-							__( 'Example: Set the value to %s', 'custom-html-block-extension' ),
-							30
-						),
-						image: 'editor-options/suggest-line-height_2.jpg',
-						value: 30,
-					},
-				] }
-				value={ editorOptions.suggestLineHeight }
-			/>
-		</HStack>
+		<div className="chbe-admin-editor-config__setting-item">
+			<HStack justify="start" align="start" wrap>
+				<RangeControl
+					__next40pxDefaultSize
+					__nextHasNoMarginBottom
+					label={ title }
+					value={ editorOptions.suggestLineHeight }
+					min={ 10 }
+					max={ 60 }
+					allowReset
+					onChange={ onChange }
+				/>
+				<ItemHelp
+					onChange={ onChange }
+					title={ title }
+					items={ [
+						{
+							label: sprintf(
+								/* translators: %s is replaced with the number. */
+								__( 'Example: Set the value to %s', 'custom-html-block-extension' ),
+								10
+							),
+							image: 'editor-options/suggest-line-height_1.jpg',
+							value: 10,
+						},
+						{
+							label: sprintf(
+								/* translators: %s is replaced with the number. */
+								__( 'Example: Set the value to %s', 'custom-html-block-extension' ),
+								30
+							),
+							image: 'editor-options/suggest-line-height_2.jpg',
+							value: 30,
+						},
+					] }
+					value={ editorOptions.suggestLineHeight }
+				/>
+			</HStack>
+		</div>
 	);
 }

--- a/src/admin/editor-config/editor-options/suggest/show-icons.js
+++ b/src/admin/editor-config/editor-options/suggest/show-icons.js
@@ -33,31 +33,33 @@ export default function SuggestShowIcons() {
 	};
 
 	return (
-		<HStack justify="start" align="start" wrap>
-			<ToggleControl
-				__nextHasNoMarginBottom
-				label={ title }
-				checked={ editorOptions.suggest.showIcons }
-				onChange={ onChange }
-			/>
-			<ItemHelp
-				onChange={ onChange }
-				title={ title }
-				items={ [
-					{
-						label: __( 'Enable', 'custom-html-block-extension' ),
-						image: 'editor-options/suggest/show-icons_1.jpg',
-						value: true,
-						isDefault: true,
-					},
-					{
-						label: __( 'Disable', 'custom-html-block-extension' ),
-						image: 'editor-options/suggest/show-icons_2.jpg',
-						value: false,
-					},
-				] }
-				value={ editorOptions.suggest.showIcons }
-			/>
-		</HStack>
+		<div className="chbe-admin-editor-config__setting-item">
+			<HStack justify="start" align="start" wrap>
+				<ToggleControl
+					__nextHasNoMarginBottom
+					label={ title }
+					checked={ editorOptions.suggest.showIcons }
+					onChange={ onChange }
+				/>
+				<ItemHelp
+					onChange={ onChange }
+					title={ title }
+					items={ [
+						{
+							label: __( 'Enable', 'custom-html-block-extension' ),
+							image: 'editor-options/suggest/show-icons_1.jpg',
+							value: true,
+							isDefault: true,
+						},
+						{
+							label: __( 'Disable', 'custom-html-block-extension' ),
+							image: 'editor-options/suggest/show-icons_2.jpg',
+							value: false,
+						},
+					] }
+					value={ editorOptions.suggest.showIcons }
+				/>
+			</HStack>
+		</div>
 	);
 }

--- a/src/admin/editor-config/editor-options/unfold-on-click-after-end-of-line.js
+++ b/src/admin/editor-config/editor-options/unfold-on-click-after-end-of-line.js
@@ -33,21 +33,23 @@ export default function UnfoldOnClickAfterEndOfLine() {
 	};
 
 	return (
-		<HStack justify="start" align="start" wrap>
-			<ToggleControl
-				__nextHasNoMarginBottom
-				label={ title }
-				checked={ editorOptions.unfoldOnClickAfterEndOfLine }
-				onChange={ onChange }
-			/>
-			<ItemHelp
-				onChange={ onChange }
-				title={ title }
-				isToggle
-				image="editor-options/unfold-on-click-after-end-of-line.gif"
-				defaultToggle={ false }
-				value={ editorOptions.unfoldOnClickAfterEndOfLine }
-			/>
-		</HStack>
+		<div className="chbe-admin-editor-config__setting-item">
+			<HStack justify="start" align="start" wrap>
+				<ToggleControl
+					__nextHasNoMarginBottom
+					label={ title }
+					checked={ editorOptions.unfoldOnClickAfterEndOfLine }
+					onChange={ onChange }
+				/>
+				<ItemHelp
+					onChange={ onChange }
+					title={ title }
+					isToggle
+					image="editor-options/unfold-on-click-after-end-of-line.gif"
+					defaultToggle={ false }
+					value={ editorOptions.unfoldOnClickAfterEndOfLine }
+				/>
+			</HStack>
+		</div>
 	);
 }

--- a/src/admin/editor-config/editor-options/use-tab-stops.js
+++ b/src/admin/editor-config/editor-options/use-tab-stops.js
@@ -33,31 +33,33 @@ export default function UseTabStops() {
 	};
 
 	return (
-		<HStack justify="start" align="start" wrap>
-			<ToggleControl
-				__nextHasNoMarginBottom
-				label={ title }
-				checked={ editorOptions.useTabStops }
-				onChange={ onChange }
-			/>
-			<ItemHelp
-				onChange={ onChange }
-				title={ title }
-				items={ [
-					{
-						label: __( 'Enable', 'custom-html-block-extension' ),
-						image: 'editor-options/use-tab-stops_1.gif',
-						value: true,
-						isDefault: true,
-					},
-					{
-						label: __( 'Disable', 'custom-html-block-extension' ),
-						image: 'editor-options/use-tab-stops_2.gif',
-						value: false,
-					},
-				] }
-				value={ editorOptions.useTabStops }
-			/>
-		</HStack>
+		<div className="chbe-admin-editor-config__setting-item">
+			<HStack justify="start" align="start" wrap>
+				<ToggleControl
+					__nextHasNoMarginBottom
+					label={ title }
+					checked={ editorOptions.useTabStops }
+					onChange={ onChange }
+				/>
+				<ItemHelp
+					onChange={ onChange }
+					title={ title }
+					items={ [
+						{
+							label: __( 'Enable', 'custom-html-block-extension' ),
+							image: 'editor-options/use-tab-stops_1.gif',
+							value: true,
+							isDefault: true,
+						},
+						{
+							label: __( 'Disable', 'custom-html-block-extension' ),
+							image: 'editor-options/use-tab-stops_2.gif',
+							value: false,
+						},
+					] }
+					value={ editorOptions.useTabStops }
+				/>
+			</HStack>
+		</div>
 	);
 }

--- a/src/admin/editor-config/editor-options/word-wrap-column.js
+++ b/src/admin/editor-config/editor-options/word-wrap-column.js
@@ -31,23 +31,25 @@ export default function WordWrapColumn() {
 	};
 
 	return (
-		<HStack justify="start" align="start" wrap>
-			<RangeControl
-				__next40pxDefaultSize
-				__nextHasNoMarginBottom
-				label={ title }
-				value={ editorOptions.wordWrapColumn }
-				min={ 20 }
-				max={ 200 }
-				allowReset
-				onChange={ onChange }
-			/>
-			<ItemHelp
-				onChange={ onChange }
-				title={ title }
-				image="editor-options/word-wrap-column.gif"
-				value={ editorOptions.wordWrapColumn }
-			/>
-		</HStack>
+		<div className="chbe-admin-editor-config__setting-item">
+			<HStack justify="start" align="start" wrap>
+				<RangeControl
+					__next40pxDefaultSize
+					__nextHasNoMarginBottom
+					label={ title }
+					value={ editorOptions.wordWrapColumn }
+					min={ 20 }
+					max={ 200 }
+					allowReset
+					onChange={ onChange }
+				/>
+				<ItemHelp
+					onChange={ onChange }
+					title={ title }
+					image="editor-options/word-wrap-column.gif"
+					value={ editorOptions.wordWrapColumn }
+				/>
+			</HStack>
+		</div>
 	);
 }

--- a/src/admin/editor-config/editor-options/word-wrap.js
+++ b/src/admin/editor-config/editor-options/word-wrap.js
@@ -64,21 +64,23 @@ export default function WordWrap() {
 	};
 
 	return (
-		<HStack justify="start" align="start" wrap>
-			<SelectControl
-				__next40pxDefaultSize
-				__nextHasNoMarginBottom
-				label={ title }
-				value={ editorOptions.wordWrap }
-				options={ items.map( ( { label, value } ) => ( { label, value } ) ) }
-				onChange={ onChange }
-			/>
-			<ItemHelp
-				onChange={ onChange }
-				title={ title }
-				items={ items }
-				value={ editorOptions.wordWrap }
-			/>
-		</HStack>
+		<div className="chbe-admin-editor-config__setting-item">
+			<HStack justify="start" align="start" wrap>
+				<SelectControl
+					__next40pxDefaultSize
+					__nextHasNoMarginBottom
+					label={ title }
+					value={ editorOptions.wordWrap }
+					options={ items.map( ( { label, value } ) => ( { label, value } ) ) }
+					onChange={ onChange }
+				/>
+				<ItemHelp
+					onChange={ onChange }
+					title={ title }
+					items={ items }
+					value={ editorOptions.wordWrap }
+				/>
+			</HStack>
+		</div>
 	);
 }

--- a/src/admin/editor-config/editor-options/wrapping-indent.js
+++ b/src/admin/editor-config/editor-options/wrapping-indent.js
@@ -54,21 +54,23 @@ export default function WrappingIndent() {
 	};
 
 	return (
-		<HStack justify="start" align="start" wrap>
-			<SelectControl
-				__next40pxDefaultSize
-				__nextHasNoMarginBottom
-				label={ title }
-				value={ editorOptions.wrappingIndent }
-				options={ items.map( ( { label, value } ) => ( { label, value } ) ) }
-				onChange={ onChange }
-			/>
-			<ItemHelp
-				onChange={ onChange }
-				title={ title }
-				items={ items }
-				value={ editorOptions.wrappingIndent }
-			/>
-		</HStack>
+		<div className="chbe-admin-editor-config__setting-item">
+			<HStack justify="start" align="start" wrap>
+				<SelectControl
+					__next40pxDefaultSize
+					__nextHasNoMarginBottom
+					label={ title }
+					value={ editorOptions.wrappingIndent }
+					options={ items.map( ( { label, value } ) => ( { label, value } ) ) }
+					onChange={ onChange }
+				/>
+				<ItemHelp
+					onChange={ onChange }
+					title={ title }
+					items={ items }
+					value={ editorOptions.wrappingIndent }
+				/>
+			</HStack>
+		</div>
 	);
 }

--- a/src/admin/editor-config/editor-settings/emmet.js
+++ b/src/admin/editor-config/editor-settings/emmet.js
@@ -36,53 +36,55 @@ export default function Emmet() {
 	};
 
 	return (
-		<HStack justify="start" align="start" wrap>
-			<ToggleControl
-				__nextHasNoMarginBottom
-				label={ title }
-				checked={ editorSettings.emmet }
-				onChange={ onChange }
-			/>
-			<ItemHelp
-				onChange={ onChange }
-				title={ title }
-				description={
-					<>
-						<Text as="p">
-							{ __(
-								'Emmet is a function for the editor that allow for high-speed coding via content assist.',
-								'custom-html-block-extension'
-							) }
-						</Text>
-						<Text as="p">
-							{ __(
-								'Only valid for HTML tags and does not support inline CSS in the block and classic editor.',
-								'custom-html-block-extension'
-							) }
-							<br />
-							{ __(
-								'You can use Emmet if the file extension is html, php, sass, scss, css, or less in the theme/plugin editor.',
-								'custom-html-block-extension'
-							) }
-						</Text>
-						<Text as="p">
-							<ExternalLink href="https://docs.emmet.io/cheat-sheet/">
-								{ __( 'Check cheat sheet', 'custom-html-block-extension' ) }
-							</ExternalLink>
-						</Text>
-						<Notice status="warning" isDismissible={ false }>
-							{ __(
-								'Save and reload the browser to reflect this settings in the preview editor area.',
-								'custom-html-block-extension'
-							) }
-						</Notice>
-					</>
-				}
-				isToggle
-				defaultToggle
-				image="editor-settings/emmet.gif"
-				value={ editorSettings.emmet }
-			/>
-		</HStack>
+		<div className="chbe-admin-editor-config__setting-item">
+			<HStack justify="start" align="start" wrap>
+				<ToggleControl
+					__nextHasNoMarginBottom
+					label={ title }
+					checked={ editorSettings.emmet }
+					onChange={ onChange }
+				/>
+				<ItemHelp
+					onChange={ onChange }
+					title={ title }
+					description={
+						<>
+							<Text as="p">
+								{ __(
+									'Emmet is a function for the editor that allow for high-speed coding via content assist.',
+									'custom-html-block-extension'
+								) }
+							</Text>
+							<Text as="p">
+								{ __(
+									'Only valid for HTML tags and does not support inline CSS in the block and classic editor.',
+									'custom-html-block-extension'
+								) }
+								<br />
+								{ __(
+									'You can use Emmet if the file extension is html, php, sass, scss, css, or less in the theme/plugin editor.',
+									'custom-html-block-extension'
+								) }
+							</Text>
+							<Text as="p">
+								<ExternalLink href="https://docs.emmet.io/cheat-sheet/">
+									{ __( 'Check cheat sheet', 'custom-html-block-extension' ) }
+								</ExternalLink>
+							</Text>
+							<Notice status="warning" isDismissible={ false }>
+								{ __(
+									'Save and reload the browser to reflect this settings in the preview editor area.',
+									'custom-html-block-extension'
+								) }
+							</Notice>
+						</>
+					}
+					isToggle
+					defaultToggle
+					image="editor-settings/emmet.gif"
+					value={ editorSettings.emmet }
+				/>
+			</HStack>
+		</div>
 	);
 }

--- a/src/admin/editor-config/editor-settings/insert-spaces.js
+++ b/src/admin/editor-config/editor-settings/insert-spaces.js
@@ -46,19 +46,25 @@ export default function InsertSpaces() {
 	};
 
 	return (
-		<HStack>
-			<ToggleGroupControl
-				__nextHasNoMarginBottom
-				size="__unstable-large"
-				label={ __( 'Indent type', 'custom-html-block-extension' ) }
-				value={ editorSettings.insertSpaces }
-				onChange={ onChange }
-				isBlock
-			>
-				{ items.map( ( item ) => (
-					<ToggleGroupControlOption key={ item.value } value={ item.value } label={ item.label } />
-				) ) }
-			</ToggleGroupControl>
-		</HStack>
+		<div className="chbe-admin-editor-config__setting-item">
+			<HStack>
+				<ToggleGroupControl
+					__nextHasNoMarginBottom
+					size="__unstable-large"
+					label={ __( 'Indent type', 'custom-html-block-extension' ) }
+					value={ editorSettings.insertSpaces }
+					onChange={ onChange }
+					isBlock
+				>
+					{ items.map( ( item ) => (
+						<ToggleGroupControlOption
+							key={ item.value }
+							value={ item.value }
+							label={ item.label }
+						/>
+					) ) }
+				</ToggleGroupControl>
+			</HStack>
+		</div>
 	);
 }

--- a/src/admin/editor-config/editor-settings/tab-size.js
+++ b/src/admin/editor-config/editor-settings/tab-size.js
@@ -30,15 +30,17 @@ export default function TabSize() {
 	};
 
 	return (
-		<RangeControl
-			__next40pxDefaultSize
-			__nextHasNoMarginBottom
-			label={ title }
-			value={ editorSettings.tabSize }
-			min={ 1 }
-			max={ 8 }
-			allowReset
-			onChange={ onChange }
-		/>
+		<div className="chbe-admin-editor-config__setting-item">
+			<RangeControl
+				__next40pxDefaultSize
+				__nextHasNoMarginBottom
+				label={ title }
+				value={ editorSettings.tabSize }
+				min={ 1 }
+				max={ 8 }
+				allowReset
+				onChange={ onChange }
+			/>
+		</div>
 	);
 }

--- a/src/admin/editor-config/editor-settings/theme.js
+++ b/src/admin/editor-config/editor-settings/theme.js
@@ -30,19 +30,21 @@ export default function Theme() {
 	};
 
 	return (
-		<HStack>
-			<SelectControl
-				__next40pxDefaultSize
-				__nextHasNoMarginBottom
-				label={ title }
-				value={ editorSettings.theme }
-				options={ [
-					{ label: __( 'Visual Studio Dark', 'custom-html-block-extension' ), value: 'vs-dark' },
-					{ label: __( 'Light', 'custom-html-block-extension' ), value: 'light' },
-					...themes,
-				] }
-				onChange={ onChange }
-			/>
-		</HStack>
+		<div className="chbe-admin-editor-config__setting-item">
+			<HStack>
+				<SelectControl
+					__next40pxDefaultSize
+					__nextHasNoMarginBottom
+					label={ title }
+					value={ editorSettings.theme }
+					options={ [
+						{ label: __( 'Visual Studio Dark', 'custom-html-block-extension' ), value: 'vs-dark' },
+						{ label: __( 'Light', 'custom-html-block-extension' ), value: 'light' },
+						...themes,
+					] }
+					onChange={ onChange }
+				/>
+			</HStack>
+		</div>
 	);
 }

--- a/src/admin/editor-config/index.js
+++ b/src/admin/editor-config/index.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import clsx from 'clsx';
+
+/**
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
@@ -140,11 +145,12 @@ export default function EditorConfig() {
 					setSearchQuery={ setSearchQuery }
 				/>
 				<VStack
-					className={
+					className={ clsx(
 						editorMode === 'basic' && ! searchQuery
 							? 'chbe-admin-editor-config__basic-settings'
-							: 'chbe-admin-editor-config__advanced-settings'
-					}
+							: 'chbe-admin-editor-config__advanced-settings',
+						{ 'is-searching': !! searchQuery }
+					) }
 					spacing={ editorMode === 'basic' && ! searchQuery ? 6 : 2 }
 				>
 					<EditorConfigContext.Provider value={ { onRefreshEditor, searchQuery } }>
@@ -168,6 +174,7 @@ export default function EditorConfig() {
 						{ ( 'advanced' === editorMode || searchQuery ) && (
 							<>
 								<PanelBody
+									className="chbe-admin-editor-config__panel"
 									title={ __( 'Editor', 'custom-html-block-extension' ) }
 									initialOpen={ searchQuery }
 									scrollAfterOpen={ ! searchQuery }
@@ -184,6 +191,7 @@ export default function EditorConfig() {
 									</VStack>
 								</PanelBody>
 								<PanelBody
+									className="chbe-admin-editor-config__panel"
 									title={ __( 'Font', 'custom-html-block-extension' ) }
 									initialOpen={ searchQuery }
 									scrollAfterOpen={ ! searchQuery }
@@ -198,6 +206,7 @@ export default function EditorConfig() {
 									</VStack>
 								</PanelBody>
 								<PanelBody
+									className="chbe-admin-editor-config__panel"
 									title={ __( 'Word wrap', 'custom-html-block-extension' ) }
 									initialOpen={ searchQuery }
 									scrollAfterOpen={ ! searchQuery }
@@ -221,6 +230,7 @@ export default function EditorConfig() {
 									</VStack>
 								</PanelBody>
 								<PanelBody
+									className="chbe-admin-editor-config__panel"
 									title={ __( 'Minimap', 'custom-html-block-extension' ) }
 									initialOpen={ searchQuery }
 									scrollAfterOpen={ ! searchQuery }
@@ -251,6 +261,7 @@ export default function EditorConfig() {
 									</VStack>
 								</PanelBody>
 								<PanelBody
+									className="chbe-admin-editor-config__panel"
 									title={ __( 'Cursor', 'custom-html-block-extension' ) }
 									initialOpen={ searchQuery }
 									scrollAfterOpen={ ! searchQuery }
@@ -271,6 +282,7 @@ export default function EditorConfig() {
 									</VStack>
 								</PanelBody>
 								<PanelBody
+									className="chbe-admin-editor-config__panel"
 									title={ __( 'Code folding', 'custom-html-block-extension' ) }
 									initialOpen={ searchQuery }
 									scrollAfterOpen={ ! searchQuery }
@@ -299,6 +311,7 @@ export default function EditorConfig() {
 									</VStack>
 								</PanelBody>
 								<PanelBody
+									className="chbe-admin-editor-config__panel"
 									title={ __( 'Line number', 'custom-html-block-extension' ) }
 									initialOpen={ searchQuery }
 									scrollAfterOpen={ ! searchQuery }
@@ -323,6 +336,7 @@ export default function EditorConfig() {
 									</VStack>
 								</PanelBody>
 								<PanelBody
+									className="chbe-admin-editor-config__panel"
 									title={ __( 'Suggest', 'custom-html-block-extension' ) }
 									initialOpen={ searchQuery }
 									scrollAfterOpen={ ! searchQuery }
@@ -351,6 +365,7 @@ export default function EditorConfig() {
 									</VStack>
 								</PanelBody>
 								<PanelBody
+									className="chbe-admin-editor-config__panel"
 									title={ __( 'Auto completion', 'custom-html-block-extension' ) }
 									initialOpen={ searchQuery }
 									scrollAfterOpen={ ! searchQuery }
@@ -364,6 +379,7 @@ export default function EditorConfig() {
 									</VStack>
 								</PanelBody>
 								<PanelBody
+									className="chbe-admin-editor-config__panel"
 									title={ __( 'Mouse and scroll', 'custom-html-block-extension' ) }
 									initialOpen={ searchQuery }
 									scrollAfterOpen={ ! searchQuery }
@@ -382,6 +398,7 @@ export default function EditorConfig() {
 									</VStack>
 								</PanelBody>
 								<PanelBody
+									className="chbe-admin-editor-config__panel"
 									title={ __( 'Select, cut, copy, and paste', 'custom-html-block-extension' ) }
 									initialOpen={ searchQuery }
 									scrollAfterOpen={ ! searchQuery }
@@ -397,6 +414,7 @@ export default function EditorConfig() {
 									</VStack>
 								</PanelBody>
 								<PanelBody
+									className="chbe-admin-editor-config__panel"
 									title={ __( 'Highlight and rendering', 'custom-html-block-extension' ) }
 									initialOpen={ searchQuery }
 									scrollAfterOpen={ ! searchQuery }
@@ -426,6 +444,7 @@ export default function EditorConfig() {
 									</VStack>
 								</PanelBody>
 								<PanelBody
+									className="chbe-admin-editor-config__panel"
 									title={ __( 'Find', 'custom-html-block-extension' ) }
 									initialOpen={ searchQuery }
 									scrollAfterOpen={ ! searchQuery }
@@ -437,6 +456,7 @@ export default function EditorConfig() {
 									</VStack>
 								</PanelBody>
 								<PanelBody
+									className="chbe-admin-editor-config__panel"
 									title={ __( 'Scrollbar', 'custom-html-block-extension' ) }
 									initialOpen={ searchQuery }
 									scrollAfterOpen={ ! searchQuery }
@@ -487,6 +507,7 @@ export default function EditorConfig() {
 									</VStack>
 								</PanelBody>
 								<PanelBody
+									className="chbe-admin-editor-config__panel"
 									title={ __( 'Other', 'custom-html-block-extension' ) }
 									initialOpen={ searchQuery }
 									scrollAfterOpen={ ! searchQuery }

--- a/src/admin/editor-config/style.scss
+++ b/src/admin/editor-config/style.scss
@@ -30,14 +30,11 @@
 		border-bottom: variables.$border-width solid colors.$gray-300;
 	}
 
-	// While searching, a panel whose settings are all filtered out still renders
-	// with just its title. Each visible setting renders a `__setting-item`
-	// wrapper, so hide panels that contain none of them. Scoped to `.is-searching`
-	// because panels are force-opened during search; outside search the panels
-	// are collapsed (no children rendered) and must not be hidden.
-	.chbe-admin-editor-config__advanced-settings.is-searching
-	.chbe-admin-editor-config__panel:not(:has(.chbe-admin-editor-config__setting-item)) {
-		display: none;
+	.chbe-admin-editor-config__advanced-settings.is-searching {
+
+		.chbe-admin-editor-config__panel:not(:has(.chbe-admin-editor-config__setting-item)) {
+			display: none;
+		}
 	}
 
 	.chbe-admin-editor-config__preview {

--- a/src/admin/editor-config/style.scss
+++ b/src/admin/editor-config/style.scss
@@ -30,6 +30,16 @@
 		border-bottom: variables.$border-width solid colors.$gray-300;
 	}
 
+	// While searching, a panel whose settings are all filtered out still renders
+	// with just its title. Each visible setting renders a `__setting-item`
+	// wrapper, so hide panels that contain none of them. Scoped to `.is-searching`
+	// because panels are force-opened during search; outside search the panels
+	// are collapsed (no children rendered) and must not be hidden.
+	.chbe-admin-editor-config__advanced-settings.is-searching
+	.chbe-admin-editor-config__panel:not(:has(.chbe-admin-editor-config__setting-item)) {
+		display: none;
+	}
+
 	.chbe-admin-editor-config__preview {
 		position: sticky;
 		top: variables.$grid-unit-50;


### PR DESCRIPTION
## Summary

In the editor config search, a panel whose settings were all filtered out still rendered with just its title, leaving empty titled panels in the results.

Each setting now renders inside a `chbe-admin-editor-config__setting-item` wrapper and every `PanelBody` carries a `chbe-admin-editor-config__panel` class. The settings container gets an `is-searching` class whenever a search query is active, so CSS can hide any panel that contains no setting item:

```scss
.chbe-admin-editor-config__advanced-settings.is-searching {
	.chbe-admin-editor-config__panel:not(:has(.chbe-admin-editor-config__setting-item)) {
		display: none;
	}
}
```

The rule is scoped to `.is-searching` on purpose: `PanelBody` drops its children when collapsed, so outside search the advanced panels (collapsed by default) would otherwise be treated as empty and all hidden.