### PR TITLE
Drop support for WordPress 6.9

### DIFF
--- a/.github/workflows/run-test-and-deploy.yml
+++ b/.github/workflows/run-test-and-deploy.yml
@@ -14,22 +14,22 @@ jobs:
           - php: '8.0'
             wp: WordPress
           - php: '8.0'
-            wp: WordPress#6.9.1
+            wp: WordPress#7.0
 
           - php: '8.2'
             wp: WordPress
           - php: '8.2'
-            wp: WordPress#6.9.1
+            wp: WordPress#7.0
 
           - php: '8.4'
             wp: WordPress
           - php: '8.4'
-            wp: WordPress#6.9.1
+            wp: WordPress#7.0
 
           - php: '8.5'
             wp: WordPress
           - php: '8.5'
-            wp: WordPress#6.9.1
+            wp: WordPress#7.0
 
     name: PHP ${{ matrix.php }} / ${{ matrix.wp }} Test
 

--- a/.github/workflows/run-test.yml
+++ b/.github/workflows/run-test.yml
@@ -22,22 +22,22 @@ jobs:
           - php: '8.0'
             wp: WordPress
           - php: '8.0'
-            wp: WordPress#6.9.1
+            wp: WordPress#7.0
 
           - php: '8.2'
             wp: WordPress
           - php: '8.2'
-            wp: WordPress#6.9.1
+            wp: WordPress#7.0
 
           - php: '8.4'
             wp: WordPress
           - php: '8.4'
-            wp: WordPress#6.9.1
+            wp: WordPress#7.0
 
           - php: '8.5'
             wp: WordPress
           - php: '8.5'
-            wp: WordPress#6.9.1
+            wp: WordPress#7.0
 
     name: PHP ${{ matrix.php }} / ${{ matrix.wp }} Test
 

--- a/custom-html-block-extension.php
+++ b/custom-html-block-extension.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: Custom HTML Block Extension
  * Description: Extend Custom HTML block to evolve into the advanced code editor.
- * Requires at least: 6.9
+ * Requires at least: 7.0
  * Requires PHP: 8.0
  * Version: 4.0.1
  * Author: Aki Hamano

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: wildworks
 Tags: gutenberg, block, html, highlighting, emmet
 Donate link: https://www.paypal.me/thamanoJP
-Requires at least: 6.9
+Requires at least: 7.0
 Tested up to: 7.0
 Stable tag: 4.0.1
 Requires PHP: 8.0


### PR DESCRIPTION
Bump the minimum required WordPress version to 7.0 and update the CI matrix to test against 7.0 instead of 6.9.1.