### PR TITLE
Replace experimental @wordpress/components primitives with @wordpress/ui

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@wordpress/icons": "^14.0.1",
+				"@wordpress/ui": "0.16.0",
 				"emmet-monaco-es": "^5.6.1",
 				"monaco-editor": "^0.55.1",
 				"webfontloader": "^1.6.28"
@@ -180,7 +181,7 @@
 			"version": "7.29.7",
 			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
 			"integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
-			"dev": true,
+			"devOptional": true,
 			"license": "MIT",
 			"dependencies": {
 				"@babel/helper-validator-identifier": "^7.29.7",
@@ -534,7 +535,7 @@
 			"version": "7.29.7",
 			"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
 			"integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
-			"dev": true,
+			"devOptional": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=6.9.0"
@@ -2105,7 +2106,6 @@
 			"version": "7.29.7",
 			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
 			"integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
-			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=6.9.0"
@@ -2181,7 +2181,6 @@
 			"version": "1.6.0",
 			"resolved": "https://registry.npmjs.org/@base-ui/react/-/react-1.6.0.tgz",
 			"integrity": "sha512-/jzjTWJYXhRFO45Bev9lc3cHbmjzCMpUqbMZ2AgKy/z25mY9B6shGSNcXcjQar9n5doM0KYW1W8fcFv2jZBuMw==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@babel/runtime": "^7.29.2",
@@ -2220,7 +2219,6 @@
 			"version": "0.3.1",
 			"resolved": "https://registry.npmjs.org/@base-ui/utils/-/utils-0.3.1.tgz",
 			"integrity": "sha512-gFFiltORVmW/N6IILTGxizP3PBpVpysqML1ALY5Vk0mH+7faVkCknOU31goYHN5Aoek2dkjxva1XOD2Ce9WuIg==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@babel/runtime": "^7.29.2",
@@ -2250,7 +2248,7 @@
 			"version": "2.0.9",
 			"resolved": "https://registry.npmjs.org/@cacheable/memory/-/memory-2.0.9.tgz",
 			"integrity": "sha512-HdMx6DoGywB30vacDbBsITbIX4pgFqj1zsrV58jZBUw3klzkNoXhj7qOqAgledhxG7YZI5rBSJg7Zp8/VG0DuA==",
-			"dev": true,
+			"devOptional": true,
 			"license": "MIT",
 			"dependencies": {
 				"@cacheable/utils": "^2.4.1",
@@ -2263,7 +2261,7 @@
 			"version": "1.3.1",
 			"resolved": "https://registry.npmjs.org/@keyv/bigmap/-/bigmap-1.3.1.tgz",
 			"integrity": "sha512-WbzE9sdmQtKy8vrNPa9BRnwZh5UF4s1KTmSK0KUVLo3eff5BlQNNWDnFOouNpKfPKDnms9xynJjsMYjMaT/aFQ==",
-			"dev": true,
+			"devOptional": true,
 			"license": "MIT",
 			"dependencies": {
 				"hashery": "^1.4.0",
@@ -2280,7 +2278,7 @@
 			"version": "5.6.0",
 			"resolved": "https://registry.npmjs.org/keyv/-/keyv-5.6.0.tgz",
 			"integrity": "sha512-CYDD3SOtsHtyXeEORYRx2qBtpDJFjRTGXUtmNEMGyzYOKj1TE3tycdlho7kA1Ufx9OYWZzg52QFBGALTirzDSw==",
-			"dev": true,
+			"devOptional": true,
 			"license": "MIT",
 			"dependencies": {
 				"@keyv/serialize": "^1.1.1"
@@ -2290,7 +2288,7 @@
 			"version": "2.4.1",
 			"resolved": "https://registry.npmjs.org/@cacheable/utils/-/utils-2.4.1.tgz",
 			"integrity": "sha512-eiFgzCbIneyMlLOmNG4g9xzF7Hv3Mga4LjxjcSC/ues6VYq2+gUbQI8JqNuw/ZM8tJIeIaBGpswAsqV2V7ApgA==",
-			"dev": true,
+			"devOptional": true,
 			"license": "MIT",
 			"dependencies": {
 				"hashery": "^1.5.1",
@@ -2301,7 +2299,7 @@
 			"version": "5.6.0",
 			"resolved": "https://registry.npmjs.org/keyv/-/keyv-5.6.0.tgz",
 			"integrity": "sha512-CYDD3SOtsHtyXeEORYRx2qBtpDJFjRTGXUtmNEMGyzYOKj1TE3tycdlho7kA1Ufx9OYWZzg52QFBGALTirzDSw==",
-			"dev": true,
+			"devOptional": true,
 			"license": "MIT",
 			"dependencies": {
 				"@keyv/serialize": "^1.1.1"
@@ -2383,7 +2381,7 @@
 			"version": "3.0.5",
 			"resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-3.0.5.tgz",
 			"integrity": "sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ==",
-			"dev": true,
+			"devOptional": true,
 			"funding": [
 				{
 					"type": "github",
@@ -2406,7 +2404,7 @@
 			"version": "1.1.5",
 			"resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.5.tgz",
 			"integrity": "sha512-oNjBvzLq2GPZtJphCjLqXow/cHySHSgtxvKZb7OqSZ/xHgw6NWNhfad+6AB9cLeVm6eA9d/qMll3JdEHjy6M+A==",
-			"dev": true,
+			"devOptional": true,
 			"funding": [
 				{
 					"type": "github",
@@ -2431,7 +2429,7 @@
 			"version": "3.0.4",
 			"resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-3.0.4.tgz",
 			"integrity": "sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==",
-			"dev": true,
+			"devOptional": true,
 			"funding": [
 				{
 					"type": "github",
@@ -2475,7 +2473,7 @@
 			"version": "1.5.0",
 			"resolved": "https://registry.npmjs.org/@date-fns/tz/-/tz-1.5.0.tgz",
 			"integrity": "sha512-lwYN/vDPeNRULcepoE/LO2Pgx+7/RV+S9ARfbc9lr2DtGkOD7pAiruHvbR1RX3Qyf6ja47EWJDMsNK5vK08DJg==",
-			"dev": true,
+			"devOptional": true,
 			"license": "MIT"
 		},
 		"node_modules/@date-fns/utc": {
@@ -2526,7 +2524,7 @@
 			"version": "4.2.1",
 			"resolved": "https://registry.npmjs.org/@dual-bundle/import-meta-resolve/-/import-meta-resolve-4.2.1.tgz",
 			"integrity": "sha512-id+7YRUgoUX6CgV0DtuhirQWodeeA7Lf4i2x71JS/vtA5pRb/hIGWlw+G6MeXvsM+MXrz0VAydTGElX1rAfgPg==",
-			"dev": true,
+			"devOptional": true,
 			"license": "MIT",
 			"funding": {
 				"type": "github",
@@ -3141,7 +3139,6 @@
 			"version": "1.7.5",
 			"resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.7.5.tgz",
 			"integrity": "sha512-1Ih4WTWyw0+lKyFMcBHGbb5U5FtuHJuujoyyr5zTaWS5EYMeT6Jb2AuDeftsCsEuchO+mM2ij5+q9crhydzLhQ==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@floating-ui/utils": "^0.2.11"
@@ -3151,7 +3148,6 @@
 			"version": "1.7.6",
 			"resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.7.6.tgz",
 			"integrity": "sha512-9gZSAI5XM36880PPMm//9dfiEngYoC6Am2izES1FF406YFsjvyBMmeJ2g4SAju3xWwtuynNRFL2s9hgxpLI5SQ==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@floating-ui/core": "^1.7.5",
@@ -3162,7 +3158,6 @@
 			"version": "2.1.8",
 			"resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.1.8.tgz",
 			"integrity": "sha512-cC52bHwM/n/CxS87FH0yWdngEZrjdtLW/qVruo68qg+prK7ZQ4YGdut2GyDVpoGeAYe/h899rVeOVm6Oi40k2A==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@floating-ui/dom": "^1.7.6"
@@ -3176,7 +3171,6 @@
 			"version": "0.2.11",
 			"resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.11.tgz",
 			"integrity": "sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==",
-			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/@formatjs/ecma402-abstract": {
@@ -5481,7 +5475,7 @@
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/@keyv/serialize/-/serialize-1.1.1.tgz",
 			"integrity": "sha512-dXn3FZhPv0US+7dtJsIi2R+c7qWYiReoEh5zUntWCf4oSpMNib8FDhSoed6m3QyZdx5hK7iLFkYk3rNxwt8vTA==",
-			"dev": true,
+			"devOptional": true,
 			"license": "MIT"
 		},
 		"node_modules/@kwsites/file-exists": {
@@ -5566,7 +5560,7 @@
 			"version": "2.1.5",
 			"resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
 			"integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
-			"dev": true,
+			"devOptional": true,
 			"license": "MIT",
 			"dependencies": {
 				"@nodelib/fs.stat": "2.0.5",
@@ -5580,7 +5574,7 @@
 			"version": "2.0.5",
 			"resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
 			"integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
-			"dev": true,
+			"devOptional": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">= 8"
@@ -5590,7 +5584,7 @@
 			"version": "1.2.8",
 			"resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
 			"integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
-			"dev": true,
+			"devOptional": true,
 			"license": "MIT",
 			"dependencies": {
 				"@nodelib/fs.scandir": "2.1.5",
@@ -8722,7 +8716,6 @@
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/@tannin/compile/-/compile-1.1.0.tgz",
 			"integrity": "sha512-n8m9eNDfoNZoxdvWiTfW/hSPhehzLJ3zW7f8E7oT6mCROoMNWCB4TYtv041+2FMAxweiE0j7i1jubQU4MEC/Gg==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@tannin/evaluate": "^1.2.0",
@@ -8733,14 +8726,12 @@
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/@tannin/evaluate/-/evaluate-1.2.0.tgz",
 			"integrity": "sha512-3ioXvNowbO/wSrxsDG5DKIMxC81P0QrQTYai8zFNY+umuoHWRPbQ/TuuDEOju9E+jQDXmj6yI5GyejNuh8I+eg==",
-			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/@tannin/plural-forms": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/@tannin/plural-forms/-/plural-forms-1.1.0.tgz",
 			"integrity": "sha512-xl9R2mDZO/qiHam1AgMnAES6IKIg7OBhcXqy6eDsRCdXuxAFPcjrej9HMjyCLE0DJ/8cHf0i5OQTstuBRhpbHw==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@tannin/compile": "^1.1.0"
@@ -8750,14 +8741,12 @@
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/@tannin/postfix/-/postfix-1.1.0.tgz",
 			"integrity": "sha512-oocsqY7g0cR+Gur5jRQLSrX2OtpMLMse1I10JQBm8CdGMrDkh1Mg2gjsiquMHRtBs4Qwu5wgEp5GgIYHk4SNPw==",
-			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/@tannin/sprintf": {
 			"version": "1.3.3",
 			"resolved": "https://registry.npmjs.org/@tannin/sprintf/-/sprintf-1.3.3.tgz",
 			"integrity": "sha512-RwARl+hFwhzy0tg9atWcchLFvoQiOh4rrP7uG2N5E4W80BPCUX0ElcUR9St43fxB9EfjsW2df9Qp+UsTbvQDjA==",
-			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/@tootallnate/quickjs-emscripten": {
@@ -9107,7 +9096,6 @@
 			"version": "1.6.15",
 			"resolved": "https://registry.npmjs.org/@types/mousetrap/-/mousetrap-1.6.15.tgz",
 			"integrity": "sha512-qL0hyIMNPow317QWW/63RvL1x5MVMV+Ru3NaY9f/CuEpCqrmb7WeuK2071ZY5hczOnm38qExWM2i2WtkXLSqFw==",
-			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/@types/ms": {
@@ -10469,14 +10457,13 @@
 			}
 		},
 		"node_modules/@wordpress/a11y": {
-			"version": "4.48.1",
-			"resolved": "https://registry.npmjs.org/@wordpress/a11y/-/a11y-4.48.1.tgz",
-			"integrity": "sha512-BPU7wRoz2XRmP3ZgVtENPKS4iO5/+bKNid/xLrvD6cP1qMhIGowQsBNqmkP1V5+q71hQM/ID6tpFjeLhmogfPg==",
-			"dev": true,
+			"version": "4.49.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/a11y/-/a11y-4.49.0.tgz",
+			"integrity": "sha512-owb2VJYS54F6R0cjxZzb/Jp+ogGaMpSkuZAWG8VqMW6I8PnFCva+6H4PP3flF7QnaiCvvgEIl2grsSJmUm9O7g==",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@wordpress/dom-ready": "^4.48.1",
-				"@wordpress/i18n": "^6.21.1"
+				"@wordpress/dom-ready": "^4.49.0",
+				"@wordpress/i18n": "^6.22.0"
 			},
 			"engines": {
 				"node": ">=18.12.0",
@@ -10619,6 +10606,37 @@
 			"engines": {
 				"node": ">=18.12.0",
 				"npm": ">=8.19.2"
+			},
+			"peerDependencies": {
+				"react": "^18.0.0",
+				"react-dom": "^18.0.0"
+			}
+		},
+		"node_modules/@wordpress/block-editor/node_modules/@wordpress/ui": {
+			"version": "0.15.1",
+			"resolved": "https://registry.npmjs.org/@wordpress/ui/-/ui-0.15.1.tgz",
+			"integrity": "sha512-zFErzf84zc7dGXrCa9fPKUpMhYx86B8n5GeshC7Ut/nfE7yp09g/Bono5S7KhY1OJx7Z1Jur9t+4vnv5cocBbA==",
+			"dev": true,
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@base-ui/react": "^1.5.0",
+				"@types/react": "^18.3.27",
+				"@wordpress/a11y": "^4.48.1",
+				"@wordpress/compose": "^8.1.1",
+				"@wordpress/element": "^8.0.1",
+				"@wordpress/i18n": "^6.21.1",
+				"@wordpress/icons": "^14.0.1",
+				"@wordpress/keycodes": "^4.48.1",
+				"@wordpress/primitives": "^4.48.1",
+				"@wordpress/private-apis": "^1.48.1",
+				"@wordpress/style-runtime": "^0.4.1",
+				"@wordpress/theme": "^0.15.1",
+				"clsx": "^2.1.1",
+				"tabbable": "^6.4.0"
+			},
+			"engines": {
+				"node": ">=20.10.0",
+				"npm": ">=10.2.3"
 			},
 			"peerDependencies": {
 				"react": "^18.0.0",
@@ -10801,6 +10819,37 @@
 				"react-dom": "^18.0.0"
 			}
 		},
+		"node_modules/@wordpress/components/node_modules/@wordpress/ui": {
+			"version": "0.15.1",
+			"resolved": "https://registry.npmjs.org/@wordpress/ui/-/ui-0.15.1.tgz",
+			"integrity": "sha512-zFErzf84zc7dGXrCa9fPKUpMhYx86B8n5GeshC7Ut/nfE7yp09g/Bono5S7KhY1OJx7Z1Jur9t+4vnv5cocBbA==",
+			"dev": true,
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@base-ui/react": "^1.5.0",
+				"@types/react": "^18.3.27",
+				"@wordpress/a11y": "^4.48.1",
+				"@wordpress/compose": "^8.1.1",
+				"@wordpress/element": "^8.0.1",
+				"@wordpress/i18n": "^6.21.1",
+				"@wordpress/icons": "^14.0.1",
+				"@wordpress/keycodes": "^4.48.1",
+				"@wordpress/primitives": "^4.48.1",
+				"@wordpress/private-apis": "^1.48.1",
+				"@wordpress/style-runtime": "^0.4.1",
+				"@wordpress/theme": "^0.15.1",
+				"clsx": "^2.1.1",
+				"tabbable": "^6.4.0"
+			},
+			"engines": {
+				"node": ">=20.10.0",
+				"npm": ">=10.2.3"
+			},
+			"peerDependencies": {
+				"react": "^18.0.0",
+				"react-dom": "^18.0.0"
+			}
+		},
 		"node_modules/@wordpress/components/node_modules/path-to-regexp": {
 			"version": "6.3.0",
 			"resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.3.0.tgz",
@@ -10823,22 +10872,20 @@
 			}
 		},
 		"node_modules/@wordpress/compose": {
-			"version": "8.1.1",
-			"resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-8.1.1.tgz",
-			"integrity": "sha512-AEC9yOS5CuTk34F+oiWebhQrxgICnb/v/KScQBUVm6zbs1AMFtu5ku+Zk0A3YTD0tO/hNzXLbvsXhJdh1bGkRA==",
-			"dev": true,
+			"version": "8.2.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-8.2.0.tgz",
+			"integrity": "sha512-JqqnNs9mHxZ9zC+4A+YAyIoqnYNqOfLXF5EshXImssFCF1JBYx6wfmyhGAdpV4nZQSHPweV4KNzEApn2cz+fXA==",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@types/mousetrap": "^1.6.8",
-				"@types/react": "^18.3.27",
-				"@wordpress/deprecated": "^4.48.1",
-				"@wordpress/dom": "^4.48.1",
-				"@wordpress/element": "^8.0.1",
-				"@wordpress/is-shallow-equal": "^5.48.1",
-				"@wordpress/keycodes": "^4.48.1",
-				"@wordpress/priority-queue": "^3.48.1",
-				"@wordpress/private-apis": "^1.48.1",
-				"@wordpress/undo-manager": "^1.48.1",
+				"@wordpress/deprecated": "^4.49.0",
+				"@wordpress/dom": "^4.49.0",
+				"@wordpress/element": "^8.1.0",
+				"@wordpress/is-shallow-equal": "^5.49.0",
+				"@wordpress/keycodes": "^4.49.0",
+				"@wordpress/priority-queue": "^3.49.0",
+				"@wordpress/private-apis": "^1.49.0",
+				"@wordpress/undo-manager": "^1.49.0",
 				"change-case": "^4.1.2",
 				"mousetrap": "^1.6.5",
 				"use-memo-one": "^1.1.1"
@@ -10848,7 +10895,13 @@
 				"npm": ">=8.19.2"
 			},
 			"peerDependencies": {
+				"@types/react": "^18.3.27",
 				"react": "^18.0.0"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				}
 			}
 		},
 		"node_modules/@wordpress/data": {
@@ -10921,6 +10974,37 @@
 				"react-dom": "^18.0.0"
 			}
 		},
+		"node_modules/@wordpress/dataviews/node_modules/@wordpress/ui": {
+			"version": "0.15.1",
+			"resolved": "https://registry.npmjs.org/@wordpress/ui/-/ui-0.15.1.tgz",
+			"integrity": "sha512-zFErzf84zc7dGXrCa9fPKUpMhYx86B8n5GeshC7Ut/nfE7yp09g/Bono5S7KhY1OJx7Z1Jur9t+4vnv5cocBbA==",
+			"dev": true,
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@base-ui/react": "^1.5.0",
+				"@types/react": "^18.3.27",
+				"@wordpress/a11y": "^4.48.1",
+				"@wordpress/compose": "^8.1.1",
+				"@wordpress/element": "^8.0.1",
+				"@wordpress/i18n": "^6.21.1",
+				"@wordpress/icons": "^14.0.1",
+				"@wordpress/keycodes": "^4.48.1",
+				"@wordpress/primitives": "^4.48.1",
+				"@wordpress/private-apis": "^1.48.1",
+				"@wordpress/style-runtime": "^0.4.1",
+				"@wordpress/theme": "^0.15.1",
+				"clsx": "^2.1.1",
+				"tabbable": "^6.4.0"
+			},
+			"engines": {
+				"node": ">=20.10.0",
+				"npm": ">=10.2.3"
+			},
+			"peerDependencies": {
+				"react": "^18.0.0",
+				"react-dom": "^18.0.0"
+			}
+		},
 		"node_modules/@wordpress/date": {
 			"version": "5.48.1",
 			"resolved": "https://registry.npmjs.org/@wordpress/date/-/date-5.48.1.tgz",
@@ -10955,12 +11039,12 @@
 			}
 		},
 		"node_modules/@wordpress/deprecated": {
-			"version": "4.48.1",
-			"resolved": "https://registry.npmjs.org/@wordpress/deprecated/-/deprecated-4.48.1.tgz",
-			"integrity": "sha512-ZfJSCxWr4Ss5qGja9W7L6+8vcrbX0n+tKDe2TrYvTq6GiqEc+0MrajIl4vi/58jhceHbSze1ITX/ocC3Ed3NLg==",
+			"version": "4.49.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/deprecated/-/deprecated-4.49.0.tgz",
+			"integrity": "sha512-xK0l4psQpjpyIeE++Aml8tLLNeRN4vEjmBaCd6VbNqbbluW8LzZJtV60JATH8blcW5MaGCGl7rlpSevaBjp0hQ==",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@wordpress/hooks": "^4.48.1"
+				"@wordpress/hooks": "^4.49.0"
 			},
 			"engines": {
 				"node": ">=18.12.0",
@@ -10968,13 +11052,12 @@
 			}
 		},
 		"node_modules/@wordpress/dom": {
-			"version": "4.48.1",
-			"resolved": "https://registry.npmjs.org/@wordpress/dom/-/dom-4.48.1.tgz",
-			"integrity": "sha512-UmouS3KAAUf6q90adAM37FZ3Tq+w+5UfNVUEKRtZjzbH3gMZJTKmYXpG9dkYyLLmicXgOrcG1GQ0qTX91MjAuA==",
-			"dev": true,
+			"version": "4.49.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/dom/-/dom-4.49.0.tgz",
+			"integrity": "sha512-ysZvqyw1PvClTWqVwLzsE7cqfYU+QppJwu2Ji/rUGyFL9WSNdMIgIQhJWZMBiw0gBtD/uuiQe7OoVJfEGw0JYw==",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@wordpress/deprecated": "^4.48.1"
+				"@wordpress/deprecated": "^4.49.0"
 			},
 			"engines": {
 				"node": ">=18.12.0",
@@ -10982,10 +11065,9 @@
 			}
 		},
 		"node_modules/@wordpress/dom-ready": {
-			"version": "4.48.1",
-			"resolved": "https://registry.npmjs.org/@wordpress/dom-ready/-/dom-ready-4.48.1.tgz",
-			"integrity": "sha512-EYd2H8cYSk8H3wSnTK1wTtuC+hOCmMmZrCEBWzgHevs1n3B9g0nwBafSiRWpzc0vA2vculkNNtlSfy3ByJ2hag==",
-			"dev": true,
+			"version": "4.49.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/dom-ready/-/dom-ready-4.49.0.tgz",
+			"integrity": "sha512-faTCKkv9zjxKKq5RNmA20piRog14+KgAy7/Pw1hbxB1JCsimxFr7f+Vg268TIFbWQJiqX1S+YuKySFGQ/hpk8Q==",
 			"license": "GPL-2.0-or-later",
 			"engines": {
 				"node": ">=18.12.0",
@@ -11039,15 +11121,15 @@
 			}
 		},
 		"node_modules/@wordpress/element": {
-			"version": "8.0.1",
-			"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-8.0.1.tgz",
-			"integrity": "sha512-otYhxfm6ZKkcLCl/tI1rB70z6MVDvTL+RiPOWXi4qm0niJf4isSXCcB91ffj1gzJXKbEpszHfysIoU9L2gCSGQ==",
+			"version": "8.1.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-8.1.0.tgz",
+			"integrity": "sha512-469K4lpolw158pipMwMVVSjGvjIhOCkA19Bct5rJ54IGj8ZaPwLiCE3QGYO1oFg4KlpyP1ro4Ao3ZvznX7DeXQ==",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@types/react": "^18.3.27",
 				"@types/react-dom": "^18.3.1",
-				"@wordpress/deprecated": "^4.48.1",
-				"@wordpress/escape-html": "^3.48.1",
+				"@wordpress/deprecated": "^4.49.0",
+				"@wordpress/escape-html": "^3.49.0",
 				"change-case": "^4.1.2",
 				"is-plain-object": "^5.0.0",
 				"react": "^18.3.1",
@@ -11152,9 +11234,9 @@
 			}
 		},
 		"node_modules/@wordpress/escape-html": {
-			"version": "3.48.1",
-			"resolved": "https://registry.npmjs.org/@wordpress/escape-html/-/escape-html-3.48.1.tgz",
-			"integrity": "sha512-TQJK6sBcmMA5+xMjiAFuivcZ27wUgAfVCgB/fGf7YoxVC+BnCCIanAsHgpY0d4juGUK6LXzDEhU6ZgOpGkGqIQ==",
+			"version": "3.49.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/escape-html/-/escape-html-3.49.0.tgz",
+			"integrity": "sha512-eOSPRJhmocfi/hztIlbCXbksg54VWIvrbfRbS7AsHY8BelbMyP4YUGEXCZf2jqf5beMB/jqulcsNLsYJ/wC+yw==",
 			"license": "GPL-2.0-or-later",
 			"engines": {
 				"node": ">=18.12.0",
@@ -11258,9 +11340,9 @@
 			}
 		},
 		"node_modules/@wordpress/hooks": {
-			"version": "4.48.1",
-			"resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-4.48.1.tgz",
-			"integrity": "sha512-QZh3Cv9TMJkrCQikuZSsDKTgX+6BBzYJe0MFKp7yP8drj/dtRpkqo5+eYmovBq3pk+HoyP7UJ1vTOb3GPJeU6Q==",
+			"version": "4.49.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-4.49.0.tgz",
+			"integrity": "sha512-65FZ3UXWkSIwFbELFABmcWn1KTA1AUdGAUH8pQlO7HKNO8F+zIrDkkO8gZA/zUHbI3I2vI1PyTA+rherPXg+Kg==",
 			"license": "GPL-2.0-or-later",
 			"engines": {
 				"node": ">=18.12.0",
@@ -11279,14 +11361,13 @@
 			}
 		},
 		"node_modules/@wordpress/i18n": {
-			"version": "6.21.1",
-			"resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-6.21.1.tgz",
-			"integrity": "sha512-qBbDJTRCtMfEzTVtzOa/fZf8XlU/JY3nI4MSdxyRQKduFanbXvzTRqJSSEIpZS4ACJTyUqafZX8zEZIH5CrNHQ==",
-			"dev": true,
+			"version": "6.22.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-6.22.0.tgz",
+			"integrity": "sha512-o6JEr26/W3Lr/Tyu6M2Xexk+wPdt/Q+GS1o4c1T3zp1t0g+L279HFLblkSciOEIteoJYx7Eodma6/VV0kCKxow==",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@tannin/sprintf": "^1.3.2",
-				"@wordpress/hooks": "^4.48.1",
+				"@wordpress/hooks": "^4.49.0",
 				"gettext-parser": "^1.3.1",
 				"memize": "^2.1.0",
 				"tannin": "^1.2.0"
@@ -11358,10 +11439,9 @@
 			}
 		},
 		"node_modules/@wordpress/is-shallow-equal": {
-			"version": "5.48.1",
-			"resolved": "https://registry.npmjs.org/@wordpress/is-shallow-equal/-/is-shallow-equal-5.48.1.tgz",
-			"integrity": "sha512-qOn4doqp8Xr5vOdF7kni5BThkMLxFA9fZIUVZo/lzs+/rwV7rwdQQXtq/PXnHcOWDOqHSXBVlUciV7clDE6aeA==",
-			"dev": true,
+			"version": "5.49.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/is-shallow-equal/-/is-shallow-equal-5.49.0.tgz",
+			"integrity": "sha512-pKvFYoExyT/A5h0Y5wLYs+8gQRaisJps2YF0jICo/LOfXR+TF8mYLH2txrA8ZCDGS0FPLSPjMxAl9hjUGrELRg==",
 			"license": "GPL-2.0-or-later",
 			"engines": {
 				"node": ">=18.12.0",
@@ -11426,18 +11506,24 @@
 			}
 		},
 		"node_modules/@wordpress/keycodes": {
-			"version": "4.48.1",
-			"resolved": "https://registry.npmjs.org/@wordpress/keycodes/-/keycodes-4.48.1.tgz",
-			"integrity": "sha512-mVNex4sY0APJj69kxFfCmaoJVOaNd9Bu7oNecuXKEAI4sp/jvvn0x+IGwLt1lMrLqC3+bPEo+q+JV3KNXMOJIQ==",
-			"dev": true,
+			"version": "4.49.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/keycodes/-/keycodes-4.49.0.tgz",
+			"integrity": "sha512-nz9i9W9uD2ZZ9lD0e75CwsLK5KF+/sw8o8TxR/OPojwHBSDKet84vtdijErQg68UxKHYnAoDjfF1otIJZ9J+pw==",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@types/react": "^18.3.27",
-				"@wordpress/i18n": "^6.21.1"
+				"@wordpress/i18n": "^6.22.0"
 			},
 			"engines": {
 				"node": ">=18.12.0",
 				"npm": ">=8.19.2"
+			},
+			"peerDependencies": {
+				"@types/react": "^18.3.27"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				}
 			}
 		},
 		"node_modules/@wordpress/notices": {
@@ -11539,13 +11625,12 @@
 			}
 		},
 		"node_modules/@wordpress/primitives": {
-			"version": "4.48.1",
-			"resolved": "https://registry.npmjs.org/@wordpress/primitives/-/primitives-4.48.1.tgz",
-			"integrity": "sha512-nzAcsXhBxw9x2q/ImVa45Ft80TO+e/WgCDmWaU3Zb2trogwThxZTezkE0oeQ6PSxSeGYM6nBgk+qqFCG8wyMhQ==",
+			"version": "4.49.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/primitives/-/primitives-4.49.0.tgz",
+			"integrity": "sha512-mmyDQ6HLFdUhLCcdsJpPzzVjQ2H4wwS3MakMfeiKx39UUAdszoP50vjOohbcUL/7RGkNPvZ66AbpK45XMhlloA==",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@types/react": "^18.3.27",
-				"@wordpress/element": "^8.0.1",
+				"@wordpress/element": "^8.1.0",
 				"clsx": "^2.1.1"
 			},
 			"engines": {
@@ -11553,14 +11638,19 @@
 				"npm": ">=8.19.2"
 			},
 			"peerDependencies": {
+				"@types/react": "^18.3.27",
 				"react": "^18.0.0"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				}
 			}
 		},
 		"node_modules/@wordpress/priority-queue": {
-			"version": "3.48.1",
-			"resolved": "https://registry.npmjs.org/@wordpress/priority-queue/-/priority-queue-3.48.1.tgz",
-			"integrity": "sha512-6nPO/FU1f9r9Zilaz7TOFSTIH5ojPqk/mmDFofo0h2kIljqik/mLwBOIls6WdDrQ2kti+BRNohbjGElAcws7kg==",
-			"dev": true,
+			"version": "3.49.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/priority-queue/-/priority-queue-3.49.0.tgz",
+			"integrity": "sha512-UcVHYan6qYvDNTFEwEnPBU9I1SnImLjEh54ISgqvvndc7jfxtdi+Akwj2kgxeLRY+bsXzMQr6byD/x4dw56yqA==",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"requestidlecallback": "^0.3.0"
@@ -11571,10 +11661,9 @@
 			}
 		},
 		"node_modules/@wordpress/private-apis": {
-			"version": "1.48.1",
-			"resolved": "https://registry.npmjs.org/@wordpress/private-apis/-/private-apis-1.48.1.tgz",
-			"integrity": "sha512-KddQQq+qboNnc4fROsy9bsX4JENRfvBMtuBg5CjOq11hScFyh169ozoHozMEtNGXou4XFykEHCRwzM5MfSHjiA==",
-			"dev": true,
+			"version": "1.49.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/private-apis/-/private-apis-1.49.0.tgz",
+			"integrity": "sha512-tGmX0XknlknSFB3UpoRQHnXW+4FufotTXYln+aXeHTFGcOuW3jSi8d8VZx7LCjUY1jqA8hCDf1vOHXW3FDcErQ==",
 			"license": "GPL-2.0-or-later",
 			"engines": {
 				"node": ">=18.12.0",
@@ -13008,24 +13097,21 @@
 			}
 		},
 		"node_modules/@wordpress/ui": {
-			"version": "0.15.1",
-			"resolved": "https://registry.npmjs.org/@wordpress/ui/-/ui-0.15.1.tgz",
-			"integrity": "sha512-zFErzf84zc7dGXrCa9fPKUpMhYx86B8n5GeshC7Ut/nfE7yp09g/Bono5S7KhY1OJx7Z1Jur9t+4vnv5cocBbA==",
-			"dev": true,
+			"version": "0.16.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/ui/-/ui-0.16.0.tgz",
+			"integrity": "sha512-Eg8djuLvwiRy4yv/n7AmqHJXlmkZFCy3MX6Bw35IdT59vpzY60erSLifGKutyjkdIDnjhqFvpLjmRNoye21f9A==",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@base-ui/react": "^1.5.0",
-				"@types/react": "^18.3.27",
-				"@wordpress/a11y": "^4.48.1",
-				"@wordpress/compose": "^8.1.1",
-				"@wordpress/element": "^8.0.1",
-				"@wordpress/i18n": "^6.21.1",
-				"@wordpress/icons": "^14.0.1",
-				"@wordpress/keycodes": "^4.48.1",
-				"@wordpress/primitives": "^4.48.1",
-				"@wordpress/private-apis": "^1.48.1",
-				"@wordpress/style-runtime": "^0.4.1",
-				"@wordpress/theme": "^0.15.1",
+				"@wordpress/a11y": "^4.49.0",
+				"@wordpress/compose": "^8.2.0",
+				"@wordpress/element": "^8.1.0",
+				"@wordpress/i18n": "^6.22.0",
+				"@wordpress/icons": "^15.0.0",
+				"@wordpress/keycodes": "^4.49.0",
+				"@wordpress/primitives": "^4.49.0",
+				"@wordpress/style-runtime": "^0.5.0",
+				"@wordpress/theme": "^0.16.0",
 				"clsx": "^2.1.1",
 				"tabbable": "^6.4.0"
 			},
@@ -13034,18 +13120,100 @@
 				"npm": ">=10.2.3"
 			},
 			"peerDependencies": {
+				"@types/react": "^18.3.27",
 				"react": "^18.0.0",
 				"react-dom": "^18.0.0"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@wordpress/ui/node_modules/@wordpress/icons": {
+			"version": "15.0.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/icons/-/icons-15.0.0.tgz",
+			"integrity": "sha512-oyBRjQehISNyThq60gTYygKaGSbqmwwQVrlnCRDTWVfmMbbqtzwuzdJYCPQYpqLV1zGx8BWhM9sbOzhhUiXOBQ==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@wordpress/element": "^8.1.0",
+				"@wordpress/primitives": "^4.49.0",
+				"change-case": "^4.1.2"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			},
+			"peerDependencies": {
+				"@types/react": "^18.3.27",
+				"react": "^18.0.0"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@wordpress/ui/node_modules/@wordpress/style-runtime": {
+			"version": "0.5.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/style-runtime/-/style-runtime-0.5.0.tgz",
+			"integrity": "sha512-hrXvdDUJpOzT1KIomgtysysgbc5bkkwAuJyEUAXiOCgVBXBeMkZlgfN19W0PuNY51j53K7VQ42txfayxgVmfgA==",
+			"license": "GPL-2.0-or-later",
+			"engines": {
+				"node": ">=20.10.0",
+				"npm": ">=10.2.3"
+			}
+		},
+		"node_modules/@wordpress/ui/node_modules/@wordpress/theme": {
+			"version": "0.16.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/theme/-/theme-0.16.0.tgz",
+			"integrity": "sha512-4t0CM1WlDunz67br/kW3lhH6Xnxzex0G9/7jKY+PJk8XepJh5OXGkTgtvsTDpYFwhhHXI+xigwj/TRPq9a/V8g==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@wordpress/compose": "^8.2.0",
+				"@wordpress/element": "^8.1.0",
+				"@wordpress/style-runtime": "^0.5.0",
+				"colorjs.io": "^0.6.0",
+				"memize": "^2.1.0"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			},
+			"peerDependencies": {
+				"@types/react": "^18.3.27",
+				"esbuild": "^0.27.2",
+				"postcss": "^8.0.0",
+				"react": "^18.0.0",
+				"react-dom": "^18.0.0",
+				"stylelint": "^16.8.2",
+				"vite": "^7.3.2"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				},
+				"esbuild": {
+					"optional": true
+				},
+				"postcss": {
+					"optional": true
+				},
+				"stylelint": {
+					"optional": true
+				},
+				"vite": {
+					"optional": true
+				}
 			}
 		},
 		"node_modules/@wordpress/undo-manager": {
-			"version": "1.48.1",
-			"resolved": "https://registry.npmjs.org/@wordpress/undo-manager/-/undo-manager-1.48.1.tgz",
-			"integrity": "sha512-i/yHiUQ5S47yong7FXxIRpJgO1MbItEKfcyp1a3rRe66rw1RVPmAlJxyeKaQg9eZbCXOmmDz5cLzZNPyUDN6uA==",
-			"dev": true,
+			"version": "1.49.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/undo-manager/-/undo-manager-1.49.0.tgz",
+			"integrity": "sha512-af3pfl8d6rnEJ6ZijDAcCRbgaTX/m5tM2Pyl8hmlsUROf5ZCto9syiugM1+TDQ6zRtKYDoYB3SUtbHdLk8FZZg==",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@wordpress/is-shallow-equal": "^5.48.1"
+				"@wordpress/is-shallow-equal": "^5.49.0"
 			},
 			"engines": {
 				"node": ">=18.12.0",
@@ -13559,7 +13727,7 @@
 			"version": "8.12.0",
 			"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
 			"integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
-			"dev": true,
+			"devOptional": true,
 			"license": "MIT",
 			"dependencies": {
 				"fast-deep-equal": "^3.1.1",
@@ -13682,7 +13850,7 @@
 			"version": "5.0.1",
 			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
 			"integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-			"dev": true,
+			"devOptional": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=8"
@@ -13692,7 +13860,7 @@
 			"version": "4.3.0",
 			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
 			"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-			"dev": true,
+			"devOptional": true,
 			"license": "MIT",
 			"dependencies": {
 				"color-convert": "^2.0.1"
@@ -13822,7 +13990,7 @@
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
 			"integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
-			"dev": true,
+			"devOptional": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=8"
@@ -13982,7 +14150,7 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-2.0.0.tgz",
 			"integrity": "sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==",
-			"dev": true,
+			"devOptional": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=8"
@@ -14608,7 +14776,7 @@
 			"version": "3.0.3",
 			"resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
 			"integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
-			"dev": true,
+			"devOptional": true,
 			"license": "MIT",
 			"dependencies": {
 				"fill-range": "^7.1.1"
@@ -14731,7 +14899,7 @@
 			"version": "2.3.5",
 			"resolved": "https://registry.npmjs.org/cacheable/-/cacheable-2.3.5.tgz",
 			"integrity": "sha512-EQfaKe09tl615iNvq/TBRWTFf1AKJNXYQSsMx0Z3EI0nA+pVsVPS8wJhnRlkbdacKPh1d0qVIhwTc2zsQNFEEg==",
-			"dev": true,
+			"devOptional": true,
 			"license": "MIT",
 			"dependencies": {
 				"@cacheable/memory": "^2.0.8",
@@ -14774,7 +14942,7 @@
 			"version": "5.6.0",
 			"resolved": "https://registry.npmjs.org/keyv/-/keyv-5.6.0.tgz",
 			"integrity": "sha512-CYDD3SOtsHtyXeEORYRx2qBtpDJFjRTGXUtmNEMGyzYOKj1TE3tycdlho7kA1Ufx9OYWZzg52QFBGALTirzDSw==",
-			"dev": true,
+			"devOptional": true,
 			"license": "MIT",
 			"dependencies": {
 				"@keyv/serialize": "^1.1.1"
@@ -14834,7 +15002,7 @@
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
 			"integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
-			"dev": true,
+			"devOptional": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=6"
@@ -15357,7 +15525,7 @@
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
 			"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-			"dev": true,
+			"devOptional": true,
 			"license": "MIT",
 			"dependencies": {
 				"color-name": "~1.1.4"
@@ -15370,14 +15538,14 @@
 			"version": "1.1.4",
 			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
 			"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-			"dev": true,
+			"devOptional": true,
 			"license": "MIT"
 		},
 		"node_modules/colord": {
 			"version": "2.9.3",
 			"resolved": "https://registry.npmjs.org/colord/-/colord-2.9.3.tgz",
 			"integrity": "sha512-jeC1axXpnb0/2nn/Y1LPuLdgXBLH7aDcHu4KEKfqw3CUhX7ZpfBSlPKyqXE6btIgEzfWtrX3/tyBCaCvXvMkOw==",
-			"dev": true,
+			"devOptional": true,
 			"license": "MIT"
 		},
 		"node_modules/colorette": {
@@ -15391,7 +15559,6 @@
 			"version": "0.6.1",
 			"resolved": "https://registry.npmjs.org/colorjs.io/-/colorjs.io-0.6.1.tgz",
 			"integrity": "sha512-8lyR2wHzuIykCpqHKgluGsqQi5iDm3/a2IgP2GBZrasn2sBRkE4NOGsglZxWLs/jZQoNkmA/KM/8NV16rLUdBg==",
-			"dev": true,
 			"license": "MIT",
 			"funding": {
 				"type": "opencollective",
@@ -16432,7 +16599,7 @@
 			"version": "3.3.3",
 			"resolved": "https://registry.npmjs.org/css-functions-list/-/css-functions-list-3.3.3.tgz",
 			"integrity": "sha512-8HFEBPKhOpJPEPu70wJJetjKta86Gw9+CCyCnB3sui2qQfOvRyqBy4IKLKKAwdMpWb2lHXWk9Wb4Z6AmaUT1Pg==",
-			"dev": true,
+			"devOptional": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=12"
@@ -16508,7 +16675,7 @@
 			"version": "3.2.1",
 			"resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
 			"integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
-			"dev": true,
+			"devOptional": true,
 			"license": "MIT",
 			"dependencies": {
 				"mdn-data": "2.27.1",
@@ -16535,7 +16702,7 @@
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
 			"integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==",
-			"dev": true,
+			"devOptional": true,
 			"license": "MIT",
 			"bin": {
 				"cssesc": "bin/cssesc"
@@ -16782,7 +16949,7 @@
 			"version": "4.4.0",
 			"resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.4.0.tgz",
 			"integrity": "sha512-+1UMbeh68lH1SegH83CGWwpb6OHHbpSgr3+s5Eww5M4CAgswBpoWS0AjTOfEJ33HiYKz1hdj/KTFprzXHmq/6w==",
-			"dev": true,
+			"devOptional": true,
 			"license": "MIT",
 			"funding": {
 				"type": "github",
@@ -17146,7 +17313,7 @@
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
 			"integrity": "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==",
-			"dev": true,
+			"devOptional": true,
 			"license": "MIT",
 			"dependencies": {
 				"path-type": "^4.0.0"
@@ -17426,7 +17593,6 @@
 			"version": "0.1.13",
 			"resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.13.tgz",
 			"integrity": "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"iconv-lite": "^0.6.2"
@@ -17436,7 +17602,6 @@
 			"version": "0.6.3",
 			"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
 			"integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"safer-buffer": ">= 2.1.2 < 3.0.0"
@@ -17500,7 +17665,7 @@
 			"version": "2.2.1",
 			"resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz",
 			"integrity": "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==",
-			"dev": true,
+			"devOptional": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=6"
@@ -17543,7 +17708,7 @@
 			"version": "1.3.4",
 			"resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.4.tgz",
 			"integrity": "sha512-sqQamAnR14VgCr1A618A3sGrygcpK+HEbenA/HiEAkkUwcZIIB/tgWqHFxWgOyDh4nB4JCRimh79dR5Ywc9MDQ==",
-			"dev": true,
+			"devOptional": true,
 			"license": "MIT",
 			"dependencies": {
 				"is-arrayish": "^0.2.1"
@@ -18920,7 +19085,7 @@
 			"version": "3.1.3",
 			"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
 			"integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-			"dev": true,
+			"devOptional": true,
 			"license": "MIT"
 		},
 		"node_modules/fast-diff": {
@@ -18941,7 +19106,7 @@
 			"version": "3.3.3",
 			"resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
 			"integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
-			"dev": true,
+			"devOptional": true,
 			"license": "MIT",
 			"dependencies": {
 				"@nodelib/fs.stat": "^2.0.2",
@@ -18958,7 +19123,7 @@
 			"version": "5.1.2",
 			"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
 			"integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
-			"dev": true,
+			"devOptional": true,
 			"license": "ISC",
 			"dependencies": {
 				"is-glob": "^4.0.1"
@@ -19024,7 +19189,7 @@
 			"version": "1.0.16",
 			"resolved": "https://registry.npmjs.org/fastest-levenshtein/-/fastest-levenshtein-1.0.16.tgz",
 			"integrity": "sha512-eRnCtTTtGZFpQCwhJiUOuxPQWRXVKYDn0b2PeHfXL6/Zi53SLAzAHfVhVWK2AryC/WH05kGfxhFIPvTF0SXQzg==",
-			"dev": true,
+			"devOptional": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">= 4.9.1"
@@ -19034,7 +19199,7 @@
 			"version": "1.20.1",
 			"resolved": "https://registry.npmjs.org/fastq/-/fastq-1.20.1.tgz",
 			"integrity": "sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==",
-			"dev": true,
+			"devOptional": true,
 			"license": "ISC",
 			"dependencies": {
 				"reusify": "^1.0.4"
@@ -19118,7 +19283,7 @@
 			"version": "7.1.1",
 			"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
 			"integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
-			"dev": true,
+			"devOptional": true,
 			"license": "MIT",
 			"dependencies": {
 				"to-regex-range": "^5.0.1"
@@ -19285,7 +19450,7 @@
 			"version": "3.4.2",
 			"resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
 			"integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
-			"dev": true,
+			"devOptional": true,
 			"license": "ISC"
 		},
 		"node_modules/follow-redirects": {
@@ -19772,7 +19937,6 @@
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/gettext-parser/-/gettext-parser-1.4.0.tgz",
 			"integrity": "sha512-sedZYLHlHeBop/gZ1jdg59hlUEcpcZJofLq2JFwJT1zTqAU3l2wFv6IsuwFHGqbiT9DWzMUW4/em2+hspnmMMA==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"encoding": "^0.1.12",
@@ -19917,7 +20081,7 @@
 			"version": "11.1.0",
 			"resolved": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
 			"integrity": "sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==",
-			"dev": true,
+			"devOptional": true,
 			"license": "MIT",
 			"dependencies": {
 				"array-union": "^2.1.0",
@@ -19938,7 +20102,7 @@
 			"version": "0.1.4",
 			"resolved": "https://registry.npmjs.org/globjoin/-/globjoin-0.1.4.tgz",
 			"integrity": "sha512-xYfnw62CKG8nLkZBfWbhWwDw02CHty86jfPcc2cr3ZfeuK9ysoVPPEUxf21bAD/rWAgk52SuBrLJlefNy8mvFg==",
-			"dev": true,
+			"devOptional": true,
 			"license": "MIT"
 		},
 		"node_modules/gopd": {
@@ -20046,7 +20210,7 @@
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
 			"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-			"dev": true,
+			"devOptional": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=8"
@@ -20114,7 +20278,7 @@
 			"version": "1.5.1",
 			"resolved": "https://registry.npmjs.org/hashery/-/hashery-1.5.1.tgz",
 			"integrity": "sha512-iZyKG96/JwPz1N55vj2Ie2vXbhu440zfUfJvSwEqEbeLluk7NnapfGqa7LH0mOsnDxTF85Mx8/dyR6HfqcbmbQ==",
-			"dev": true,
+			"devOptional": true,
 			"license": "MIT",
 			"dependencies": {
 				"hookified": "^1.15.0"
@@ -20204,7 +20368,7 @@
 			"version": "1.15.1",
 			"resolved": "https://registry.npmjs.org/hookified/-/hookified-1.15.1.tgz",
 			"integrity": "sha512-MvG/clsADq1GPM2KGo2nyfaWVyn9naPiXrqIe4jYjXNZQt238kWyOGrsyc/DmRAQ+Re6yeo6yX/yoNCG5KAEVg==",
-			"dev": true,
+			"devOptional": true,
 			"license": "MIT"
 		},
 		"node_modules/hosted-git-info": {
@@ -20341,7 +20505,7 @@
 			"version": "3.3.1",
 			"resolved": "https://registry.npmjs.org/html-tags/-/html-tags-3.3.1.tgz",
 			"integrity": "sha512-ztqyC3kLto0e9WbNp0aeP+M3kTt+nbaIveGmUxAtZa+8iFgKLUOD4YKM5j+f3QD89bra7UeumolZHKuOXnTmeQ==",
-			"dev": true,
+			"devOptional": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=8"
@@ -20608,7 +20772,7 @@
 			"version": "5.3.2",
 			"resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
 			"integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
-			"dev": true,
+			"devOptional": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">= 4"
@@ -20645,7 +20809,7 @@
 			"version": "3.3.1",
 			"resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
 			"integrity": "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==",
-			"dev": true,
+			"devOptional": true,
 			"license": "MIT",
 			"dependencies": {
 				"parent-module": "^1.0.0",
@@ -20662,7 +20826,7 @@
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
 			"integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
-			"dev": true,
+			"devOptional": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=4"
@@ -20725,7 +20889,7 @@
 			"version": "0.1.4",
 			"resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
 			"integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
-			"dev": true,
+			"devOptional": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=0.8.19"
@@ -20860,7 +21024,7 @@
 			"version": "0.2.1",
 			"resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
 			"integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
-			"dev": true,
+			"devOptional": true,
 			"license": "MIT"
 		},
 		"node_modules/is-async-function": {
@@ -21069,7 +21233,7 @@
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
 			"integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
-			"dev": true,
+			"devOptional": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=0.10.0"
@@ -21141,7 +21305,7 @@
 			"version": "4.0.3",
 			"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
 			"integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
-			"dev": true,
+			"devOptional": true,
 			"license": "MIT",
 			"dependencies": {
 				"is-extglob": "^2.1.1"
@@ -21190,7 +21354,7 @@
 			"version": "7.0.0",
 			"resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
 			"integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
-			"dev": true,
+			"devOptional": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=0.12.0"
@@ -21454,7 +21618,7 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
 			"integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
-			"dev": true,
+			"devOptional": true,
 			"license": "ISC"
 		},
 		"node_modules/isobject": {
@@ -24613,14 +24777,14 @@
 			"version": "2.3.1",
 			"resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
 			"integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
-			"dev": true,
+			"devOptional": true,
 			"license": "MIT"
 		},
 		"node_modules/json-schema-traverse": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
 			"integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-			"dev": true,
+			"devOptional": true,
 			"license": "MIT"
 		},
 		"node_modules/json-stable-stringify-without-jsonify": {
@@ -24789,7 +24953,7 @@
 			"version": "0.37.0",
 			"resolved": "https://registry.npmjs.org/known-css-properties/-/known-css-properties-0.37.0.tgz",
 			"integrity": "sha512-JCDrsP4Z1Sb9JwG0aJ8Eo2r7k4Ou5MwmThS/6lcIe1ICyb7UBJKGRIUUdqc2ASdE/42lgz6zFUnzAIhtXnBVrQ==",
-			"dev": true,
+			"devOptional": true,
 			"license": "MIT"
 		},
 		"node_modules/language-subtag-registry": {
@@ -24996,7 +25160,7 @@
 			"version": "1.2.4",
 			"resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
 			"integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
-			"dev": true,
+			"devOptional": true,
 			"license": "MIT"
 		},
 		"node_modules/linkify-it": {
@@ -25272,7 +25436,7 @@
 			"version": "4.4.2",
 			"resolved": "https://registry.npmjs.org/lodash.truncate/-/lodash.truncate-4.4.2.tgz",
 			"integrity": "sha512-jttmRe7bRse52OsWIMDLaXxWqRAmtIUccAQ3garviCqJjafXOfNMO0yMfNpdD6zbGaTU0P5Nz7e7gAT6cKmJRw==",
-			"dev": true,
+			"devOptional": true,
 			"license": "MIT"
 		},
 		"node_modules/lodash.uniq": {
@@ -25730,7 +25894,7 @@
 			"version": "2.1.3",
 			"resolved": "https://registry.npmjs.org/mathml-tag-names/-/mathml-tag-names-2.1.3.tgz",
 			"integrity": "sha512-APMBEanjybaPzUrfqU0IMU5I0AswKMH7k8OTLs0vvV4KZpExkTkY87nR/zpbuTPj+gARop7aGUbl11pnDfW6xg==",
-			"dev": true,
+			"devOptional": true,
 			"license": "MIT",
 			"funding": {
 				"type": "github",
@@ -25741,7 +25905,7 @@
 			"version": "2.27.1",
 			"resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
 			"integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
-			"dev": true,
+			"devOptional": true,
 			"license": "CC0-1.0"
 		},
 		"node_modules/mdurl": {
@@ -25778,7 +25942,6 @@
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/memize/-/memize-2.1.1.tgz",
 			"integrity": "sha512-8Nl+i9S5D6KXnruM03Jgjb+LwSupvR13WBr4hJegaaEyobvowCVupi79y2WSiWvO1mzBWxPwEYE5feCe8vyA5w==",
-			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/meow": {
@@ -25867,7 +26030,7 @@
 			"version": "1.4.1",
 			"resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
 			"integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
-			"dev": true,
+			"devOptional": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">= 8"
@@ -25894,7 +26057,7 @@
 			"version": "4.0.8",
 			"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
 			"integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
-			"dev": true,
+			"devOptional": true,
 			"license": "MIT",
 			"dependencies": {
 				"braces": "^3.0.3",
@@ -26181,7 +26344,6 @@
 			"version": "1.6.5",
 			"resolved": "https://registry.npmjs.org/mousetrap/-/mousetrap-1.6.5.tgz",
 			"integrity": "sha512-QNo4kEepaIBwiT8CDhP98umTetp+JNfQYBWvC1pc6/OAibuXtRcxZ58Qz8skvEHYvURne/7R8T5VoOI7rDsEUA==",
-			"dev": true,
 			"license": "Apache-2.0 WITH LLVM-exception"
 		},
 		"node_modules/mrmime": {
@@ -26198,7 +26360,7 @@
 			"version": "2.1.3",
 			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
 			"integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-			"dev": true,
+			"devOptional": true,
 			"license": "MIT"
 		},
 		"node_modules/multicast-dns": {
@@ -26236,7 +26398,7 @@
 			"version": "3.3.11",
 			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
 			"integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
-			"dev": true,
+			"devOptional": true,
 			"funding": [
 				{
 					"type": "github",
@@ -26444,7 +26606,7 @@
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
 			"integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
-			"dev": true,
+			"devOptional": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=0.10.0"
@@ -27250,7 +27412,7 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
 			"integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
-			"dev": true,
+			"devOptional": true,
 			"license": "MIT",
 			"dependencies": {
 				"callsites": "^3.0.0"
@@ -27279,7 +27441,7 @@
 			"version": "5.2.0",
 			"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
 			"integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
-			"dev": true,
+			"devOptional": true,
 			"license": "MIT",
 			"dependencies": {
 				"@babel/code-frame": "^7.0.0",
@@ -27472,7 +27634,7 @@
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
 			"integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
-			"dev": true,
+			"devOptional": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=8"
@@ -27523,14 +27685,14 @@
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
 			"integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
-			"dev": true,
+			"devOptional": true,
 			"license": "ISC"
 		},
 		"node_modules/picomatch": {
 			"version": "2.3.2",
 			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
 			"integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
-			"dev": true,
+			"devOptional": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=8.6"
@@ -27743,7 +27905,7 @@
 			"version": "8.5.14",
 			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.14.tgz",
 			"integrity": "sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==",
-			"dev": true,
+			"devOptional": true,
 			"funding": [
 				{
 					"type": "opencollective",
@@ -28362,14 +28524,14 @@
 			"version": "0.1.6",
 			"resolved": "https://registry.npmjs.org/postcss-resolve-nested-selector/-/postcss-resolve-nested-selector-0.1.6.tgz",
 			"integrity": "sha512-0sglIs9Wmkzbr8lQwEyIzlDOOC9bGmfVKcJTaxv3vMmd3uo4o4DerC3En0bnmgceeql9BfC8hRkp7cg0fjdVqw==",
-			"dev": true,
+			"devOptional": true,
 			"license": "MIT"
 		},
 		"node_modules/postcss-safe-parser": {
 			"version": "7.0.1",
 			"resolved": "https://registry.npmjs.org/postcss-safe-parser/-/postcss-safe-parser-7.0.1.tgz",
 			"integrity": "sha512-0AioNCJZ2DPYz5ABT6bddIqlhgwhpHZ/l65YAYo0BCIn0xiDpsnTHz0gnoTGk0OXZW0JRs+cDwL8u/teRdz+8A==",
-			"dev": true,
+			"devOptional": true,
 			"funding": [
 				{
 					"type": "opencollective",
@@ -28483,7 +28645,7 @@
 			"version": "4.2.0",
 			"resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
 			"integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
-			"dev": true,
+			"devOptional": true,
 			"license": "MIT"
 		},
 		"node_modules/postgres-array": {
@@ -28769,7 +28931,7 @@
 			"version": "2.3.1",
 			"resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
 			"integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
-			"dev": true,
+			"devOptional": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=6"
@@ -28863,7 +29025,7 @@
 			"version": "0.10.1",
 			"resolved": "https://registry.npmjs.org/qified/-/qified-0.10.1.tgz",
 			"integrity": "sha512-+Owyggi9IxT1ePKGafcI87ubSmxol6smwJ+RAHDQlx9+9cPwFWDiKFFCPuWhr9ignlGpZ9vDQLw67N4dcTVFEA==",
-			"dev": true,
+			"devOptional": true,
 			"license": "MIT",
 			"dependencies": {
 				"hookified": "^2.1.1"
@@ -28876,7 +29038,7 @@
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/hookified/-/hookified-2.2.0.tgz",
 			"integrity": "sha512-p/LgFzRN5FeoD3DLS6bkUapeye6E4SI6yJs6KetENd18S+FBthqYq2amJUWpt5z0EQwwHemidjY5OqJGEKm5uA==",
-			"dev": true,
+			"devOptional": true,
 			"license": "MIT"
 		},
 		"node_modules/qs": {
@@ -28899,7 +29061,7 @@
 			"version": "1.2.3",
 			"resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
 			"integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
-			"dev": true,
+			"devOptional": true,
 			"funding": [
 				{
 					"type": "github",
@@ -29445,7 +29607,6 @@
 			"version": "0.3.0",
 			"resolved": "https://registry.npmjs.org/requestidlecallback/-/requestidlecallback-0.3.0.tgz",
 			"integrity": "sha512-TWHFkT7S9p7IxLC5A1hYmAYQx2Eb9w1skrXmQ+dS1URyvR8tenMLl4lHbqEOUnpEYxNKpkVMXUgknVpBZWXXfQ==",
-			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/require-directory": {
@@ -29462,7 +29623,7 @@
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
 			"integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
-			"dev": true,
+			"devOptional": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=0.10.0"
@@ -29529,7 +29690,6 @@
 			"version": "5.2.0",
 			"resolved": "https://registry.npmjs.org/reselect/-/reselect-5.2.0.tgz",
 			"integrity": "sha512-AgZ3UOZm3YndfrJ4OYjgrT7bmCm/1iqkjvEfH/oYjzh6PD2qw4QuT3jjnXIrpdt4MTpMXclMT3lXbmRY+XRakw==",
-			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/resolve": {
@@ -29601,7 +29761,7 @@
 			"version": "5.0.0",
 			"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
 			"integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
-			"dev": true,
+			"devOptional": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=8"
@@ -29687,7 +29847,7 @@
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
 			"integrity": "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==",
-			"dev": true,
+			"devOptional": true,
 			"license": "MIT",
 			"engines": {
 				"iojs": ">=1.0.0",
@@ -29871,7 +30031,7 @@
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
 			"integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
-			"dev": true,
+			"devOptional": true,
 			"funding": [
 				{
 					"type": "github",
@@ -29932,7 +30092,6 @@
 			"version": "5.2.1",
 			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
 			"integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
-			"dev": true,
 			"funding": [
 				{
 					"type": "github",
@@ -29988,7 +30147,6 @@
 			"version": "2.1.2",
 			"resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
 			"integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
-			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/sass": {
@@ -30790,7 +30948,7 @@
 			"version": "4.1.0",
 			"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
 			"integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
-			"dev": true,
+			"devOptional": true,
 			"license": "ISC",
 			"engines": {
 				"node": ">=14"
@@ -30915,7 +31073,7 @@
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
 			"integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
-			"dev": true,
+			"devOptional": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=8"
@@ -31046,7 +31204,7 @@
 			"version": "1.2.1",
 			"resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
 			"integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
-			"dev": true,
+			"devOptional": true,
 			"license": "BSD-3-Clause",
 			"engines": {
 				"node": ">=0.10.0"
@@ -31566,7 +31724,7 @@
 			"version": "6.0.1",
 			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
 			"integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-			"dev": true,
+			"devOptional": true,
 			"license": "MIT",
 			"dependencies": {
 				"ansi-regex": "^5.0.1"
@@ -31716,7 +31874,7 @@
 			"version": "16.26.1",
 			"resolved": "https://registry.npmjs.org/stylelint/-/stylelint-16.26.1.tgz",
 			"integrity": "sha512-v20V59/crfc8sVTAtge0mdafI3AdnzQ2KsWe6v523L4OA1bJO02S7MO2oyXDCS6iWb9ckIPnqAFVItqSBQr7jw==",
-			"dev": true,
+			"devOptional": true,
 			"funding": [
 				{
 					"type": "opencollective",
@@ -31864,7 +32022,7 @@
 			"version": "4.0.3",
 			"resolved": "https://registry.npmjs.org/@csstools/media-query-list-parser/-/media-query-list-parser-4.0.3.tgz",
 			"integrity": "sha512-HAYH7d3TLRHDOUQK4mZKf9k9Ph/m8Akstg66ywKR4SFAigjs3yBiUeZtFxywiTm5moZMAp/5W/ZuFnNXXYLuuQ==",
-			"dev": true,
+			"devOptional": true,
 			"funding": [
 				{
 					"type": "github",
@@ -31888,7 +32046,7 @@
 			"version": "5.0.0",
 			"resolved": "https://registry.npmjs.org/@csstools/selector-specificity/-/selector-specificity-5.0.0.tgz",
 			"integrity": "sha512-PCqQV3c4CoVm3kdPhyeZ07VmBRdH2EpMFA/pd9OASpOEC3aXNGoqPDAZ80D0cLpMBxnmk0+yNhGsEx31hq7Gtw==",
-			"dev": true,
+			"devOptional": true,
 			"funding": [
 				{
 					"type": "github",
@@ -31911,21 +32069,21 @@
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
 			"integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-			"dev": true,
+			"devOptional": true,
 			"license": "Python-2.0"
 		},
 		"node_modules/stylelint/node_modules/balanced-match": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-2.0.0.tgz",
 			"integrity": "sha512-1ugUSr8BHXRnK23KfuYS+gVMC3LB8QGH9W1iGtDPsNWoQbgtXSExkBu2aDR4epiGWZOjZsj6lDl/N/AqqTC3UA==",
-			"dev": true,
+			"devOptional": true,
 			"license": "MIT"
 		},
 		"node_modules/stylelint/node_modules/cosmiconfig": {
 			"version": "9.0.2",
 			"resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-9.0.2.tgz",
 			"integrity": "sha512-gtTZxTDau1wL7Y7zifc2dd8jHSK/k6BTx/2Xp/BpdlAdnlYWFVt7qhJqgwi7637yRwRQ3qL4ZidbB4I8tA5VOg==",
-			"dev": true,
+			"devOptional": true,
 			"license": "MIT",
 			"dependencies": {
 				"env-paths": "^2.2.1",
@@ -31952,7 +32110,7 @@
 			"version": "4.4.3",
 			"resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
 			"integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-			"dev": true,
+			"devOptional": true,
 			"license": "MIT",
 			"dependencies": {
 				"ms": "^2.1.3"
@@ -31970,14 +32128,14 @@
 			"version": "8.0.0",
 			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
 			"integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-			"dev": true,
+			"devOptional": true,
 			"license": "MIT"
 		},
 		"node_modules/stylelint/node_modules/file-entry-cache": {
 			"version": "11.1.3",
 			"resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-11.1.3.tgz",
 			"integrity": "sha512-oMbq0PD6VIiIwMF6LIa7MEwd/l9huKwmqRKXqmrkqIZv8CvRbfowL+L0ryAl8h//HfAS0zS+4SbYoRyAoA6BJA==",
-			"dev": true,
+			"devOptional": true,
 			"license": "MIT",
 			"dependencies": {
 				"flat-cache": "^6.1.22"
@@ -31987,7 +32145,7 @@
 			"version": "6.1.22",
 			"resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-6.1.22.tgz",
 			"integrity": "sha512-N2dnzVJIphnNsjHcrxGW7DePckJ6haPrSFqpsBUhHYgwtKGVq4JrBGielEGD2fCVnsGm1zlBVZ8wGhkyuetgug==",
-			"dev": true,
+			"devOptional": true,
 			"license": "MIT",
 			"dependencies": {
 				"cacheable": "^2.3.4",
@@ -31999,7 +32157,7 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/global-modules/-/global-modules-2.0.0.tgz",
 			"integrity": "sha512-NGbfmJBp9x8IxyJSd1P+otYK8vonoJactOogrVfFRIAEY1ukil8RSKDz2Yo7wh1oihl51l/r6W4epkeKJHqL8A==",
-			"dev": true,
+			"devOptional": true,
 			"license": "MIT",
 			"dependencies": {
 				"global-prefix": "^3.0.0"
@@ -32012,7 +32170,7 @@
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/global-prefix/-/global-prefix-3.0.0.tgz",
 			"integrity": "sha512-awConJSVCHVGND6x3tmMaKcQvwXLhjdkmomy2W+Goaui8YPgYgXJZewhg3fWC+DlfqqQuWg8AwqjGTD2nAPVWg==",
-			"dev": true,
+			"devOptional": true,
 			"license": "MIT",
 			"dependencies": {
 				"ini": "^1.3.5",
@@ -32027,7 +32185,7 @@
 			"version": "7.0.5",
 			"resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
 			"integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
-			"dev": true,
+			"devOptional": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">= 4"
@@ -32037,14 +32195,14 @@
 			"version": "1.3.8",
 			"resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
 			"integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
-			"dev": true,
+			"devOptional": true,
 			"license": "ISC"
 		},
 		"node_modules/stylelint/node_modules/is-fullwidth-code-point": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
 			"integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-			"dev": true,
+			"devOptional": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=8"
@@ -32054,7 +32212,7 @@
 			"version": "4.2.0",
 			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
 			"integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
-			"dev": true,
+			"devOptional": true,
 			"funding": [
 				{
 					"type": "github",
@@ -32077,7 +32235,7 @@
 			"version": "6.0.3",
 			"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
 			"integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
-			"dev": true,
+			"devOptional": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=0.10.0"
@@ -32087,7 +32245,7 @@
 			"version": "13.2.0",
 			"resolved": "https://registry.npmjs.org/meow/-/meow-13.2.0.tgz",
 			"integrity": "sha512-pxQJQzB6djGPXh08dacEloMFopsOqGVRKFPYvPOt9XDZ1HasbgDZA74CJGreSU4G3Ak7EFJGoiH2auq+yXISgA==",
-			"dev": true,
+			"devOptional": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=18"
@@ -32100,7 +32258,7 @@
 			"version": "7.1.4",
 			"resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.4.tgz",
 			"integrity": "sha512-HeP7D2wyhkR+XaK6v4W8oRF62Dsz4flyuczALJp61GckGm42u1saSSJ/0auvcBqxs3jMRFEcPK34At/0JBKdOg==",
-			"dev": true,
+			"devOptional": true,
 			"license": "MIT",
 			"dependencies": {
 				"cssesc": "^3.0.0",
@@ -32114,7 +32272,7 @@
 			"version": "4.2.3",
 			"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
 			"integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-			"dev": true,
+			"devOptional": true,
 			"license": "MIT",
 			"dependencies": {
 				"emoji-regex": "^8.0.0",
@@ -32129,7 +32287,7 @@
 			"version": "1.3.1",
 			"resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
 			"integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
-			"dev": true,
+			"devOptional": true,
 			"license": "ISC",
 			"dependencies": {
 				"isexe": "^2.0.0"
@@ -32142,7 +32300,7 @@
 			"version": "5.0.1",
 			"resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-5.0.1.tgz",
 			"integrity": "sha512-+QU2zd6OTD8XWIJCbffaiQeH9U73qIqafo1x6V1snCWYGJf6cVE0cDR4D8xRzcEnfI21IFrUPzPGtcPf8AC+Rw==",
-			"dev": true,
+			"devOptional": true,
 			"license": "ISC",
 			"dependencies": {
 				"imurmurhash": "^0.1.4",
@@ -32173,7 +32331,7 @@
 			"version": "7.2.0",
 			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
 			"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-			"dev": true,
+			"devOptional": true,
 			"license": "MIT",
 			"dependencies": {
 				"has-flag": "^4.0.0"
@@ -32186,7 +32344,7 @@
 			"version": "3.2.0",
 			"resolved": "https://registry.npmjs.org/supports-hyperlinks/-/supports-hyperlinks-3.2.0.tgz",
 			"integrity": "sha512-zFObLMyZeEwzAoKCyu1B91U79K2t7ApXuQfo8OuxwXLDgcKxuwM+YvcbIhm6QWqz7mHUH1TVytR1PwVVjEuMig==",
-			"dev": true,
+			"devOptional": true,
 			"license": "MIT",
 			"dependencies": {
 				"has-flag": "^4.0.0",
@@ -32223,7 +32381,7 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/svg-tags/-/svg-tags-1.0.0.tgz",
 			"integrity": "sha512-ovssysQTa+luh7A5Weu3Rta6FJlFBBbInjOh722LIt6klpU2/HtdUbszju/G4devcvk8PGt7FCLv5wftu3THUA==",
-			"dev": true
+			"devOptional": true
 		},
 		"node_modules/svgo": {
 			"version": "3.3.3",
@@ -32309,14 +32467,13 @@
 			"version": "6.5.0",
 			"resolved": "https://registry.npmjs.org/tabbable/-/tabbable-6.5.0.tgz",
 			"integrity": "sha512-wieBHXygIm7OyQOu5hQlkk62/WyCFYGlWg7L6/ZCUZwx0o398Zkn4pVmMyfYhfMG8kGrj/Krt8eIk6UKC6VzwA==",
-			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/table": {
 			"version": "6.9.0",
 			"resolved": "https://registry.npmjs.org/table/-/table-6.9.0.tgz",
 			"integrity": "sha512-9kY+CygyYM6j02t5YFHbNz2FN5QmYGv9zAjVp4lCDjlCw7amdckXlEt/bjMhUIfj4ThGRE4gCUH5+yGnNuPo5A==",
-			"dev": true,
+			"devOptional": true,
 			"license": "BSD-3-Clause",
 			"dependencies": {
 				"ajv": "^8.0.1",
@@ -32333,14 +32490,14 @@
 			"version": "8.0.0",
 			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
 			"integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-			"dev": true,
+			"devOptional": true,
 			"license": "MIT"
 		},
 		"node_modules/table/node_modules/is-fullwidth-code-point": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
 			"integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-			"dev": true,
+			"devOptional": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=8"
@@ -32350,7 +32507,7 @@
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-4.0.0.tgz",
 			"integrity": "sha512-qMCMfhY040cVHT43K9BFygqYbUPFZKHOg7K73mtTWJRb8pyP3fzf4Ixd5SzdEJQ6MRUg/WBnOLxghZtKKurENQ==",
-			"dev": true,
+			"devOptional": true,
 			"license": "MIT",
 			"dependencies": {
 				"ansi-styles": "^4.0.0",
@@ -32368,7 +32525,7 @@
 			"version": "4.2.3",
 			"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
 			"integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-			"dev": true,
+			"devOptional": true,
 			"license": "MIT",
 			"dependencies": {
 				"emoji-regex": "^8.0.0",
@@ -32383,7 +32540,6 @@
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/tannin/-/tannin-1.2.0.tgz",
 			"integrity": "sha512-U7GgX/RcSeUETbV7gYgoz8PD7Ni4y95pgIP/Z6ayI3CfhSujwKEBlGFTCRN+Aqnuyf4AN2yHL+L8x+TCGjb9uA==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@tannin/plural-forms": "^1.1.0"
@@ -32771,7 +32927,7 @@
 			"version": "5.0.1",
 			"resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
 			"integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
-			"dev": true,
+			"devOptional": true,
 			"license": "MIT",
 			"dependencies": {
 				"is-number": "^7.0.0"
@@ -33050,7 +33206,7 @@
 			"version": "5.9.3",
 			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
 			"integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
-			"dev": true,
+			"devOptional": true,
 			"license": "Apache-2.0",
 			"bin": {
 				"tsc": "bin/tsc",
@@ -33298,7 +33454,7 @@
 			"version": "4.4.1",
 			"resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
 			"integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
-			"dev": true,
+			"devOptional": true,
 			"license": "BSD-2-Clause",
 			"dependencies": {
 				"punycode": "^2.1.0"
@@ -33411,7 +33567,6 @@
 			"version": "1.1.3",
 			"resolved": "https://registry.npmjs.org/use-memo-one/-/use-memo-one-1.1.3.tgz",
 			"integrity": "sha512-g66/K7ZQGYrI6dy8GLpVcMsBp4s17xNkYJVSMvTEevGy3nDxHOfE6z8BVE22+5G5x7t3+bhzrlTDB7ObrEE0cQ==",
-			"dev": true,
 			"license": "MIT",
 			"peerDependencies": {
 				"react": "^16.8.0 || ^17.0.0 || ^18.0.0"
@@ -33444,7 +33599,6 @@
 			"version": "1.6.0",
 			"resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
 			"integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
-			"dev": true,
 			"license": "MIT",
 			"peerDependencies": {
 				"react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
@@ -33454,7 +33608,7 @@
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
 			"integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
-			"dev": true,
+			"devOptional": true,
 			"license": "MIT"
 		},
 		"node_modules/utils-merge": {

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
 	],
 	"dependencies": {
 		"@wordpress/icons": "^14.0.1",
+		"@wordpress/ui": "0.16.0",
 		"emmet-monaco-es": "^5.6.1",
 		"monaco-editor": "^0.55.1",
 		"webfontloader": "^1.6.28"

--- a/src/admin/components/header/index.tsx
+++ b/src/admin/components/header/index.tsx
@@ -2,12 +2,8 @@
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import {
-	Icon,
-	__experimentalHeading as Heading,
-	__experimentalHStack as HStack,
-	__experimentalVStack as VStack,
-} from '@wordpress/components';
+import { Icon, __experimentalHeading as Heading } from '@wordpress/components';
+import { Stack } from '@wordpress/ui';
 
 /**
  * Internal dependencies
@@ -21,15 +17,15 @@ export default function Header() {
 		<header className="chbe-admin-header">
 			<div className="chbe-admin-container">
 				<Heading as="h1">
-					<HStack justify="center">
+					<Stack justify="center" gap="sm">
 						<Icon icon={ BlockIcon } size={ 32 } />
 						<span>{ __( 'Custom HTML Block Extension', 'custom-html-block-extension' ) }</span>
-					</HStack>
+					</Stack>
 				</Heading>
-				<VStack className="chbe-admin-header__info">
+				<Stack direction="column" className="chbe-admin-header__info" gap="sm">
 					<WelcomeGuide />
 					<Shortcut />
-				</VStack>
+				</Stack>
 			</div>
 		</header>
 	);

--- a/src/admin/components/shortcut/index.tsx
+++ b/src/admin/components/shortcut/index.tsx
@@ -4,13 +4,8 @@
 import { __ } from '@wordpress/i18n';
 import { useState } from '@wordpress/element';
 import { info } from '@wordpress/icons';
-import {
-	Button,
-	ExternalLink,
-	Modal,
-	__experimentalText as Text,
-	__experimentalVStack as VStack,
-} from '@wordpress/components';
+import { Button, Modal } from '@wordpress/components';
+import { Link, Stack, Text } from '@wordpress/ui';
 
 export default function Shortcut() {
 	const [ isModalOpen, setIsModalOpen ] = useState( false );
@@ -32,20 +27,20 @@ export default function Shortcut() {
 					title={ __( 'About shortcut', 'custom-html-block-extension' ) }
 					onRequestClose={ () => setIsModalOpen( false ) }
 				>
-					<VStack spacing={ 4 }>
-						<Text as="p">
+					<Stack direction="column" gap="lg">
+						<Text render={ <p /> }>
 							{ __(
 								'This plugin is made with "Monaco Editor", the code editor behind VS Code.',
 								'custom-html-block-extension'
 							) }
 						</Text>
-						<Text as="p">
+						<Text render={ <p /> }>
 							{ __(
 								'So you can use many of keyboard shortcuts available in VS Code on custom HTML block.',
 								'custom-html-block-extension'
 							) }
 						</Text>
-						<Text as="p">
+						<Text render={ <p /> }>
 							{ __(
 								'Check the following link for a list of shortcuts.',
 								'custom-html-block-extension'
@@ -53,27 +48,29 @@ export default function Shortcut() {
 						</Text>
 						<ul>
 							<li>
-								<ExternalLink
+								<Link
 									href={ __(
 										'https://code.visualstudio.com/shortcuts/keyboard-shortcuts-windows.pdf',
 										'custom-html-block-extension'
 									) }
+									openInNewTab
 								>
 									{ __( 'Keyboard shortcuts for Windows', 'custom-html-block-extension' ) }
-								</ExternalLink>
+								</Link>
 							</li>
 							<li>
-								<ExternalLink
+								<Link
 									href={ __(
 										'https://code.visualstudio.com/shortcuts/keyboard-shortcuts-macos.pdf',
 										'custom-html-block-extension'
 									) }
+									openInNewTab
 								>
 									{ __( 'Keyboard shortcuts for macOS', 'custom-html-block-extension' ) }
-								</ExternalLink>
+								</Link>
 							</li>
 						</ul>
-					</VStack>
+					</Stack>
 				</Modal>
 			) }
 		</>

--- a/src/admin/components/welcome-guide/index.tsx
+++ b/src/admin/components/welcome-guide/index.tsx
@@ -49,26 +49,28 @@ export default function WelcomeGuide() {
 								/>
 							),
 							content: (
-								<div className="chbe-admin-welcome-guide-modal__content">
-									<Stack direction="column" gap="lg">
-										<Heading level="2" as="h1">
-											{ __( 'About Custom HTML Block Extension', 'custom-html-block-extension' ) }
-										</Heading>
-										<Text render={ <p /> }>
-											{ sprintf(
-												/* translators: %s is replaced with the number. */
-												__( 'Version: %s', 'custom-html-block-extension' ),
-												window.chbeObj.version
-											) }
-										</Text>
-										<Text render={ <p /> }>
-											{ __(
-												'Custom HTML Block Extension extends Custom HTML block to evolve into the advanced code editor.',
-												'custom-html-block-extension'
-											) }
-										</Text>
-									</Stack>
-								</div>
+								<Stack
+									className="chbe-admin-welcome-guide-modal__content"
+									direction="column"
+									gap="lg"
+								>
+									<Heading level="2" as="h1">
+										{ __( 'About Custom HTML Block Extension', 'custom-html-block-extension' ) }
+									</Heading>
+									<Text render={ <p /> }>
+										{ sprintf(
+											/* translators: %s is replaced with the number. */
+											__( 'Version: %s', 'custom-html-block-extension' ),
+											window.chbeObj.version
+										) }
+									</Text>
+									<Text render={ <p /> }>
+										{ __(
+											'Custom HTML Block Extension extends Custom HTML block to evolve into the advanced code editor.',
+											'custom-html-block-extension'
+										) }
+									</Text>
+								</Stack>
 							),
 						},
 						{
@@ -81,19 +83,21 @@ export default function WelcomeGuide() {
 								/>
 							),
 							content: (
-								<div className="chbe-admin-welcome-guide-modal__content">
-									<Stack direction="column" gap="lg">
-										<Heading level="2" as="h1">
-											{ __( 'Various color themes', 'custom-html-block-extension' ) }
-										</Heading>
-										<Text render={ <p /> }>
-											{ __(
-												'There are 50 different color themes to choose from, and you can select the one that best suits your taste.',
-												'custom-html-block-extension'
-											) }
-										</Text>
-									</Stack>
-								</div>
+								<Stack
+									className="chbe-admin-welcome-guide-modal__content"
+									direction="column"
+									gap="lg"
+								>
+									<Heading level="2" as="h1">
+										{ __( 'Various color themes', 'custom-html-block-extension' ) }
+									</Heading>
+									<Text render={ <p /> }>
+										{ __(
+											'There are 50 different color themes to choose from, and you can select the one that best suits your taste.',
+											'custom-html-block-extension'
+										) }
+									</Text>
+								</Stack>
 							),
 						},
 						{
@@ -106,19 +110,21 @@ export default function WelcomeGuide() {
 								/>
 							),
 							content: (
-								<div className="chbe-admin-welcome-guide-modal__content">
-									<Stack direction="column" gap="lg">
-										<Heading level="2" as="h1">
-											{ __( 'Faster coding with Emmet', 'custom-html-block-extension' ) }
-										</Heading>
-										<Text render={ <p /> }>
-											{ __(
-												'Emmet allows you to type shortcuts that are then expanded into full pieces of code. Type less, saving both keystrokes.',
-												'custom-html-block-extension'
-											) }
-										</Text>
-									</Stack>
-								</div>
+								<Stack
+									className="chbe-admin-welcome-guide-modal__content"
+									direction="column"
+									gap="lg"
+								>
+									<Heading level="2" as="h1">
+										{ __( 'Faster coding with Emmet', 'custom-html-block-extension' ) }
+									</Heading>
+									<Text render={ <p /> }>
+										{ __(
+											'Emmet allows you to type shortcuts that are then expanded into full pieces of code. Type less, saving both keystrokes.',
+											'custom-html-block-extension'
+										) }
+									</Text>
+								</Stack>
 							),
 						},
 						{
@@ -131,19 +137,21 @@ export default function WelcomeGuide() {
 								/>
 							),
 							content: (
-								<div className="chbe-admin-welcome-guide-modal__content">
-									<Stack direction="column" gap="lg">
-										<Heading level="2" as="h1">
-											{ __( 'High customizability', 'custom-html-block-extension' ) }
-										</Heading>
-										<Text render={ <p /> }>
-											{ __(
-												'You can change all kinds of settings to create your ideal editor in advanced mode.',
-												'custom-html-block-extension'
-											) }
-										</Text>
-									</Stack>
-								</div>
+								<Stack
+									className="chbe-admin-welcome-guide-modal__content"
+									direction="column"
+									gap="lg"
+								>
+									<Heading level="2" as="h1">
+										{ __( 'High customizability', 'custom-html-block-extension' ) }
+									</Heading>
+									<Text render={ <p /> }>
+										{ __(
+											'You can change all kinds of settings to create your ideal editor in advanced mode.',
+											'custom-html-block-extension'
+										) }
+									</Text>
+								</Stack>
 							),
 						},
 						{
@@ -156,19 +164,21 @@ export default function WelcomeGuide() {
 								/>
 							),
 							content: (
-								<div className="chbe-admin-welcome-guide-modal__content">
-									<Stack direction="column" gap="lg">
-										<Heading level="2" as="h1">
-											{ __( 'More support', 'custom-html-block-extension' ) }
-										</Heading>
-										<Text render={ <p /> }>
-											{ __(
-												'Supports the classic editor, the theme/plugin editor, and import/export editor settings.',
-												'custom-html-block-extension'
-											) }
-										</Text>
-									</Stack>
-								</div>
+								<Stack
+									className="chbe-admin-welcome-guide-modal__content"
+									direction="column"
+									gap="lg"
+								>
+									<Heading level="2" as="h1">
+										{ __( 'More support', 'custom-html-block-extension' ) }
+									</Heading>
+									<Text render={ <p /> }>
+										{ __(
+											'Supports the classic editor, the theme/plugin editor, and import/export editor settings.',
+											'custom-html-block-extension'
+										) }
+									</Text>
+								</Stack>
 							),
 						},
 					] }

--- a/src/admin/components/welcome-guide/index.tsx
+++ b/src/admin/components/welcome-guide/index.tsx
@@ -5,14 +5,8 @@ import { __, sprintf } from '@wordpress/i18n';
 import apiFetch from '@wordpress/api-fetch';
 import { useState } from '@wordpress/element';
 import { info } from '@wordpress/icons';
-import {
-	Button,
-	Guide,
-	__experimentalText as Text,
-	__experimentalHeading as Heading,
-	__experimentalSpacer as Spacer,
-	__experimentalVStack as VStack,
-} from '@wordpress/components';
+import { Button, Guide, __experimentalHeading as Heading } from '@wordpress/components';
+import { Stack, Text } from '@wordpress/ui';
 
 export default function WelcomeGuide() {
 	const [ isModalOpen, setIsModalOpen ] = useState( ! window.chbeObj.dismissWelcomeGuide );
@@ -55,26 +49,26 @@ export default function WelcomeGuide() {
 								/>
 							),
 							content: (
-								<Spacer paddingX={ 8 } paddingY={ 4 } marginBottom={ 0 }>
-									<VStack spacing={ 4 }>
+								<div className="chbe-admin-welcome-guide-modal__content">
+									<Stack direction="column" gap="lg">
 										<Heading level="2" as="h1">
 											{ __( 'About Custom HTML Block Extension', 'custom-html-block-extension' ) }
 										</Heading>
-										<Text as="p">
+										<Text render={ <p /> }>
 											{ sprintf(
 												/* translators: %s is replaced with the number. */
 												__( 'Version: %s', 'custom-html-block-extension' ),
 												window.chbeObj.version
 											) }
 										</Text>
-										<Text as="p">
+										<Text render={ <p /> }>
 											{ __(
 												'Custom HTML Block Extension extends Custom HTML block to evolve into the advanced code editor.',
 												'custom-html-block-extension'
 											) }
 										</Text>
-									</VStack>
-								</Spacer>
+									</Stack>
+								</div>
 							),
 						},
 						{
@@ -87,19 +81,19 @@ export default function WelcomeGuide() {
 								/>
 							),
 							content: (
-								<Spacer paddingX={ 8 } paddingY={ 4 } marginBottom={ 0 }>
-									<VStack spacing={ 4 }>
+								<div className="chbe-admin-welcome-guide-modal__content">
+									<Stack direction="column" gap="lg">
 										<Heading level="2" as="h1">
 											{ __( 'Various color themes', 'custom-html-block-extension' ) }
 										</Heading>
-										<Text as="p">
+										<Text render={ <p /> }>
 											{ __(
 												'There are 50 different color themes to choose from, and you can select the one that best suits your taste.',
 												'custom-html-block-extension'
 											) }
 										</Text>
-									</VStack>
-								</Spacer>
+									</Stack>
+								</div>
 							),
 						},
 						{
@@ -112,19 +106,19 @@ export default function WelcomeGuide() {
 								/>
 							),
 							content: (
-								<Spacer paddingX={ 8 } paddingY={ 4 } marginBottom={ 0 }>
-									<VStack spacing={ 4 }>
+								<div className="chbe-admin-welcome-guide-modal__content">
+									<Stack direction="column" gap="lg">
 										<Heading level="2" as="h1">
 											{ __( 'Faster coding with Emmet', 'custom-html-block-extension' ) }
 										</Heading>
-										<Text as="p">
+										<Text render={ <p /> }>
 											{ __(
 												'Emmet allows you to type shortcuts that are then expanded into full pieces of code. Type less, saving both keystrokes.',
 												'custom-html-block-extension'
 											) }
 										</Text>
-									</VStack>
-								</Spacer>
+									</Stack>
+								</div>
 							),
 						},
 						{
@@ -137,19 +131,19 @@ export default function WelcomeGuide() {
 								/>
 							),
 							content: (
-								<Spacer paddingX={ 8 } paddingY={ 4 } marginBottom={ 0 }>
-									<VStack spacing={ 4 }>
+								<div className="chbe-admin-welcome-guide-modal__content">
+									<Stack direction="column" gap="lg">
 										<Heading level="2" as="h1">
 											{ __( 'High customizability', 'custom-html-block-extension' ) }
 										</Heading>
-										<Text as="p">
+										<Text render={ <p /> }>
 											{ __(
 												'You can change all kinds of settings to create your ideal editor in advanced mode.',
 												'custom-html-block-extension'
 											) }
 										</Text>
-									</VStack>
-								</Spacer>
+									</Stack>
+								</div>
 							),
 						},
 						{
@@ -162,19 +156,19 @@ export default function WelcomeGuide() {
 								/>
 							),
 							content: (
-								<Spacer paddingX={ 8 } paddingY={ 4 } marginBottom={ 0 }>
-									<VStack spacing={ 4 }>
+								<div className="chbe-admin-welcome-guide-modal__content">
+									<Stack direction="column" gap="lg">
 										<Heading level="2" as="h1">
 											{ __( 'More support', 'custom-html-block-extension' ) }
 										</Heading>
-										<Text as="p">
+										<Text render={ <p /> }>
 											{ __(
 												'Supports the classic editor, the theme/plugin editor, and import/export editor settings.',
 												'custom-html-block-extension'
 											) }
 										</Text>
-									</VStack>
-								</Spacer>
+									</Stack>
+								</div>
 							),
 						},
 					] }

--- a/src/admin/components/welcome-guide/style.scss
+++ b/src/admin/components/welcome-guide/style.scss
@@ -7,7 +7,7 @@
 		margin-bottom: variables.$grid-unit-20;
 	}
 
-	&__content {
+	.chbe-admin-welcome-guide-modal__content {
 		padding: variables.$grid-unit-20 variables.$grid-unit-40;
 	}
 }

--- a/src/admin/components/welcome-guide/style.scss
+++ b/src/admin/components/welcome-guide/style.scss
@@ -6,4 +6,8 @@
 	img {
 		margin-bottom: variables.$grid-unit-20;
 	}
+
+	&__content {
+		padding: variables.$grid-unit-20 variables.$grid-unit-40;
+	}
 }

--- a/src/admin/editor-config/components/controls/index.tsx
+++ b/src/admin/editor-config/components/controls/index.tsx
@@ -3,11 +3,8 @@
  */
 import { __ } from '@wordpress/i18n';
 import { useState } from '@wordpress/element';
-import {
-	Button,
-	__experimentalConfirmDialog as ConfirmDialog,
-	__experimentalHStack as HStack,
-} from '@wordpress/components';
+import { Button, __experimentalConfirmDialog as ConfirmDialog } from '@wordpress/components';
+import { Stack } from '@wordpress/ui';
 
 type ControlsProps = {
 	isWaiting: boolean;
@@ -20,7 +17,7 @@ export default function Controls( { isWaiting, onUpdateOptions, onResetOptions }
 
 	return (
 		<>
-			<HStack>
+			<Stack gap="sm">
 				<Button
 					variant="primary"
 					disabled={ isWaiting }
@@ -37,7 +34,7 @@ export default function Controls( { isWaiting, onUpdateOptions, onResetOptions }
 				>
 					{ __( 'Reset', 'custom-html-block-extension' ) }
 				</Button>
-			</HStack>
+			</Stack>
 			{ isModalOpen && (
 				<ConfirmDialog
 					onConfirm={ () => {

--- a/src/admin/editor-config/components/filter/index.tsx
+++ b/src/admin/editor-config/components/filter/index.tsx
@@ -4,12 +4,11 @@
 import { __ } from '@wordpress/i18n';
 import { useState } from '@wordpress/element';
 import {
-	FlexBlock,
 	SearchControl,
-	__experimentalHStack as HStack,
 	__experimentalToggleGroupControl as ToggleGroupControl,
 	__experimentalToggleGroupControlOption as ToggleGroupControlOption,
 } from '@wordpress/components';
+import { Stack } from '@wordpress/ui';
 import { useDebounce } from '@wordpress/compose';
 
 const MODES = [
@@ -43,8 +42,8 @@ export default function Filter( {
 	const debouncedOnChangeSearchQuery = useDebounce( setSearchQuery, 100 );
 
 	return (
-		<HStack className="chbe-admin-editor-config-filter">
-			<FlexBlock>
+		<Stack className="chbe-admin-editor-config-filter" gap="sm">
+			<div style={ { flex: 1 } }>
 				<ToggleGroupControl
 					size="__unstable-large"
 					label={ __( 'Mode', 'custom-html-block-extension' ) }
@@ -62,8 +61,8 @@ export default function Filter( {
 						/>
 					) ) }
 				</ToggleGroupControl>
-			</FlexBlock>
-			<FlexBlock>
+			</div>
+			<div style={ { flex: 1 } }>
 				<SearchControl
 					value={ searchQueryState }
 					onChange={ ( value ) => {
@@ -71,7 +70,7 @@ export default function Filter( {
 						debouncedOnChangeSearchQuery( value );
 					} }
 				/>
-			</FlexBlock>
-		</HStack>
+			</div>
+		</Stack>
 	);
 }

--- a/src/admin/editor-config/components/item-help/index.tsx
+++ b/src/admin/editor-config/components/item-help/index.tsx
@@ -13,10 +13,9 @@ import {
 	Button,
 	Modal,
 	ToggleControl,
-	__experimentalText as Text,
 	__experimentalHeading as Heading,
-	__experimentalVStack as VStack,
 } from '@wordpress/components';
+import { Stack, Text } from '@wordpress/ui';
 
 type ItemHelpProps = {
 	title: string;
@@ -62,17 +61,19 @@ export default function ItemHelp( {
 					className="chbe-admin-editor-config-item-help-modal"
 					onRequestClose={ () => setIsModalOpen( false ) }
 				>
-					<VStack spacing={ 4 } alignment="start">
+					<Stack direction="column" align="start" gap="lg">
 						{ description && (
-							<VStack
-								as={ typeof description === 'object' ? 'div' : 'p' }
+							<Stack
+								direction="column"
+								render={ typeof description === 'object' ? <div /> : <p /> }
 								className="chbe-admin-editor-config-item-help-modal__decription"
+								gap="sm"
 							>
 								{ description }
-							</VStack>
+							</Stack>
 						) }
 						{ isToggle && (
-							<Text as="p">
+							<Text render={ <p /> }>
 								{ defaultToggle
 									? __( 'Defaults to enable.', 'custom-html-block-extension' )
 									: __( 'Defaults to disable.', 'custom-html-block-extension' ) }
@@ -83,7 +84,7 @@ export default function ItemHelp( {
 								className={ `chbe-admin-editor-config-item-help-modal__items is-col-${ colCount }` }
 							>
 								{ items.map( ( item, index ) => (
-									<VStack spacing="4" alignment="start" key={ index }>
+									<Stack direction="column" align="start" gap="lg" key={ index }>
 										<Heading as="h3" level="4">
 											{ item.isDefault
 												? sprintf(
@@ -106,8 +107,8 @@ export default function ItemHelp( {
 												alt={ item.title }
 											/>
 										</Button>
-										{ item.description && <Text as="p">{ item.description }</Text> }
-									</VStack>
+										{ item.description && <Text render={ <p /> }>{ item.description }</Text> }
+									</Stack>
 								) ) }
 							</div>
 						) }
@@ -127,7 +128,7 @@ export default function ItemHelp( {
 								label={ title }
 							/>
 						) }
-					</VStack>
+					</Stack>
 				</Modal>
 			) }
 			<Button

--- a/src/admin/editor-config/editor-options/accept-suggestion-on-enter.tsx
+++ b/src/admin/editor-config/editor-options/accept-suggestion-on-enter.tsx
@@ -3,7 +3,8 @@
  */
 import { __ } from '@wordpress/i18n';
 import { createInterpolateElement, useContext } from '@wordpress/element';
-import { ToggleControl, __experimentalHStack as HStack } from '@wordpress/components';
+import { ToggleControl } from '@wordpress/components';
+import { Stack } from '@wordpress/ui';
 
 /**
  * Internal dependencies
@@ -35,7 +36,7 @@ export default function AcceptSuggestionOnEnter() {
 
 	return (
 		<div className="chbe-admin-editor-config__setting-item">
-			<HStack justify="start" alignment="start" wrap>
+			<Stack justify="start" align="start" wrap="wrap" gap="sm">
 				<ToggleControl label={ title } checked={ isEnabled } onChange={ onChange } />
 				<ItemHelp
 					onChange={ onChange }
@@ -53,7 +54,7 @@ export default function AcceptSuggestionOnEnter() {
 					defaultToggle
 					value={ isEnabled }
 				/>
-			</HStack>
+			</Stack>
 		</div>
 	);
 }

--- a/src/admin/editor-config/editor-options/accept-suggestion-on-enter.tsx
+++ b/src/admin/editor-config/editor-options/accept-suggestion-on-enter.tsx
@@ -35,26 +35,30 @@ export default function AcceptSuggestionOnEnter() {
 	};
 
 	return (
-		<div className="chbe-admin-editor-config__setting-item">
-			<Stack justify="start" align="start" wrap="wrap" gap="sm">
-				<ToggleControl label={ title } checked={ isEnabled } onChange={ onChange } />
-				<ItemHelp
-					onChange={ onChange }
-					title={ title }
-					description={ createInterpolateElement(
-						__(
-							'Accept suggestions on <code>Enter</code> key in addition to <code>Tab</code> key.',
-							'custom-html-block-extension'
-						),
-						{
-							code: <code />,
-						}
-					) }
-					isToggle
-					defaultToggle
-					value={ isEnabled }
-				/>
-			</Stack>
-		</div>
+		<Stack
+			className="chbe-admin-editor-config__setting-item"
+			justify="start"
+			align="start"
+			wrap="wrap"
+			gap="sm"
+		>
+			<ToggleControl label={ title } checked={ isEnabled } onChange={ onChange } />
+			<ItemHelp
+				onChange={ onChange }
+				title={ title }
+				description={ createInterpolateElement(
+					__(
+						'Accept suggestions on <code>Enter</code> key in addition to <code>Tab</code> key.',
+						'custom-html-block-extension'
+					),
+					{
+						code: <code />,
+					}
+				) }
+				isToggle
+				defaultToggle
+				value={ isEnabled }
+			/>
+		</Stack>
 	);
 }

--- a/src/admin/editor-config/editor-options/auto-closing-brackets.tsx
+++ b/src/admin/editor-config/editor-options/auto-closing-brackets.tsx
@@ -3,7 +3,8 @@
  */
 import { __ } from '@wordpress/i18n';
 import { useContext } from '@wordpress/element';
-import { SelectControl, __experimentalHStack as HStack } from '@wordpress/components';
+import { SelectControl } from '@wordpress/components';
+import { Stack } from '@wordpress/ui';
 
 /**
  * Internal dependencies
@@ -54,7 +55,7 @@ export default function AutoClosingBrackets() {
 
 	return (
 		<div className="chbe-admin-editor-config__setting-item">
-			<HStack justify="start" alignment="start" wrap>
+			<Stack justify="start" align="start" wrap="wrap" gap="sm">
 				<SelectControl< EditorOptions[ 'autoClosingBrackets' ] >
 					__next40pxDefaultSize
 					label={ title }
@@ -69,7 +70,7 @@ export default function AutoClosingBrackets() {
 					colCount="3"
 					value={ editorOptions.autoClosingBrackets }
 				/>
-			</HStack>
+			</Stack>
 		</div>
 	);
 }

--- a/src/admin/editor-config/editor-options/auto-closing-brackets.tsx
+++ b/src/admin/editor-config/editor-options/auto-closing-brackets.tsx
@@ -54,23 +54,27 @@ export default function AutoClosingBrackets() {
 	};
 
 	return (
-		<div className="chbe-admin-editor-config__setting-item">
-			<Stack justify="start" align="start" wrap="wrap" gap="sm">
-				<SelectControl< EditorOptions[ 'autoClosingBrackets' ] >
-					__next40pxDefaultSize
-					label={ title }
-					value={ editorOptions.autoClosingBrackets }
-					options={ items.map( ( { label, value } ) => ( { label, value } ) ) }
-					onChange={ onChange }
-				/>
-				<ItemHelp
-					onChange={ onChange }
-					title={ title }
-					items={ items }
-					colCount="3"
-					value={ editorOptions.autoClosingBrackets }
-				/>
-			</Stack>
-		</div>
+		<Stack
+			className="chbe-admin-editor-config__setting-item"
+			justify="start"
+			align="start"
+			wrap="wrap"
+			gap="sm"
+		>
+			<SelectControl< EditorOptions[ 'autoClosingBrackets' ] >
+				__next40pxDefaultSize
+				label={ title }
+				value={ editorOptions.autoClosingBrackets }
+				options={ items.map( ( { label, value } ) => ( { label, value } ) ) }
+				onChange={ onChange }
+			/>
+			<ItemHelp
+				onChange={ onChange }
+				title={ title }
+				items={ items }
+				colCount="3"
+				value={ editorOptions.autoClosingBrackets }
+			/>
+		</Stack>
 	);
 }

--- a/src/admin/editor-config/editor-options/auto-closing-quotes.tsx
+++ b/src/admin/editor-config/editor-options/auto-closing-quotes.tsx
@@ -54,23 +54,27 @@ export default function AutoClosingQuotes() {
 	};
 
 	return (
-		<div className="chbe-admin-editor-config__setting-item">
-			<Stack justify="start" align="start" wrap="wrap" gap="sm">
-				<SelectControl< EditorOptions[ 'autoClosingQuotes' ] >
-					__next40pxDefaultSize
-					label={ title }
-					value={ editorOptions.autoClosingQuotes }
-					options={ items.map( ( { label, value } ) => ( { label, value } ) ) }
-					onChange={ onChange }
-				/>
-				<ItemHelp
-					onChange={ onChange }
-					title={ title }
-					items={ items }
-					colCount="3"
-					value={ editorOptions.autoClosingQuotes }
-				/>
-			</Stack>
-		</div>
+		<Stack
+			className="chbe-admin-editor-config__setting-item"
+			justify="start"
+			align="start"
+			wrap="wrap"
+			gap="sm"
+		>
+			<SelectControl< EditorOptions[ 'autoClosingQuotes' ] >
+				__next40pxDefaultSize
+				label={ title }
+				value={ editorOptions.autoClosingQuotes }
+				options={ items.map( ( { label, value } ) => ( { label, value } ) ) }
+				onChange={ onChange }
+			/>
+			<ItemHelp
+				onChange={ onChange }
+				title={ title }
+				items={ items }
+				colCount="3"
+				value={ editorOptions.autoClosingQuotes }
+			/>
+		</Stack>
 	);
 }

--- a/src/admin/editor-config/editor-options/auto-closing-quotes.tsx
+++ b/src/admin/editor-config/editor-options/auto-closing-quotes.tsx
@@ -3,7 +3,8 @@
  */
 import { __ } from '@wordpress/i18n';
 import { useContext } from '@wordpress/element';
-import { SelectControl, __experimentalHStack as HStack } from '@wordpress/components';
+import { SelectControl } from '@wordpress/components';
+import { Stack } from '@wordpress/ui';
 
 /**
  * Internal dependencies
@@ -54,7 +55,7 @@ export default function AutoClosingQuotes() {
 
 	return (
 		<div className="chbe-admin-editor-config__setting-item">
-			<HStack justify="start" alignment="start" wrap>
+			<Stack justify="start" align="start" wrap="wrap" gap="sm">
 				<SelectControl< EditorOptions[ 'autoClosingQuotes' ] >
 					__next40pxDefaultSize
 					label={ title }
@@ -69,7 +70,7 @@ export default function AutoClosingQuotes() {
 					colCount="3"
 					value={ editorOptions.autoClosingQuotes }
 				/>
-			</HStack>
+			</Stack>
 		</div>
 	);
 }

--- a/src/admin/editor-config/editor-options/auto-indent.tsx
+++ b/src/admin/editor-config/editor-options/auto-indent.tsx
@@ -3,7 +3,8 @@
  */
 import { __ } from '@wordpress/i18n';
 import { useContext } from '@wordpress/element';
-import { SelectControl, __experimentalHStack as HStack } from '@wordpress/components';
+import { SelectControl } from '@wordpress/components';
+import { Stack } from '@wordpress/ui';
 
 /**
  * Internal dependencies
@@ -53,7 +54,7 @@ export default function AutoIndent() {
 
 	return (
 		<div className="chbe-admin-editor-config__setting-item">
-			<HStack justify="start" alignment="start" wrap>
+			<Stack justify="start" align="start" wrap="wrap" gap="sm">
 				<SelectControl< EditorOptions[ 'autoIndent' ] >
 					__next40pxDefaultSize
 					label={ title }
@@ -68,7 +69,7 @@ export default function AutoIndent() {
 					colCount="3"
 					value={ editorOptions.autoIndent }
 				/>
-			</HStack>
+			</Stack>
 		</div>
 	);
 }

--- a/src/admin/editor-config/editor-options/auto-indent.tsx
+++ b/src/admin/editor-config/editor-options/auto-indent.tsx
@@ -53,23 +53,27 @@ export default function AutoIndent() {
 	};
 
 	return (
-		<div className="chbe-admin-editor-config__setting-item">
-			<Stack justify="start" align="start" wrap="wrap" gap="sm">
-				<SelectControl< EditorOptions[ 'autoIndent' ] >
-					__next40pxDefaultSize
-					label={ title }
-					value={ editorOptions.autoIndent }
-					options={ items.map( ( { label, value } ) => ( { label, value } ) ) }
-					onChange={ onChange }
-				/>
-				<ItemHelp
-					onChange={ onChange }
-					title={ title }
-					items={ items }
-					colCount="3"
-					value={ editorOptions.autoIndent }
-				/>
-			</Stack>
-		</div>
+		<Stack
+			className="chbe-admin-editor-config__setting-item"
+			justify="start"
+			align="start"
+			wrap="wrap"
+			gap="sm"
+		>
+			<SelectControl< EditorOptions[ 'autoIndent' ] >
+				__next40pxDefaultSize
+				label={ title }
+				value={ editorOptions.autoIndent }
+				options={ items.map( ( { label, value } ) => ( { label, value } ) ) }
+				onChange={ onChange }
+			/>
+			<ItemHelp
+				onChange={ onChange }
+				title={ title }
+				items={ items }
+				colCount="3"
+				value={ editorOptions.autoIndent }
+			/>
+		</Stack>
 	);
 }

--- a/src/admin/editor-config/editor-options/auto-surround.tsx
+++ b/src/admin/editor-config/editor-options/auto-surround.tsx
@@ -59,22 +59,26 @@ export default function AutoSurround() {
 	};
 
 	return (
-		<div className="chbe-admin-editor-config__setting-item">
-			<Stack justify="start" align="start" wrap="wrap" gap="sm">
-				<SelectControl< EditorOptions[ 'autoSurround' ] >
-					__next40pxDefaultSize
-					label={ title }
-					value={ editorOptions.autoSurround }
-					options={ items.map( ( { label, value } ) => ( { label, value } ) ) }
-					onChange={ onChange }
-				/>
-				<ItemHelp
-					onChange={ onChange }
-					title={ title }
-					items={ items }
-					value={ editorOptions.autoSurround }
-				/>
-			</Stack>
-		</div>
+		<Stack
+			className="chbe-admin-editor-config__setting-item"
+			justify="start"
+			align="start"
+			wrap="wrap"
+			gap="sm"
+		>
+			<SelectControl< EditorOptions[ 'autoSurround' ] >
+				__next40pxDefaultSize
+				label={ title }
+				value={ editorOptions.autoSurround }
+				options={ items.map( ( { label, value } ) => ( { label, value } ) ) }
+				onChange={ onChange }
+			/>
+			<ItemHelp
+				onChange={ onChange }
+				title={ title }
+				items={ items }
+				value={ editorOptions.autoSurround }
+			/>
+		</Stack>
 	);
 }

--- a/src/admin/editor-config/editor-options/auto-surround.tsx
+++ b/src/admin/editor-config/editor-options/auto-surround.tsx
@@ -3,7 +3,8 @@
  */
 import { __ } from '@wordpress/i18n';
 import { useContext } from '@wordpress/element';
-import { SelectControl, __experimentalHStack as HStack } from '@wordpress/components';
+import { SelectControl } from '@wordpress/components';
+import { Stack } from '@wordpress/ui';
 
 /**
  * Internal dependencies
@@ -59,7 +60,7 @@ export default function AutoSurround() {
 
 	return (
 		<div className="chbe-admin-editor-config__setting-item">
-			<HStack justify="start" alignment="start" wrap>
+			<Stack justify="start" align="start" wrap="wrap" gap="sm">
 				<SelectControl< EditorOptions[ 'autoSurround' ] >
 					__next40pxDefaultSize
 					label={ title }
@@ -73,7 +74,7 @@ export default function AutoSurround() {
 					items={ items }
 					value={ editorOptions.autoSurround }
 				/>
-			</HStack>
+			</Stack>
 		</div>
 	);
 }

--- a/src/admin/editor-config/editor-options/column-selection.tsx
+++ b/src/admin/editor-config/editor-options/column-selection.tsx
@@ -3,11 +3,8 @@
  */
 import { __ } from '@wordpress/i18n';
 import { createInterpolateElement, useContext } from '@wordpress/element';
-import {
-	ToggleControl,
-	__experimentalText as Text,
-	__experimentalHStack as HStack,
-} from '@wordpress/components';
+import { ToggleControl } from '@wordpress/components';
+import { Stack, Text } from '@wordpress/ui';
 
 /**
  * Internal dependencies
@@ -35,7 +32,7 @@ export default function ColumnSelection() {
 
 	return (
 		<div className="chbe-admin-editor-config__setting-item">
-			<HStack justify="start" alignment="start" wrap>
+			<Stack justify="start" align="start" wrap="wrap" gap="sm">
 				<ToggleControl
 					label={ __( 'Enable column selection', 'custom-html-block-extension' ) }
 					checked={ editorOptions.columnSelection }
@@ -46,7 +43,7 @@ export default function ColumnSelection() {
 					title={ title }
 					description={
 						<>
-							<Text as="p">
+							<Text render={ <p /> }>
 								{ __(
 									'Always enable column selection. Following command can be used to select column selection even when disabled.',
 									'custom-html-block-extension'
@@ -83,7 +80,7 @@ export default function ColumnSelection() {
 					image="editor-options/column-selection.gif"
 					value={ editorOptions.columnSelection }
 				/>
-			</HStack>
+			</Stack>
 		</div>
 	);
 }

--- a/src/admin/editor-config/editor-options/column-selection.tsx
+++ b/src/admin/editor-config/editor-options/column-selection.tsx
@@ -31,56 +31,60 @@ export default function ColumnSelection() {
 	};
 
 	return (
-		<div className="chbe-admin-editor-config__setting-item">
-			<Stack justify="start" align="start" wrap="wrap" gap="sm">
-				<ToggleControl
-					label={ __( 'Enable column selection', 'custom-html-block-extension' ) }
-					checked={ editorOptions.columnSelection }
-					onChange={ onChange }
-				/>
-				<ItemHelp
-					onChange={ onChange }
-					title={ title }
-					description={
-						<>
-							<Text render={ <p /> }>
-								{ __(
-									'Always enable column selection. Following command can be used to select column selection even when disabled.',
-									'custom-html-block-extension'
+		<Stack
+			className="chbe-admin-editor-config__setting-item"
+			justify="start"
+			align="start"
+			wrap="wrap"
+			gap="sm"
+		>
+			<ToggleControl
+				label={ __( 'Enable column selection', 'custom-html-block-extension' ) }
+				checked={ editorOptions.columnSelection }
+				onChange={ onChange }
+			/>
+			<ItemHelp
+				onChange={ onChange }
+				title={ title }
+				description={
+					<>
+						<Text render={ <p /> }>
+							{ __(
+								'Always enable column selection. Following command can be used to select column selection even when disabled.',
+								'custom-html-block-extension'
+							) }
+						</Text>
+						<ul>
+							<li>
+								{ createInterpolateElement(
+									__(
+										'Windows: <code>Shift</code> + <code>Alt</code> + drag mouse, or "<code>Ctrl</code> + <code>Shift</code> + <code>Alt</code> + arrow key',
+										'custom-html-block-extension'
+									),
+									{
+										code: <code />,
+									}
 								) }
-							</Text>
-							<ul>
-								<li>
-									{ createInterpolateElement(
-										__(
-											'Windows: <code>Shift</code> + <code>Alt</code> + drag mouse, or "<code>Ctrl</code> + <code>Shift</code> + <code>Alt</code> + arrow key',
-											'custom-html-block-extension'
-										),
-										{
-											code: <code />,
-										}
-									) }
-								</li>
-								<li>
-									{ createInterpolateElement(
-										__(
-											'macOS: <code>Shift</code> + <code>Option</code> + drag mouse, or <code>Shift</code> + <code>Option</code> + <code>Command</code> + arrow key',
-											'custom-html-block-extension'
-										),
-										{
-											code: <code />,
-										}
-									) }
-								</li>
-							</ul>
-						</>
-					}
-					isToggle
-					defaultToggle={ false }
-					image="editor-options/column-selection.gif"
-					value={ editorOptions.columnSelection }
-				/>
-			</Stack>
-		</div>
+							</li>
+							<li>
+								{ createInterpolateElement(
+									__(
+										'macOS: <code>Shift</code> + <code>Option</code> + drag mouse, or <code>Shift</code> + <code>Option</code> + <code>Command</code> + arrow key',
+										'custom-html-block-extension'
+									),
+									{
+										code: <code />,
+									}
+								) }
+							</li>
+						</ul>
+					</>
+				}
+				isToggle
+				defaultToggle={ false }
+				image="editor-options/column-selection.gif"
+				value={ editorOptions.columnSelection }
+			/>
+		</Stack>
 	);
 }

--- a/src/admin/editor-config/editor-options/comments/insert-space.tsx
+++ b/src/admin/editor-config/editor-options/comments/insert-space.tsx
@@ -34,36 +34,40 @@ export default function CommentsInsertSpace() {
 	};
 
 	return (
-		<div className="chbe-admin-editor-config__setting-item">
-			<Stack justify="start" align="start" wrap="wrap" gap="sm">
-				<ToggleControl
-					label={ title }
-					checked={ editorOptions.comments.insertSpace }
-					onChange={ onChange }
-				/>
-				<ItemHelp
-					onChange={ onChange }
-					title={ title }
-					description={ __(
-						'Insert whitespace inside the comment tokens when comment out using the keyboard shortcut.',
-						'custom-html-block-extension'
-					) }
-					items={ [
-						{
-							label: __( 'Enable', 'custom-html-block-extension' ),
-							value: true,
-							image: 'editor-options/comments_insert-space_1.jpg',
-							isDefault: true,
-						},
-						{
-							label: __( 'Disable', 'custom-html-block-extension' ),
-							value: false,
-							image: 'editor-options/comments_insert-space_2.jpg',
-						},
-					] }
-					value={ editorOptions.comments.insertSpace }
-				/>
-			</Stack>
-		</div>
+		<Stack
+			className="chbe-admin-editor-config__setting-item"
+			justify="start"
+			align="start"
+			wrap="wrap"
+			gap="sm"
+		>
+			<ToggleControl
+				label={ title }
+				checked={ editorOptions.comments.insertSpace }
+				onChange={ onChange }
+			/>
+			<ItemHelp
+				onChange={ onChange }
+				title={ title }
+				description={ __(
+					'Insert whitespace inside the comment tokens when comment out using the keyboard shortcut.',
+					'custom-html-block-extension'
+				) }
+				items={ [
+					{
+						label: __( 'Enable', 'custom-html-block-extension' ),
+						value: true,
+						image: 'editor-options/comments_insert-space_1.jpg',
+						isDefault: true,
+					},
+					{
+						label: __( 'Disable', 'custom-html-block-extension' ),
+						value: false,
+						image: 'editor-options/comments_insert-space_2.jpg',
+					},
+				] }
+				value={ editorOptions.comments.insertSpace }
+			/>
+		</Stack>
 	);
 }

--- a/src/admin/editor-config/editor-options/comments/insert-space.tsx
+++ b/src/admin/editor-config/editor-options/comments/insert-space.tsx
@@ -3,7 +3,8 @@
  */
 import { __ } from '@wordpress/i18n';
 import { useContext } from '@wordpress/element';
-import { ToggleControl, __experimentalHStack as HStack } from '@wordpress/components';
+import { ToggleControl } from '@wordpress/components';
+import { Stack } from '@wordpress/ui';
 
 /**
  * Internal dependencies
@@ -34,7 +35,7 @@ export default function CommentsInsertSpace() {
 
 	return (
 		<div className="chbe-admin-editor-config__setting-item">
-			<HStack justify="start" alignment="start" wrap>
+			<Stack justify="start" align="start" wrap="wrap" gap="sm">
 				<ToggleControl
 					label={ title }
 					checked={ editorOptions.comments.insertSpace }
@@ -62,7 +63,7 @@ export default function CommentsInsertSpace() {
 					] }
 					value={ editorOptions.comments.insertSpace }
 				/>
-			</HStack>
+			</Stack>
 		</div>
 	);
 }

--- a/src/admin/editor-config/editor-options/contextmenu.tsx
+++ b/src/admin/editor-config/editor-options/contextmenu.tsx
@@ -31,38 +31,38 @@ export default function Contextmenu() {
 	};
 
 	return (
-		<div className="chbe-admin-editor-config__setting-item">
-			<Stack justify="start" align="start" wrap="wrap" gap="sm">
-				<ToggleControl
-					label={ title }
-					checked={ editorOptions.contextmenu }
-					onChange={ onChange }
-				/>
-				<ItemHelp
-					onChange={ onChange }
-					title={ title }
-					description={ __(
-						'Sets the context menu when right-click in the editor.',
-						'custom-html-block-extension'
-					) }
-					items={ [
-						{
-							label: __( 'Enable', 'custom-html-block-extension' ),
-							value: true,
-							image: 'editor-options/contextmenu_1.jpg',
-							isDefault: true,
-							description: __( 'Show the editor context menu.', 'custom-html-block-extension' ),
-						},
-						{
-							label: __( 'Disable', 'custom-html-block-extension' ),
-							value: false,
-							image: 'editor-options/contextmenu_2.jpg',
-							description: __( 'Show the browser context menu.', 'custom-html-block-extension' ),
-						},
-					] }
-					value={ editorOptions.contextmenu }
-				/>
-			</Stack>
-		</div>
+		<Stack
+			className="chbe-admin-editor-config__setting-item"
+			justify="start"
+			align="start"
+			wrap="wrap"
+			gap="sm"
+		>
+			<ToggleControl label={ title } checked={ editorOptions.contextmenu } onChange={ onChange } />
+			<ItemHelp
+				onChange={ onChange }
+				title={ title }
+				description={ __(
+					'Sets the context menu when right-click in the editor.',
+					'custom-html-block-extension'
+				) }
+				items={ [
+					{
+						label: __( 'Enable', 'custom-html-block-extension' ),
+						value: true,
+						image: 'editor-options/contextmenu_1.jpg',
+						isDefault: true,
+						description: __( 'Show the editor context menu.', 'custom-html-block-extension' ),
+					},
+					{
+						label: __( 'Disable', 'custom-html-block-extension' ),
+						value: false,
+						image: 'editor-options/contextmenu_2.jpg',
+						description: __( 'Show the browser context menu.', 'custom-html-block-extension' ),
+					},
+				] }
+				value={ editorOptions.contextmenu }
+			/>
+		</Stack>
 	);
 }

--- a/src/admin/editor-config/editor-options/contextmenu.tsx
+++ b/src/admin/editor-config/editor-options/contextmenu.tsx
@@ -3,7 +3,8 @@
  */
 import { __ } from '@wordpress/i18n';
 import { useContext } from '@wordpress/element';
-import { ToggleControl, __experimentalHStack as HStack } from '@wordpress/components';
+import { ToggleControl } from '@wordpress/components';
+import { Stack } from '@wordpress/ui';
 
 /**
  * Internal dependencies
@@ -31,7 +32,7 @@ export default function Contextmenu() {
 
 	return (
 		<div className="chbe-admin-editor-config__setting-item">
-			<HStack justify="start" alignment="start" wrap>
+			<Stack justify="start" align="start" wrap="wrap" gap="sm">
 				<ToggleControl
 					label={ title }
 					checked={ editorOptions.contextmenu }
@@ -61,7 +62,7 @@ export default function Contextmenu() {
 					] }
 					value={ editorOptions.contextmenu }
 				/>
-			</HStack>
+			</Stack>
 		</div>
 	);
 }

--- a/src/admin/editor-config/editor-options/copy-with-syntax-highlighting.tsx
+++ b/src/admin/editor-config/editor-options/copy-with-syntax-highlighting.tsx
@@ -31,36 +31,40 @@ export default function CopyWithSyntaxHighlighting() {
 	};
 
 	return (
-		<div className="chbe-admin-editor-config__setting-item">
-			<Stack justify="start" align="start" wrap="wrap" gap="sm">
-				<ToggleControl
-					label={ title }
-					checked={ editorOptions.copyWithSyntaxHighlighting }
-					onChange={ onChange }
-				/>
-				<ItemHelp
-					onChange={ onChange }
-					title={ title }
-					description={ __(
-						'Example: How it looks when pasted into Microsoft Word',
-						'custom-html-block-extension'
-					) }
-					items={ [
-						{
-							label: __( 'Enable', 'custom-html-block-extension' ),
-							value: true,
-							image: 'editor-options/copy-with-syntax-highlighting_1.jpg',
-							isDefault: true,
-						},
-						{
-							label: __( 'Disable', 'custom-html-block-extension' ),
-							value: false,
-							image: 'editor-options/copy-with-syntax-highlighting_2.jpg',
-						},
-					] }
-					value={ editorOptions.copyWithSyntaxHighlighting }
-				/>
-			</Stack>
-		</div>
+		<Stack
+			className="chbe-admin-editor-config__setting-item"
+			justify="start"
+			align="start"
+			wrap="wrap"
+			gap="sm"
+		>
+			<ToggleControl
+				label={ title }
+				checked={ editorOptions.copyWithSyntaxHighlighting }
+				onChange={ onChange }
+			/>
+			<ItemHelp
+				onChange={ onChange }
+				title={ title }
+				description={ __(
+					'Example: How it looks when pasted into Microsoft Word',
+					'custom-html-block-extension'
+				) }
+				items={ [
+					{
+						label: __( 'Enable', 'custom-html-block-extension' ),
+						value: true,
+						image: 'editor-options/copy-with-syntax-highlighting_1.jpg',
+						isDefault: true,
+					},
+					{
+						label: __( 'Disable', 'custom-html-block-extension' ),
+						value: false,
+						image: 'editor-options/copy-with-syntax-highlighting_2.jpg',
+					},
+				] }
+				value={ editorOptions.copyWithSyntaxHighlighting }
+			/>
+		</Stack>
 	);
 }

--- a/src/admin/editor-config/editor-options/copy-with-syntax-highlighting.tsx
+++ b/src/admin/editor-config/editor-options/copy-with-syntax-highlighting.tsx
@@ -3,7 +3,8 @@
  */
 import { __ } from '@wordpress/i18n';
 import { useContext } from '@wordpress/element';
-import { ToggleControl, __experimentalHStack as HStack } from '@wordpress/components';
+import { ToggleControl } from '@wordpress/components';
+import { Stack } from '@wordpress/ui';
 
 /**
  * Internal dependencies
@@ -31,7 +32,7 @@ export default function CopyWithSyntaxHighlighting() {
 
 	return (
 		<div className="chbe-admin-editor-config__setting-item">
-			<HStack justify="start" alignment="start" wrap>
+			<Stack justify="start" align="start" wrap="wrap" gap="sm">
 				<ToggleControl
 					label={ title }
 					checked={ editorOptions.copyWithSyntaxHighlighting }
@@ -59,7 +60,7 @@ export default function CopyWithSyntaxHighlighting() {
 					] }
 					value={ editorOptions.copyWithSyntaxHighlighting }
 				/>
-			</HStack>
+			</Stack>
 		</div>
 	);
 }

--- a/src/admin/editor-config/editor-options/cursor-blinking.tsx
+++ b/src/admin/editor-config/editor-options/cursor-blinking.tsx
@@ -3,7 +3,8 @@
  */
 import { __ } from '@wordpress/i18n';
 import { useContext } from '@wordpress/element';
-import { SelectControl, __experimentalHStack as HStack } from '@wordpress/components';
+import { SelectControl } from '@wordpress/components';
+import { Stack } from '@wordpress/ui';
 
 /**
  * Internal dependencies
@@ -61,7 +62,7 @@ export default function CursorBlinking() {
 
 	return (
 		<div className="chbe-admin-editor-config__setting-item">
-			<HStack justify="start" alignment="start" wrap>
+			<Stack justify="start" align="start" wrap="wrap" gap="sm">
 				<SelectControl< EditorOptions[ 'cursorBlinking' ] >
 					__next40pxDefaultSize
 					label={ title }
@@ -76,7 +77,7 @@ export default function CursorBlinking() {
 					colCount="5"
 					value={ editorOptions.cursorBlinking }
 				/>
-			</HStack>
+			</Stack>
 		</div>
 	);
 }

--- a/src/admin/editor-config/editor-options/cursor-blinking.tsx
+++ b/src/admin/editor-config/editor-options/cursor-blinking.tsx
@@ -61,23 +61,27 @@ export default function CursorBlinking() {
 	};
 
 	return (
-		<div className="chbe-admin-editor-config__setting-item">
-			<Stack justify="start" align="start" wrap="wrap" gap="sm">
-				<SelectControl< EditorOptions[ 'cursorBlinking' ] >
-					__next40pxDefaultSize
-					label={ title }
-					value={ editorOptions.cursorBlinking }
-					options={ items.map( ( { label, value } ) => ( { label, value } ) ) }
-					onChange={ onChange }
-				/>
-				<ItemHelp
-					onChange={ onChange }
-					title={ title }
-					items={ items }
-					colCount="5"
-					value={ editorOptions.cursorBlinking }
-				/>
-			</Stack>
-		</div>
+		<Stack
+			className="chbe-admin-editor-config__setting-item"
+			justify="start"
+			align="start"
+			wrap="wrap"
+			gap="sm"
+		>
+			<SelectControl< EditorOptions[ 'cursorBlinking' ] >
+				__next40pxDefaultSize
+				label={ title }
+				value={ editorOptions.cursorBlinking }
+				options={ items.map( ( { label, value } ) => ( { label, value } ) ) }
+				onChange={ onChange }
+			/>
+			<ItemHelp
+				onChange={ onChange }
+				title={ title }
+				items={ items }
+				colCount="5"
+				value={ editorOptions.cursorBlinking }
+			/>
+		</Stack>
 	);
 }

--- a/src/admin/editor-config/editor-options/cursor-smooth-caret-animation.tsx
+++ b/src/admin/editor-config/editor-options/cursor-smooth-caret-animation.tsx
@@ -35,28 +35,32 @@ export default function CursorSmoothCaretAnimation() {
 	};
 
 	return (
-		<div className="chbe-admin-editor-config__setting-item">
-			<Stack justify="start" align="start" wrap="wrap" gap="sm">
-				<ToggleControl label={ title } checked={ isEnabled } onChange={ onChange } />
-				<ItemHelp
-					onChange={ onChange }
-					title={ title }
-					items={ [
-						{
-							label: __( 'Enable', 'custom-html-block-extension' ),
-							value: true,
-							image: 'editor-options/cursor-smooth-caret-animation_1.gif',
-						},
-						{
-							label: __( 'Disable', 'custom-html-block-extension' ),
-							value: false,
-							image: 'editor-options/cursor-smooth-caret-animation_2.gif',
-							isDefault: true,
-						},
-					] }
-					value={ isEnabled }
-				/>
-			</Stack>
-		</div>
+		<Stack
+			className="chbe-admin-editor-config__setting-item"
+			justify="start"
+			align="start"
+			wrap="wrap"
+			gap="sm"
+		>
+			<ToggleControl label={ title } checked={ isEnabled } onChange={ onChange } />
+			<ItemHelp
+				onChange={ onChange }
+				title={ title }
+				items={ [
+					{
+						label: __( 'Enable', 'custom-html-block-extension' ),
+						value: true,
+						image: 'editor-options/cursor-smooth-caret-animation_1.gif',
+					},
+					{
+						label: __( 'Disable', 'custom-html-block-extension' ),
+						value: false,
+						image: 'editor-options/cursor-smooth-caret-animation_2.gif',
+						isDefault: true,
+					},
+				] }
+				value={ isEnabled }
+			/>
+		</Stack>
 	);
 }

--- a/src/admin/editor-config/editor-options/cursor-smooth-caret-animation.tsx
+++ b/src/admin/editor-config/editor-options/cursor-smooth-caret-animation.tsx
@@ -3,7 +3,8 @@
  */
 import { __ } from '@wordpress/i18n';
 import { useContext } from '@wordpress/element';
-import { ToggleControl, __experimentalHStack as HStack } from '@wordpress/components';
+import { ToggleControl } from '@wordpress/components';
+import { Stack } from '@wordpress/ui';
 
 /**
  * Internal dependencies
@@ -35,7 +36,7 @@ export default function CursorSmoothCaretAnimation() {
 
 	return (
 		<div className="chbe-admin-editor-config__setting-item">
-			<HStack justify="start" alignment="start" wrap>
+			<Stack justify="start" align="start" wrap="wrap" gap="sm">
 				<ToggleControl label={ title } checked={ isEnabled } onChange={ onChange } />
 				<ItemHelp
 					onChange={ onChange }
@@ -55,7 +56,7 @@ export default function CursorSmoothCaretAnimation() {
 					] }
 					value={ isEnabled }
 				/>
-			</HStack>
+			</Stack>
 		</div>
 	);
 }

--- a/src/admin/editor-config/editor-options/cursor-style.tsx
+++ b/src/admin/editor-config/editor-options/cursor-style.tsx
@@ -3,7 +3,8 @@
  */
 import { __ } from '@wordpress/i18n';
 import { useContext } from '@wordpress/element';
-import { SelectControl, __experimentalHStack as HStack } from '@wordpress/components';
+import { SelectControl } from '@wordpress/components';
+import { Stack } from '@wordpress/ui';
 
 /**
  * Internal dependencies
@@ -66,7 +67,7 @@ export default function CursorStyle() {
 
 	return (
 		<div className="chbe-admin-editor-config__setting-item">
-			<HStack justify="start" alignment="start" wrap>
+			<Stack justify="start" align="start" wrap="wrap" gap="sm">
 				<SelectControl< EditorOptions[ 'cursorStyle' ] >
 					__next40pxDefaultSize
 					label={ title }
@@ -81,7 +82,7 @@ export default function CursorStyle() {
 					colCount="3"
 					value={ editorOptions.cursorStyle }
 				/>
-			</HStack>
+			</Stack>
 		</div>
 	);
 }

--- a/src/admin/editor-config/editor-options/cursor-style.tsx
+++ b/src/admin/editor-config/editor-options/cursor-style.tsx
@@ -66,23 +66,27 @@ export default function CursorStyle() {
 	};
 
 	return (
-		<div className="chbe-admin-editor-config__setting-item">
-			<Stack justify="start" align="start" wrap="wrap" gap="sm">
-				<SelectControl< EditorOptions[ 'cursorStyle' ] >
-					__next40pxDefaultSize
-					label={ title }
-					value={ editorOptions.cursorStyle }
-					options={ items.map( ( { label, value } ) => ( { label, value } ) ) }
-					onChange={ onChange }
-				/>
-				<ItemHelp
-					onChange={ onChange }
-					title={ title }
-					items={ items }
-					colCount="3"
-					value={ editorOptions.cursorStyle }
-				/>
-			</Stack>
-		</div>
+		<Stack
+			className="chbe-admin-editor-config__setting-item"
+			justify="start"
+			align="start"
+			wrap="wrap"
+			gap="sm"
+		>
+			<SelectControl< EditorOptions[ 'cursorStyle' ] >
+				__next40pxDefaultSize
+				label={ title }
+				value={ editorOptions.cursorStyle }
+				options={ items.map( ( { label, value } ) => ( { label, value } ) ) }
+				onChange={ onChange }
+			/>
+			<ItemHelp
+				onChange={ onChange }
+				title={ title }
+				items={ items }
+				colCount="3"
+				value={ editorOptions.cursorStyle }
+			/>
+		</Stack>
 	);
 }

--- a/src/admin/editor-config/editor-options/cursor-surrounding-lines-style.tsx
+++ b/src/admin/editor-config/editor-options/cursor-surrounding-lines-style.tsx
@@ -3,7 +3,8 @@
  */
 import { __ } from '@wordpress/i18n';
 import { useContext } from '@wordpress/element';
-import { ToggleControl, __experimentalHStack as HStack } from '@wordpress/components';
+import { ToggleControl } from '@wordpress/components';
+import { Stack } from '@wordpress/ui';
 
 /**
  * Internal dependencies
@@ -34,7 +35,7 @@ export default function CursorSurroundingLinesStyle() {
 
 	return (
 		<div className="chbe-admin-editor-config__setting-item">
-			<HStack justify="start" alignment="start" wrap>
+			<Stack justify="start" align="start" wrap="wrap" gap="sm">
 				<ToggleControl
 					label={ title }
 					checked={ 'all' === editorOptions.cursorSurroundingLinesStyle }
@@ -62,7 +63,7 @@ export default function CursorSurroundingLinesStyle() {
 					] }
 					value={ 'all' === editorOptions.cursorSurroundingLinesStyle }
 				/>
-			</HStack>
+			</Stack>
 		</div>
 	);
 }

--- a/src/admin/editor-config/editor-options/cursor-surrounding-lines-style.tsx
+++ b/src/admin/editor-config/editor-options/cursor-surrounding-lines-style.tsx
@@ -34,36 +34,40 @@ export default function CursorSurroundingLinesStyle() {
 	};
 
 	return (
-		<div className="chbe-admin-editor-config__setting-item">
-			<Stack justify="start" align="start" wrap="wrap" gap="sm">
-				<ToggleControl
-					label={ title }
-					checked={ 'all' === editorOptions.cursorSurroundingLinesStyle }
-					onChange={ onChange }
-				/>
-				<ItemHelp
-					onChange={ onChange }
-					title={ title }
-					description={ __(
-						'Sets the context menu when right-click in the editor.',
-						'custom-html-block-extension'
-					) }
-					items={ [
-						{
-							label: __( 'Enable', 'custom-html-block-extension' ),
-							value: true,
-							image: 'editor-options/cursor-surrounding-lines-style_1.gif',
-						},
-						{
-							label: __( 'Disable', 'custom-html-block-extension' ),
-							value: false,
-							image: 'editor-options/cursor-surrounding-lines-style_2.gif',
-							isDefault: true,
-						},
-					] }
-					value={ 'all' === editorOptions.cursorSurroundingLinesStyle }
-				/>
-			</Stack>
-		</div>
+		<Stack
+			className="chbe-admin-editor-config__setting-item"
+			justify="start"
+			align="start"
+			wrap="wrap"
+			gap="sm"
+		>
+			<ToggleControl
+				label={ title }
+				checked={ 'all' === editorOptions.cursorSurroundingLinesStyle }
+				onChange={ onChange }
+			/>
+			<ItemHelp
+				onChange={ onChange }
+				title={ title }
+				description={ __(
+					'Sets the context menu when right-click in the editor.',
+					'custom-html-block-extension'
+				) }
+				items={ [
+					{
+						label: __( 'Enable', 'custom-html-block-extension' ),
+						value: true,
+						image: 'editor-options/cursor-surrounding-lines-style_1.gif',
+					},
+					{
+						label: __( 'Disable', 'custom-html-block-extension' ),
+						value: false,
+						image: 'editor-options/cursor-surrounding-lines-style_2.gif',
+						isDefault: true,
+					},
+				] }
+				value={ 'all' === editorOptions.cursorSurroundingLinesStyle }
+			/>
+		</Stack>
 	);
 }

--- a/src/admin/editor-config/editor-options/cursor-surrounding-lines.tsx
+++ b/src/admin/editor-config/editor-options/cursor-surrounding-lines.tsx
@@ -3,7 +3,8 @@
  */
 import { __, sprintf } from '@wordpress/i18n';
 import { useContext } from '@wordpress/element';
-import { RangeControl, __experimentalHStack as HStack } from '@wordpress/components';
+import { RangeControl } from '@wordpress/components';
+import { Stack } from '@wordpress/ui';
 
 /**
  * Internal dependencies
@@ -35,7 +36,7 @@ export default function CursorSurroundingLines() {
 
 	return (
 		<div className="chbe-admin-editor-config__setting-item">
-			<HStack justify="start" alignment="start" wrap>
+			<Stack justify="start" align="start" wrap="wrap" gap="sm">
 				<RangeControl
 					__next40pxDefaultSize
 					label={ title }
@@ -74,7 +75,7 @@ export default function CursorSurroundingLines() {
 					] }
 					value={ editorOptions.cursorSurroundingLines }
 				/>
-			</HStack>
+			</Stack>
 		</div>
 	);
 }

--- a/src/admin/editor-config/editor-options/cursor-surrounding-lines.tsx
+++ b/src/admin/editor-config/editor-options/cursor-surrounding-lines.tsx
@@ -35,47 +35,51 @@ export default function CursorSurroundingLines() {
 	};
 
 	return (
-		<div className="chbe-admin-editor-config__setting-item">
-			<Stack justify="start" align="start" wrap="wrap" gap="sm">
-				<RangeControl
-					__next40pxDefaultSize
-					label={ title }
-					value={ editorOptions.cursorSurroundingLines }
-					min={ 0 }
-					max={ 20 }
-					allowReset
-					onChange={ onChange }
-				/>
-				<ItemHelp
-					onChange={ onChange }
-					title={ title }
-					description={ __(
-						'Sets the number of lines to keep before and after the cursor when the cursor is moved up and down.',
-						'custom-html-block-extension'
-					) }
-					items={ [
-						{
-							label: sprintf(
-								/* translators: %s is replaced with the number. */
-								__( 'Example: Set the value to %s', 'custom-html-block-extension' ),
-								'0'
-							),
-							image: 'editor-options/cursor-surrounding-lines_1.gif',
-							value: 0,
-						},
-						{
-							label: sprintf(
-								/* translators: %s is replaced with the number. */
-								__( 'Example: Set the value to %s', 'custom-html-block-extension' ),
-								'5'
-							),
-							image: 'editor-options/cursor-surrounding-lines_2.gif',
-							value: 5,
-						},
-					] }
-					value={ editorOptions.cursorSurroundingLines }
-				/>
-			</Stack>
-		</div>
+		<Stack
+			className="chbe-admin-editor-config__setting-item"
+			justify="start"
+			align="start"
+			wrap="wrap"
+			gap="sm"
+		>
+			<RangeControl
+				__next40pxDefaultSize
+				label={ title }
+				value={ editorOptions.cursorSurroundingLines }
+				min={ 0 }
+				max={ 20 }
+				allowReset
+				onChange={ onChange }
+			/>
+			<ItemHelp
+				onChange={ onChange }
+				title={ title }
+				description={ __(
+					'Sets the number of lines to keep before and after the cursor when the cursor is moved up and down.',
+					'custom-html-block-extension'
+				) }
+				items={ [
+					{
+						label: sprintf(
+							/* translators: %s is replaced with the number. */
+							__( 'Example: Set the value to %s', 'custom-html-block-extension' ),
+							'0'
+						),
+						image: 'editor-options/cursor-surrounding-lines_1.gif',
+						value: 0,
+					},
+					{
+						label: sprintf(
+							/* translators: %s is replaced with the number. */
+							__( 'Example: Set the value to %s', 'custom-html-block-extension' ),
+							'5'
+						),
+						image: 'editor-options/cursor-surrounding-lines_2.gif',
+						value: 5,
+					},
+				] }
+				value={ editorOptions.cursorSurroundingLines }
+			/>
+		</Stack>
 	);
 }

--- a/src/admin/editor-config/editor-options/drag-and-drop.tsx
+++ b/src/admin/editor-config/editor-options/drag-and-drop.tsx
@@ -31,22 +31,22 @@ export default function DragAndDrop() {
 	};
 
 	return (
-		<div className="chbe-admin-editor-config__setting-item">
-			<Stack justify="start" align="start" wrap="wrap" gap="sm">
-				<ToggleControl
-					label={ title }
-					checked={ editorOptions.dragAndDrop }
-					onChange={ onChange }
-				/>
-				<ItemHelp
-					onChange={ onChange }
-					title={ title }
-					isToggle
-					defaultToggle={ false }
-					image="editor-options/drag-and-drop.gif"
-					value={ editorOptions.dragAndDrop }
-				/>
-			</Stack>
-		</div>
+		<Stack
+			className="chbe-admin-editor-config__setting-item"
+			justify="start"
+			align="start"
+			wrap="wrap"
+			gap="sm"
+		>
+			<ToggleControl label={ title } checked={ editorOptions.dragAndDrop } onChange={ onChange } />
+			<ItemHelp
+				onChange={ onChange }
+				title={ title }
+				isToggle
+				defaultToggle={ false }
+				image="editor-options/drag-and-drop.gif"
+				value={ editorOptions.dragAndDrop }
+			/>
+		</Stack>
 	);
 }

--- a/src/admin/editor-config/editor-options/drag-and-drop.tsx
+++ b/src/admin/editor-config/editor-options/drag-and-drop.tsx
@@ -3,7 +3,8 @@
  */
 import { __ } from '@wordpress/i18n';
 import { useContext } from '@wordpress/element';
-import { ToggleControl, __experimentalHStack as HStack } from '@wordpress/components';
+import { ToggleControl } from '@wordpress/components';
+import { Stack } from '@wordpress/ui';
 
 /**
  * Internal dependencies
@@ -31,7 +32,7 @@ export default function DragAndDrop() {
 
 	return (
 		<div className="chbe-admin-editor-config__setting-item">
-			<HStack justify="start" alignment="start" wrap>
+			<Stack justify="start" align="start" wrap="wrap" gap="sm">
 				<ToggleControl
 					label={ title }
 					checked={ editorOptions.dragAndDrop }
@@ -45,7 +46,7 @@ export default function DragAndDrop() {
 					image="editor-options/drag-and-drop.gif"
 					value={ editorOptions.dragAndDrop }
 				/>
-			</HStack>
+			</Stack>
 		</div>
 	);
 }

--- a/src/admin/editor-config/editor-options/empty-selection-clipboard.tsx
+++ b/src/admin/editor-config/editor-options/empty-selection-clipboard.tsx
@@ -3,7 +3,8 @@
  */
 import { __ } from '@wordpress/i18n';
 import { useContext } from '@wordpress/element';
-import { ToggleControl, __experimentalHStack as HStack } from '@wordpress/components';
+import { ToggleControl } from '@wordpress/components';
+import { Stack } from '@wordpress/ui';
 
 /**
  * Internal dependencies
@@ -31,7 +32,7 @@ export default function EmptySelectionClipboard() {
 
 	return (
 		<div className="chbe-admin-editor-config__setting-item">
-			<HStack justify="start" alignment="start" wrap>
+			<Stack justify="start" align="start" wrap="wrap" gap="sm">
 				<ToggleControl
 					label={ title }
 					checked={ editorOptions.emptySelectionClipboard }
@@ -45,7 +46,7 @@ export default function EmptySelectionClipboard() {
 					image="editor-options/empty-selection-clipboard.gif"
 					value={ editorOptions.emptySelectionClipboard }
 				/>
-			</HStack>
+			</Stack>
 		</div>
 	);
 }

--- a/src/admin/editor-config/editor-options/empty-selection-clipboard.tsx
+++ b/src/admin/editor-config/editor-options/empty-selection-clipboard.tsx
@@ -31,22 +31,26 @@ export default function EmptySelectionClipboard() {
 	};
 
 	return (
-		<div className="chbe-admin-editor-config__setting-item">
-			<Stack justify="start" align="start" wrap="wrap" gap="sm">
-				<ToggleControl
-					label={ title }
-					checked={ editorOptions.emptySelectionClipboard }
-					onChange={ onChange }
-				/>
-				<ItemHelp
-					onChange={ onChange }
-					title={ title }
-					isToggle
-					defaultToggle
-					image="editor-options/empty-selection-clipboard.gif"
-					value={ editorOptions.emptySelectionClipboard }
-				/>
-			</Stack>
-		</div>
+		<Stack
+			className="chbe-admin-editor-config__setting-item"
+			justify="start"
+			align="start"
+			wrap="wrap"
+			gap="sm"
+		>
+			<ToggleControl
+				label={ title }
+				checked={ editorOptions.emptySelectionClipboard }
+				onChange={ onChange }
+			/>
+			<ItemHelp
+				onChange={ onChange }
+				title={ title }
+				isToggle
+				defaultToggle
+				image="editor-options/empty-selection-clipboard.gif"
+				value={ editorOptions.emptySelectionClipboard }
+			/>
+		</Stack>
 	);
 }

--- a/src/admin/editor-config/editor-options/find/addextra-space-on-top.tsx
+++ b/src/admin/editor-config/editor-options/find/addextra-space-on-top.tsx
@@ -3,7 +3,8 @@
  */
 import { __ } from '@wordpress/i18n';
 import { useContext } from '@wordpress/element';
-import { ToggleControl, __experimentalHStack as HStack } from '@wordpress/components';
+import { ToggleControl } from '@wordpress/components';
+import { Stack } from '@wordpress/ui';
 
 /**
  * Internal dependencies
@@ -34,7 +35,7 @@ export default function FindAddExtraSpaceOnTop() {
 
 	return (
 		<div className="chbe-admin-editor-config__setting-item">
-			<HStack justify="start" alignment="start" wrap>
+			<Stack justify="start" align="start" wrap="wrap" gap="sm">
 				<ToggleControl
 					label={ title }
 					checked={ editorOptions.find.addExtraSpaceOnTop }
@@ -58,7 +59,7 @@ export default function FindAddExtraSpaceOnTop() {
 					] }
 					value={ editorOptions.find.addExtraSpaceOnTop }
 				/>
-			</HStack>
+			</Stack>
 		</div>
 	);
 }

--- a/src/admin/editor-config/editor-options/find/addextra-space-on-top.tsx
+++ b/src/admin/editor-config/editor-options/find/addextra-space-on-top.tsx
@@ -34,32 +34,36 @@ export default function FindAddExtraSpaceOnTop() {
 	};
 
 	return (
-		<div className="chbe-admin-editor-config__setting-item">
-			<Stack justify="start" align="start" wrap="wrap" gap="sm">
-				<ToggleControl
-					label={ title }
-					checked={ editorOptions.find.addExtraSpaceOnTop }
-					onChange={ onChange }
-				/>
-				<ItemHelp
-					onChange={ onChange }
-					title={ title }
-					items={ [
-						{
-							label: __( 'Enable', 'custom-html-block-extension' ),
-							value: true,
-							image: 'editor-options/find/addextra-space-on-top_1.jpg',
-							isDefault: true,
-						},
-						{
-							label: __( 'Disable', 'custom-html-block-extension' ),
-							value: false,
-							image: 'editor-options/find/addextra-space-on-top_2.jpg',
-						},
-					] }
-					value={ editorOptions.find.addExtraSpaceOnTop }
-				/>
-			</Stack>
-		</div>
+		<Stack
+			className="chbe-admin-editor-config__setting-item"
+			justify="start"
+			align="start"
+			wrap="wrap"
+			gap="sm"
+		>
+			<ToggleControl
+				label={ title }
+				checked={ editorOptions.find.addExtraSpaceOnTop }
+				onChange={ onChange }
+			/>
+			<ItemHelp
+				onChange={ onChange }
+				title={ title }
+				items={ [
+					{
+						label: __( 'Enable', 'custom-html-block-extension' ),
+						value: true,
+						image: 'editor-options/find/addextra-space-on-top_1.jpg',
+						isDefault: true,
+					},
+					{
+						label: __( 'Disable', 'custom-html-block-extension' ),
+						value: false,
+						image: 'editor-options/find/addextra-space-on-top_2.jpg',
+					},
+				] }
+				value={ editorOptions.find.addExtraSpaceOnTop }
+			/>
+		</Stack>
 	);
 }

--- a/src/admin/editor-config/editor-options/find/loop.tsx
+++ b/src/admin/editor-config/editor-options/find/loop.tsx
@@ -3,7 +3,8 @@
  */
 import { __ } from '@wordpress/i18n';
 import { useContext } from '@wordpress/element';
-import { ToggleControl, __experimentalHStack as HStack } from '@wordpress/components';
+import { ToggleControl } from '@wordpress/components';
+import { Stack } from '@wordpress/ui';
 
 /**
  * Internal dependencies
@@ -34,7 +35,7 @@ export default function FindLoop() {
 
 	return (
 		<div className="chbe-admin-editor-config__setting-item">
-			<HStack justify="start" alignment="start" wrap>
+			<Stack justify="start" align="start" wrap="wrap" gap="sm">
 				<ToggleControl label={ title } checked={ editorOptions.find.loop } onChange={ onChange } />
 				<ItemHelp
 					onChange={ onChange }
@@ -48,7 +49,7 @@ export default function FindLoop() {
 					image="editor-options/find/loop.gif"
 					value={ editorOptions.find.loop }
 				/>
-			</HStack>
+			</Stack>
 		</div>
 	);
 }

--- a/src/admin/editor-config/editor-options/find/loop.tsx
+++ b/src/admin/editor-config/editor-options/find/loop.tsx
@@ -34,22 +34,26 @@ export default function FindLoop() {
 	};
 
 	return (
-		<div className="chbe-admin-editor-config__setting-item">
-			<Stack justify="start" align="start" wrap="wrap" gap="sm">
-				<ToggleControl label={ title } checked={ editorOptions.find.loop } onChange={ onChange } />
-				<ItemHelp
-					onChange={ onChange }
-					title={ title }
-					description={ __(
-						'Automatically restart the search from the beginning (or end) when no more matches are found.',
-						'custom-html-block-extension'
-					) }
-					isToggle
-					defaultToggle
-					image="editor-options/find/loop.gif"
-					value={ editorOptions.find.loop }
-				/>
-			</Stack>
-		</div>
+		<Stack
+			className="chbe-admin-editor-config__setting-item"
+			justify="start"
+			align="start"
+			wrap="wrap"
+			gap="sm"
+		>
+			<ToggleControl label={ title } checked={ editorOptions.find.loop } onChange={ onChange } />
+			<ItemHelp
+				onChange={ onChange }
+				title={ title }
+				description={ __(
+					'Automatically restart the search from the beginning (or end) when no more matches are found.',
+					'custom-html-block-extension'
+				) }
+				isToggle
+				defaultToggle
+				image="editor-options/find/loop.gif"
+				value={ editorOptions.find.loop }
+			/>
+		</Stack>
 	);
 }

--- a/src/admin/editor-config/editor-options/find/seed-search-string-from-selection.tsx
+++ b/src/admin/editor-config/editor-options/find/seed-search-string-from-selection.tsx
@@ -3,7 +3,8 @@
  */
 import { __ } from '@wordpress/i18n';
 import { useContext } from '@wordpress/element';
-import { ToggleControl, __experimentalHStack as HStack } from '@wordpress/components';
+import { ToggleControl } from '@wordpress/components';
+import { Stack } from '@wordpress/ui';
 
 /**
  * Internal dependencies
@@ -39,7 +40,7 @@ export default function FindSeedSearchStringFromSelection() {
 
 	return (
 		<div className="chbe-admin-editor-config__setting-item">
-			<HStack justify="start" alignment="start" wrap>
+			<Stack justify="start" align="start" wrap="wrap" gap="sm">
 				<ToggleControl label={ title } checked={ isEnabled } onChange={ onChange } />
 				<ItemHelp
 					onChange={ onChange }
@@ -49,7 +50,7 @@ export default function FindSeedSearchStringFromSelection() {
 					image="editor-options/find/seed-search-string-from-selection.gif"
 					value={ isEnabled }
 				/>
-			</HStack>
+			</Stack>
 		</div>
 	);
 }

--- a/src/admin/editor-config/editor-options/find/seed-search-string-from-selection.tsx
+++ b/src/admin/editor-config/editor-options/find/seed-search-string-from-selection.tsx
@@ -39,18 +39,22 @@ export default function FindSeedSearchStringFromSelection() {
 	};
 
 	return (
-		<div className="chbe-admin-editor-config__setting-item">
-			<Stack justify="start" align="start" wrap="wrap" gap="sm">
-				<ToggleControl label={ title } checked={ isEnabled } onChange={ onChange } />
-				<ItemHelp
-					onChange={ onChange }
-					title={ title }
-					isToggle
-					defaultToggle
-					image="editor-options/find/seed-search-string-from-selection.gif"
-					value={ isEnabled }
-				/>
-			</Stack>
-		</div>
+		<Stack
+			className="chbe-admin-editor-config__setting-item"
+			justify="start"
+			align="start"
+			wrap="wrap"
+			gap="sm"
+		>
+			<ToggleControl label={ title } checked={ isEnabled } onChange={ onChange } />
+			<ItemHelp
+				onChange={ onChange }
+				title={ title }
+				isToggle
+				defaultToggle
+				image="editor-options/find/seed-search-string-from-selection.gif"
+				value={ isEnabled }
+			/>
+		</Stack>
 	);
 }

--- a/src/admin/editor-config/editor-options/folding-highlight.tsx
+++ b/src/admin/editor-config/editor-options/folding-highlight.tsx
@@ -3,7 +3,8 @@
  */
 import { __ } from '@wordpress/i18n';
 import { useContext } from '@wordpress/element';
-import { ToggleControl, __experimentalHStack as HStack } from '@wordpress/components';
+import { ToggleControl } from '@wordpress/components';
+import { Stack } from '@wordpress/ui';
 
 /**
  * Internal dependencies
@@ -31,7 +32,7 @@ export default function FoldingHighlight() {
 
 	return (
 		<div className="chbe-admin-editor-config__setting-item">
-			<HStack justify="start" alignment="start" wrap>
+			<Stack justify="start" align="start" wrap="wrap" gap="sm">
 				<ToggleControl
 					label={ title }
 					checked={ editorOptions.foldingHighlight }
@@ -55,7 +56,7 @@ export default function FoldingHighlight() {
 					] }
 					value={ editorOptions.foldingHighlight }
 				/>
-			</HStack>
+			</Stack>
 		</div>
 	);
 }

--- a/src/admin/editor-config/editor-options/folding-highlight.tsx
+++ b/src/admin/editor-config/editor-options/folding-highlight.tsx
@@ -31,32 +31,36 @@ export default function FoldingHighlight() {
 	};
 
 	return (
-		<div className="chbe-admin-editor-config__setting-item">
-			<Stack justify="start" align="start" wrap="wrap" gap="sm">
-				<ToggleControl
-					label={ title }
-					checked={ editorOptions.foldingHighlight }
-					onChange={ onChange }
-				/>
-				<ItemHelp
-					onChange={ onChange }
-					title={ title }
-					items={ [
-						{
-							label: __( 'Enable', 'custom-html-block-extension' ),
-							value: true,
-							image: 'editor-options/folding-highlight_1.jpg',
-							isDefault: true,
-						},
-						{
-							label: __( 'Disable', 'custom-html-block-extension' ),
-							value: false,
-							image: 'editor-options/folding-highlight_2.jpg',
-						},
-					] }
-					value={ editorOptions.foldingHighlight }
-				/>
-			</Stack>
-		</div>
+		<Stack
+			className="chbe-admin-editor-config__setting-item"
+			justify="start"
+			align="start"
+			wrap="wrap"
+			gap="sm"
+		>
+			<ToggleControl
+				label={ title }
+				checked={ editorOptions.foldingHighlight }
+				onChange={ onChange }
+			/>
+			<ItemHelp
+				onChange={ onChange }
+				title={ title }
+				items={ [
+					{
+						label: __( 'Enable', 'custom-html-block-extension' ),
+						value: true,
+						image: 'editor-options/folding-highlight_1.jpg',
+						isDefault: true,
+					},
+					{
+						label: __( 'Disable', 'custom-html-block-extension' ),
+						value: false,
+						image: 'editor-options/folding-highlight_2.jpg',
+					},
+				] }
+				value={ editorOptions.foldingHighlight }
+			/>
+		</Stack>
 	);
 }

--- a/src/admin/editor-config/editor-options/folding-strategy.tsx
+++ b/src/admin/editor-config/editor-options/folding-strategy.tsx
@@ -3,7 +3,8 @@
  */
 import { __ } from '@wordpress/i18n';
 import { useContext } from '@wordpress/element';
-import { SelectControl, __experimentalHStack as HStack } from '@wordpress/components';
+import { SelectControl } from '@wordpress/components';
+import { Stack } from '@wordpress/ui';
 
 /**
  * Internal dependencies
@@ -50,7 +51,7 @@ export default function FoldingStrategy() {
 
 	return (
 		<div className="chbe-admin-editor-config__setting-item">
-			<HStack justify="start" alignment="start" wrap>
+			<Stack justify="start" align="start" wrap="wrap" gap="sm">
 				<SelectControl< EditorOptions[ 'foldingStrategy' ] >
 					__next40pxDefaultSize
 					label={ title }
@@ -64,7 +65,7 @@ export default function FoldingStrategy() {
 					items={ items }
 					value={ editorOptions.foldingStrategy }
 				/>
-			</HStack>
+			</Stack>
 		</div>
 	);
 }

--- a/src/admin/editor-config/editor-options/folding-strategy.tsx
+++ b/src/admin/editor-config/editor-options/folding-strategy.tsx
@@ -50,22 +50,26 @@ export default function FoldingStrategy() {
 	};
 
 	return (
-		<div className="chbe-admin-editor-config__setting-item">
-			<Stack justify="start" align="start" wrap="wrap" gap="sm">
-				<SelectControl< EditorOptions[ 'foldingStrategy' ] >
-					__next40pxDefaultSize
-					label={ title }
-					value={ editorOptions.foldingStrategy }
-					options={ items.map( ( { label, value } ) => ( { label, value } ) ) }
-					onChange={ onChange }
-				/>
-				<ItemHelp
-					onChange={ onChange }
-					title={ title }
-					items={ items }
-					value={ editorOptions.foldingStrategy }
-				/>
-			</Stack>
-		</div>
+		<Stack
+			className="chbe-admin-editor-config__setting-item"
+			justify="start"
+			align="start"
+			wrap="wrap"
+			gap="sm"
+		>
+			<SelectControl< EditorOptions[ 'foldingStrategy' ] >
+				__next40pxDefaultSize
+				label={ title }
+				value={ editorOptions.foldingStrategy }
+				options={ items.map( ( { label, value } ) => ( { label, value } ) ) }
+				onChange={ onChange }
+			/>
+			<ItemHelp
+				onChange={ onChange }
+				title={ title }
+				items={ items }
+				value={ editorOptions.foldingStrategy }
+			/>
+		</Stack>
 	);
 }

--- a/src/admin/editor-config/editor-options/folding.tsx
+++ b/src/admin/editor-config/editor-options/folding.tsx
@@ -3,7 +3,8 @@
  */
 import { __ } from '@wordpress/i18n';
 import { useContext } from '@wordpress/element';
-import { ToggleControl, __experimentalHStack as HStack } from '@wordpress/components';
+import { ToggleControl } from '@wordpress/components';
+import { Stack } from '@wordpress/ui';
 
 /**
  * Internal dependencies
@@ -31,7 +32,7 @@ export default function Folding() {
 
 	return (
 		<div className="chbe-admin-editor-config__setting-item">
-			<HStack justify="start" alignment="start" wrap>
+			<Stack justify="start" align="start" wrap="wrap" gap="sm">
 				<ToggleControl label={ title } checked={ editorOptions.folding } onChange={ onChange } />
 				<ItemHelp
 					onChange={ onChange }
@@ -45,7 +46,7 @@ export default function Folding() {
 					image="editor-options/folding.gif"
 					value={ editorOptions.folding }
 				/>
-			</HStack>
+			</Stack>
 		</div>
 	);
 }

--- a/src/admin/editor-config/editor-options/folding.tsx
+++ b/src/admin/editor-config/editor-options/folding.tsx
@@ -31,22 +31,26 @@ export default function Folding() {
 	};
 
 	return (
-		<div className="chbe-admin-editor-config__setting-item">
-			<Stack justify="start" align="start" wrap="wrap" gap="sm">
-				<ToggleControl label={ title } checked={ editorOptions.folding } onChange={ onChange } />
-				<ItemHelp
-					onChange={ onChange }
-					title={ title }
-					description={ __(
-						'You can fold regions of source code using the folding icons between line numbers and line start. Move the mouse over the folding icon and click to fold and unfold regions. Use Shift + Click on the folding icon to fold or unfold the region and all regions inside.',
-						'custom-html-block-extension'
-					) }
-					isToggle
-					defaultToggle
-					image="editor-options/folding.gif"
-					value={ editorOptions.folding }
-				/>
-			</Stack>
-		</div>
+		<Stack
+			className="chbe-admin-editor-config__setting-item"
+			justify="start"
+			align="start"
+			wrap="wrap"
+			gap="sm"
+		>
+			<ToggleControl label={ title } checked={ editorOptions.folding } onChange={ onChange } />
+			<ItemHelp
+				onChange={ onChange }
+				title={ title }
+				description={ __(
+					'You can fold regions of source code using the folding icons between line numbers and line start. Move the mouse over the folding icon and click to fold and unfold regions. Use Shift + Click on the folding icon to fold or unfold the region and all regions inside.',
+					'custom-html-block-extension'
+				) }
+				isToggle
+				defaultToggle
+				image="editor-options/folding.gif"
+				value={ editorOptions.folding }
+			/>
+		</Stack>
 	);
 }

--- a/src/admin/editor-config/editor-options/font-family.tsx
+++ b/src/admin/editor-config/editor-options/font-family.tsx
@@ -3,12 +3,8 @@
  */
 import { __ } from '@wordpress/i18n';
 import { useContext } from '@wordpress/element';
-import {
-	ExternalLink,
-	SelectControl,
-	__experimentalText as Text,
-	__experimentalHStack as HStack,
-} from '@wordpress/components';
+import { SelectControl } from '@wordpress/components';
+import { Link, Stack, Text } from '@wordpress/ui';
 
 /**
  * Internal dependencies
@@ -36,7 +32,7 @@ export default function FontFamily() {
 
 	return (
 		<div className="chbe-admin-editor-config__setting-item">
-			<HStack justify="start" alignment="start" wrap>
+			<Stack justify="start" align="start" wrap="wrap" gap="sm">
 				<SelectControl
 					__next40pxDefaultSize
 					label={ title }
@@ -57,26 +53,27 @@ export default function FontFamily() {
 					title={ title }
 					description={
 						<>
-							<Text as="p">
+							<Text render={ <p /> }>
 								{ __(
 									'You can use your own favorite fonts in addition to the default fonts. Please refer to the following document for instructions on how to add custom fonts.',
 									'custom-html-block-extension'
 								) }
 							</Text>
-							<Text as="p">
-								<ExternalLink
+							<Text render={ <p /> }>
+								<Link
 									href={ __(
 										'https://github.com/t-hamano/custom-html-block-extension#add-custom-fonts',
 										'custom-html-block-extension'
 									) }
+									openInNewTab
 								>
 									{ __( 'GitHub project page', 'custom-html-block-extension' ) }
-								</ExternalLink>
+								</Link>
 							</Text>
 						</>
 					}
 				/>
-			</HStack>
+			</Stack>
 		</div>
 	);
 }

--- a/src/admin/editor-config/editor-options/font-family.tsx
+++ b/src/admin/editor-config/editor-options/font-family.tsx
@@ -31,49 +31,53 @@ export default function FontFamily() {
 	};
 
 	return (
-		<div className="chbe-admin-editor-config__setting-item">
-			<Stack justify="start" align="start" wrap="wrap" gap="sm">
-				<SelectControl
-					__next40pxDefaultSize
-					label={ title }
-					value={ editorOptions.fontFamily }
-					options={ [
-						...window.chbeObj.fontFamily.map( ( { label, name } ) => ( {
-							label: label ?? name,
-							value: name,
-						} ) ),
-						{
-							label: __( 'Monospace', 'custom-html-block-extension' ),
-							value: 'monospace',
-						},
-					] }
-					onChange={ onChange }
-				/>
-				<ItemHelp
-					title={ title }
-					description={
-						<>
-							<Text render={ <p /> }>
-								{ __(
-									'You can use your own favorite fonts in addition to the default fonts. Please refer to the following document for instructions on how to add custom fonts.',
+		<Stack
+			className="chbe-admin-editor-config__setting-item"
+			justify="start"
+			align="start"
+			wrap="wrap"
+			gap="sm"
+		>
+			<SelectControl
+				__next40pxDefaultSize
+				label={ title }
+				value={ editorOptions.fontFamily }
+				options={ [
+					...window.chbeObj.fontFamily.map( ( { label, name } ) => ( {
+						label: label ?? name,
+						value: name,
+					} ) ),
+					{
+						label: __( 'Monospace', 'custom-html-block-extension' ),
+						value: 'monospace',
+					},
+				] }
+				onChange={ onChange }
+			/>
+			<ItemHelp
+				title={ title }
+				description={
+					<>
+						<Text render={ <p /> }>
+							{ __(
+								'You can use your own favorite fonts in addition to the default fonts. Please refer to the following document for instructions on how to add custom fonts.',
+								'custom-html-block-extension'
+							) }
+						</Text>
+						<Text render={ <p /> }>
+							<Link
+								href={ __(
+									'https://github.com/t-hamano/custom-html-block-extension#add-custom-fonts',
 									'custom-html-block-extension'
 								) }
-							</Text>
-							<Text render={ <p /> }>
-								<Link
-									href={ __(
-										'https://github.com/t-hamano/custom-html-block-extension#add-custom-fonts',
-										'custom-html-block-extension'
-									) }
-									openInNewTab
-								>
-									{ __( 'GitHub project page', 'custom-html-block-extension' ) }
-								</Link>
-							</Text>
-						</>
-					}
-				/>
-			</Stack>
-		</div>
+								openInNewTab
+							>
+								{ __( 'GitHub project page', 'custom-html-block-extension' ) }
+							</Link>
+						</Text>
+					</>
+				}
+			/>
+		</Stack>
 	);
 }

--- a/src/admin/editor-config/editor-options/font-ligatures.tsx
+++ b/src/admin/editor-config/editor-options/font-ligatures.tsx
@@ -3,7 +3,8 @@
  */
 import { __ } from '@wordpress/i18n';
 import { useContext } from '@wordpress/element';
-import { ToggleControl, __experimentalHStack as HStack } from '@wordpress/components';
+import { ToggleControl } from '@wordpress/components';
+import { Stack } from '@wordpress/ui';
 
 /**
  * Internal dependencies
@@ -31,7 +32,7 @@ export default function FontLigatures() {
 
 	return (
 		<div className="chbe-admin-editor-config__setting-item">
-			<HStack justify="start" alignment="start" wrap>
+			<Stack justify="start" align="start" wrap="wrap" gap="sm">
 				<ToggleControl
 					label={ title }
 					checked={ editorOptions.fontLigatures }
@@ -59,7 +60,7 @@ export default function FontLigatures() {
 					] }
 					value={ editorOptions.fontLigatures }
 				/>
-			</HStack>
+			</Stack>
 		</div>
 	);
 }

--- a/src/admin/editor-config/editor-options/font-ligatures.tsx
+++ b/src/admin/editor-config/editor-options/font-ligatures.tsx
@@ -31,36 +31,40 @@ export default function FontLigatures() {
 	};
 
 	return (
-		<div className="chbe-admin-editor-config__setting-item">
-			<Stack justify="start" align="start" wrap="wrap" gap="sm">
-				<ToggleControl
-					label={ title }
-					checked={ editorOptions.fontLigatures }
-					onChange={ onChange }
-				/>
-				<ItemHelp
-					onChange={ onChange }
-					title={ title }
-					description={ __(
-						'Ligatures are special characters in a font that combine two or more characters into one. Only Fira Code font supports ligatures.',
-						'custom-html-block-extension'
-					) }
-					items={ [
-						{
-							label: __( 'Enable', 'custom-html-block-extension' ),
-							value: true,
-							image: 'editor-options/font-ligatures_1.jpg',
-							isDefault: true,
-						},
-						{
-							label: __( 'Disable', 'custom-html-block-extension' ),
-							value: false,
-							image: 'editor-options/font-ligatures_2.jpg',
-						},
-					] }
-					value={ editorOptions.fontLigatures }
-				/>
-			</Stack>
-		</div>
+		<Stack
+			className="chbe-admin-editor-config__setting-item"
+			justify="start"
+			align="start"
+			wrap="wrap"
+			gap="sm"
+		>
+			<ToggleControl
+				label={ title }
+				checked={ editorOptions.fontLigatures }
+				onChange={ onChange }
+			/>
+			<ItemHelp
+				onChange={ onChange }
+				title={ title }
+				description={ __(
+					'Ligatures are special characters in a font that combine two or more characters into one. Only Fira Code font supports ligatures.',
+					'custom-html-block-extension'
+				) }
+				items={ [
+					{
+						label: __( 'Enable', 'custom-html-block-extension' ),
+						value: true,
+						image: 'editor-options/font-ligatures_1.jpg',
+						isDefault: true,
+					},
+					{
+						label: __( 'Disable', 'custom-html-block-extension' ),
+						value: false,
+						image: 'editor-options/font-ligatures_2.jpg',
+					},
+				] }
+				value={ editorOptions.fontLigatures }
+			/>
+		</Stack>
 	);
 }

--- a/src/admin/editor-config/editor-options/font-weight.tsx
+++ b/src/admin/editor-config/editor-options/font-weight.tsx
@@ -34,19 +34,17 @@ export default function FontWeight( { fontWeights }: FontWeightProps ) {
 	};
 
 	return (
-		<div className="chbe-admin-editor-config__setting-item">
-			<Stack gap="sm">
-				<SelectControl
-					__next40pxDefaultSize
-					label={ title }
-					value={ String( editorOptions.fontWeight ) }
-					options={ fontWeights.map( ( fontWeight ) => ( {
-						label: String( fontWeight ),
-						value: String( fontWeight ),
-					} ) ) }
-					onChange={ onChange }
-				/>
-			</Stack>
-		</div>
+		<Stack className="chbe-admin-editor-config__setting-item" gap="sm">
+			<SelectControl
+				__next40pxDefaultSize
+				label={ title }
+				value={ String( editorOptions.fontWeight ) }
+				options={ fontWeights.map( ( fontWeight ) => ( {
+					label: String( fontWeight ),
+					value: String( fontWeight ),
+				} ) ) }
+				onChange={ onChange }
+			/>
+		</Stack>
 	);
 }

--- a/src/admin/editor-config/editor-options/font-weight.tsx
+++ b/src/admin/editor-config/editor-options/font-weight.tsx
@@ -3,7 +3,8 @@
  */
 import { __ } from '@wordpress/i18n';
 import { useContext } from '@wordpress/element';
-import { SelectControl, __experimentalHStack as HStack } from '@wordpress/components';
+import { SelectControl } from '@wordpress/components';
+import { Stack } from '@wordpress/ui';
 
 /**
  * Internal dependencies
@@ -34,7 +35,7 @@ export default function FontWeight( { fontWeights }: FontWeightProps ) {
 
 	return (
 		<div className="chbe-admin-editor-config__setting-item">
-			<HStack>
+			<Stack gap="sm">
 				<SelectControl
 					__next40pxDefaultSize
 					label={ title }
@@ -45,7 +46,7 @@ export default function FontWeight( { fontWeights }: FontWeightProps ) {
 					} ) ) }
 					onChange={ onChange }
 				/>
-			</HStack>
+			</Stack>
 		</div>
 	);
 }

--- a/src/admin/editor-config/editor-options/format-on-paste.tsx
+++ b/src/admin/editor-config/editor-options/format-on-paste.tsx
@@ -31,32 +31,36 @@ export default function FormatOnPaste() {
 	};
 
 	return (
-		<div className="chbe-admin-editor-config__setting-item">
-			<Stack justify="start" align="start" wrap="wrap" gap="sm">
-				<ToggleControl
-					label={ title }
-					checked={ editorOptions.formatOnPaste }
-					onChange={ onChange }
-				/>
-				<ItemHelp
-					onChange={ onChange }
-					title={ title }
-					items={ [
-						{
-							label: __( 'Enable', 'custom-html-block-extension' ),
-							value: true,
-							image: 'editor-options/format-on-paste_1.gif',
-						},
-						{
-							label: __( 'Disable', 'custom-html-block-extension' ),
-							value: false,
-							isDefault: true,
-							image: 'editor-options/format-on-paste_2.gif',
-						},
-					] }
-					value={ editorOptions.formatOnPaste }
-				/>
-			</Stack>
-		</div>
+		<Stack
+			className="chbe-admin-editor-config__setting-item"
+			justify="start"
+			align="start"
+			wrap="wrap"
+			gap="sm"
+		>
+			<ToggleControl
+				label={ title }
+				checked={ editorOptions.formatOnPaste }
+				onChange={ onChange }
+			/>
+			<ItemHelp
+				onChange={ onChange }
+				title={ title }
+				items={ [
+					{
+						label: __( 'Enable', 'custom-html-block-extension' ),
+						value: true,
+						image: 'editor-options/format-on-paste_1.gif',
+					},
+					{
+						label: __( 'Disable', 'custom-html-block-extension' ),
+						value: false,
+						isDefault: true,
+						image: 'editor-options/format-on-paste_2.gif',
+					},
+				] }
+				value={ editorOptions.formatOnPaste }
+			/>
+		</Stack>
 	);
 }

--- a/src/admin/editor-config/editor-options/format-on-paste.tsx
+++ b/src/admin/editor-config/editor-options/format-on-paste.tsx
@@ -3,7 +3,8 @@
  */
 import { __ } from '@wordpress/i18n';
 import { useContext } from '@wordpress/element';
-import { ToggleControl, __experimentalHStack as HStack } from '@wordpress/components';
+import { ToggleControl } from '@wordpress/components';
+import { Stack } from '@wordpress/ui';
 
 /**
  * Internal dependencies
@@ -31,7 +32,7 @@ export default function FormatOnPaste() {
 
 	return (
 		<div className="chbe-admin-editor-config__setting-item">
-			<HStack justify="start" alignment="start" wrap>
+			<Stack justify="start" align="start" wrap="wrap" gap="sm">
 				<ToggleControl
 					label={ title }
 					checked={ editorOptions.formatOnPaste }
@@ -55,7 +56,7 @@ export default function FormatOnPaste() {
 					] }
 					value={ editorOptions.formatOnPaste }
 				/>
-			</HStack>
+			</Stack>
 		</div>
 	);
 }

--- a/src/admin/editor-config/editor-options/glyph-margin.tsx
+++ b/src/admin/editor-config/editor-options/glyph-margin.tsx
@@ -31,36 +31,36 @@ export default function GlyphMargin() {
 	};
 
 	return (
-		<div className="chbe-admin-editor-config__setting-item">
-			<Stack justify="start" align="start" wrap="wrap" gap="sm">
-				<ToggleControl
-					label={ title }
-					checked={ editorOptions.glyphMargin }
-					onChange={ onChange }
-				/>
-				<ItemHelp
-					onChange={ onChange }
-					title={ title }
-					description={ __(
-						'Margin at the left edge of the editor.',
-						'custom-html-block-extension'
-					) }
-					items={ [
-						{
-							label: __( 'Enable', 'custom-html-block-extension' ),
-							value: true,
-							image: 'editor-options/glyph-margin_1.jpg',
-						},
-						{
-							label: __( 'Disable', 'custom-html-block-extension' ),
-							value: false,
-							image: 'editor-options/glyph-margin_2.jpg',
-							isDefault: true,
-						},
-					] }
-					value={ editorOptions.glyphMargin }
-				/>
-			</Stack>
-		</div>
+		<Stack
+			className="chbe-admin-editor-config__setting-item"
+			justify="start"
+			align="start"
+			wrap="wrap"
+			gap="sm"
+		>
+			<ToggleControl label={ title } checked={ editorOptions.glyphMargin } onChange={ onChange } />
+			<ItemHelp
+				onChange={ onChange }
+				title={ title }
+				description={ __(
+					'Margin at the left edge of the editor.',
+					'custom-html-block-extension'
+				) }
+				items={ [
+					{
+						label: __( 'Enable', 'custom-html-block-extension' ),
+						value: true,
+						image: 'editor-options/glyph-margin_1.jpg',
+					},
+					{
+						label: __( 'Disable', 'custom-html-block-extension' ),
+						value: false,
+						image: 'editor-options/glyph-margin_2.jpg',
+						isDefault: true,
+					},
+				] }
+				value={ editorOptions.glyphMargin }
+			/>
+		</Stack>
 	);
 }

--- a/src/admin/editor-config/editor-options/glyph-margin.tsx
+++ b/src/admin/editor-config/editor-options/glyph-margin.tsx
@@ -3,7 +3,8 @@
  */
 import { __ } from '@wordpress/i18n';
 import { useContext } from '@wordpress/element';
-import { ToggleControl, __experimentalHStack as HStack } from '@wordpress/components';
+import { ToggleControl } from '@wordpress/components';
+import { Stack } from '@wordpress/ui';
 
 /**
  * Internal dependencies
@@ -31,7 +32,7 @@ export default function GlyphMargin() {
 
 	return (
 		<div className="chbe-admin-editor-config__setting-item">
-			<HStack justify="start" alignment="start" wrap>
+			<Stack justify="start" align="start" wrap="wrap" gap="sm">
 				<ToggleControl
 					label={ title }
 					checked={ editorOptions.glyphMargin }
@@ -59,7 +60,7 @@ export default function GlyphMargin() {
 					] }
 					value={ editorOptions.glyphMargin }
 				/>
-			</HStack>
+			</Stack>
 		</div>
 	);
 }

--- a/src/admin/editor-config/editor-options/hide-cursor-in-overview-ruler.tsx
+++ b/src/admin/editor-config/editor-options/hide-cursor-in-overview-ruler.tsx
@@ -31,32 +31,36 @@ export default function HideCursorInOverviewRuler() {
 	};
 
 	return (
-		<div className="chbe-admin-editor-config__setting-item">
-			<Stack justify="start" align="start" wrap="wrap" gap="sm">
-				<ToggleControl
-					label={ title }
-					checked={ editorOptions.hideCursorInOverviewRuler }
-					onChange={ onChange }
-				/>
-				<ItemHelp
-					onChange={ onChange }
-					title={ title }
-					items={ [
-						{
-							label: __( 'Enable', 'custom-html-block-extension' ),
-							value: true,
-							image: 'editor-options/hide-cursor-in-overview-ruler_1.jpg',
-						},
-						{
-							label: __( 'Disable', 'custom-html-block-extension' ),
-							value: false,
-							image: 'editor-options/hide-cursor-in-overview-ruler_2.jpg',
-							isDefault: true,
-						},
-					] }
-					value={ editorOptions.hideCursorInOverviewRuler }
-				/>
-			</Stack>
-		</div>
+		<Stack
+			className="chbe-admin-editor-config__setting-item"
+			justify="start"
+			align="start"
+			wrap="wrap"
+			gap="sm"
+		>
+			<ToggleControl
+				label={ title }
+				checked={ editorOptions.hideCursorInOverviewRuler }
+				onChange={ onChange }
+			/>
+			<ItemHelp
+				onChange={ onChange }
+				title={ title }
+				items={ [
+					{
+						label: __( 'Enable', 'custom-html-block-extension' ),
+						value: true,
+						image: 'editor-options/hide-cursor-in-overview-ruler_1.jpg',
+					},
+					{
+						label: __( 'Disable', 'custom-html-block-extension' ),
+						value: false,
+						image: 'editor-options/hide-cursor-in-overview-ruler_2.jpg',
+						isDefault: true,
+					},
+				] }
+				value={ editorOptions.hideCursorInOverviewRuler }
+			/>
+		</Stack>
 	);
 }

--- a/src/admin/editor-config/editor-options/hide-cursor-in-overview-ruler.tsx
+++ b/src/admin/editor-config/editor-options/hide-cursor-in-overview-ruler.tsx
@@ -3,7 +3,8 @@
  */
 import { __ } from '@wordpress/i18n';
 import { useContext } from '@wordpress/element';
-import { ToggleControl, __experimentalHStack as HStack } from '@wordpress/components';
+import { ToggleControl } from '@wordpress/components';
+import { Stack } from '@wordpress/ui';
 
 /**
  * Internal dependencies
@@ -31,7 +32,7 @@ export default function HideCursorInOverviewRuler() {
 
 	return (
 		<div className="chbe-admin-editor-config__setting-item">
-			<HStack justify="start" alignment="start" wrap>
+			<Stack justify="start" align="start" wrap="wrap" gap="sm">
 				<ToggleControl
 					label={ title }
 					checked={ editorOptions.hideCursorInOverviewRuler }
@@ -55,7 +56,7 @@ export default function HideCursorInOverviewRuler() {
 					] }
 					value={ editorOptions.hideCursorInOverviewRuler }
 				/>
-			</HStack>
+			</Stack>
 		</div>
 	);
 }

--- a/src/admin/editor-config/editor-options/highlight-active-indent-guide.tsx
+++ b/src/admin/editor-config/editor-options/highlight-active-indent-guide.tsx
@@ -3,7 +3,8 @@
  */
 import { __ } from '@wordpress/i18n';
 import { useContext } from '@wordpress/element';
-import { ToggleControl, __experimentalHStack as HStack } from '@wordpress/components';
+import { ToggleControl } from '@wordpress/components';
+import { Stack } from '@wordpress/ui';
 
 /**
  * Internal dependencies
@@ -31,7 +32,7 @@ export default function HighlightActiveIndentGuide() {
 
 	return (
 		<div className="chbe-admin-editor-config__setting-item">
-			<HStack justify="start" alignment="start" wrap>
+			<Stack justify="start" align="start" wrap="wrap" gap="sm">
 				<ToggleControl
 					label={ title }
 					checked={ editorOptions.highlightActiveIndentGuide }
@@ -55,7 +56,7 @@ export default function HighlightActiveIndentGuide() {
 					] }
 					value={ editorOptions.highlightActiveIndentGuide }
 				/>
-			</HStack>
+			</Stack>
 		</div>
 	);
 }

--- a/src/admin/editor-config/editor-options/highlight-active-indent-guide.tsx
+++ b/src/admin/editor-config/editor-options/highlight-active-indent-guide.tsx
@@ -31,32 +31,36 @@ export default function HighlightActiveIndentGuide() {
 	};
 
 	return (
-		<div className="chbe-admin-editor-config__setting-item">
-			<Stack justify="start" align="start" wrap="wrap" gap="sm">
-				<ToggleControl
-					label={ title }
-					checked={ editorOptions.highlightActiveIndentGuide }
-					onChange={ onChange }
-				/>
-				<ItemHelp
-					onChange={ onChange }
-					title={ title }
-					items={ [
-						{
-							label: __( 'Enable', 'custom-html-block-extension' ),
-							value: true,
-							image: 'editor-options/highlight-active-indent-guide_1.gif',
-							isDefault: true,
-						},
-						{
-							label: __( 'Disable', 'custom-html-block-extension' ),
-							value: false,
-							image: 'editor-options/highlight-active-indent-guide_2.gif',
-						},
-					] }
-					value={ editorOptions.highlightActiveIndentGuide }
-				/>
-			</Stack>
-		</div>
+		<Stack
+			className="chbe-admin-editor-config__setting-item"
+			justify="start"
+			align="start"
+			wrap="wrap"
+			gap="sm"
+		>
+			<ToggleControl
+				label={ title }
+				checked={ editorOptions.highlightActiveIndentGuide }
+				onChange={ onChange }
+			/>
+			<ItemHelp
+				onChange={ onChange }
+				title={ title }
+				items={ [
+					{
+						label: __( 'Enable', 'custom-html-block-extension' ),
+						value: true,
+						image: 'editor-options/highlight-active-indent-guide_1.gif',
+						isDefault: true,
+					},
+					{
+						label: __( 'Disable', 'custom-html-block-extension' ),
+						value: false,
+						image: 'editor-options/highlight-active-indent-guide_2.gif',
+					},
+				] }
+				value={ editorOptions.highlightActiveIndentGuide }
+			/>
+		</Stack>
 	);
 }

--- a/src/admin/editor-config/editor-options/hover.tsx
+++ b/src/admin/editor-config/editor-options/hover.tsx
@@ -34,22 +34,26 @@ export default function Hover() {
 	};
 
 	return (
-		<div className="chbe-admin-editor-config__setting-item">
-			<Stack justify="start" align="start" wrap="wrap" gap="sm">
-				<ToggleControl
-					label={ title }
-					checked={ editorOptions.hover.enabled }
-					onChange={ onChange }
-				/>
-				<ItemHelp
-					onChange={ onChange }
-					title={ title }
-					isToggle
-					defaultToggle
-					image="editor-options/hover.gif"
-					value={ editorOptions.hover.enabled }
-				/>
-			</Stack>
-		</div>
+		<Stack
+			className="chbe-admin-editor-config__setting-item"
+			justify="start"
+			align="start"
+			wrap="wrap"
+			gap="sm"
+		>
+			<ToggleControl
+				label={ title }
+				checked={ editorOptions.hover.enabled }
+				onChange={ onChange }
+			/>
+			<ItemHelp
+				onChange={ onChange }
+				title={ title }
+				isToggle
+				defaultToggle
+				image="editor-options/hover.gif"
+				value={ editorOptions.hover.enabled }
+			/>
+		</Stack>
 	);
 }

--- a/src/admin/editor-config/editor-options/hover.tsx
+++ b/src/admin/editor-config/editor-options/hover.tsx
@@ -3,7 +3,8 @@
  */
 import { __ } from '@wordpress/i18n';
 import { useContext } from '@wordpress/element';
-import { ToggleControl, __experimentalHStack as HStack } from '@wordpress/components';
+import { ToggleControl } from '@wordpress/components';
+import { Stack } from '@wordpress/ui';
 
 /**
  * Internal dependencies
@@ -34,7 +35,7 @@ export default function Hover() {
 
 	return (
 		<div className="chbe-admin-editor-config__setting-item">
-			<HStack justify="start" alignment="start" wrap>
+			<Stack justify="start" align="start" wrap="wrap" gap="sm">
 				<ToggleControl
 					label={ title }
 					checked={ editorOptions.hover.enabled }
@@ -48,7 +49,7 @@ export default function Hover() {
 					image="editor-options/hover.gif"
 					value={ editorOptions.hover.enabled }
 				/>
-			</HStack>
+			</Stack>
 		</div>
 	);
 }

--- a/src/admin/editor-config/editor-options/line-decorations-width.tsx
+++ b/src/admin/editor-config/editor-options/line-decorations-width.tsx
@@ -32,24 +32,28 @@ export default function LineDecorationsWidth() {
 	};
 
 	return (
-		<div className="chbe-admin-editor-config__setting-item">
-			<Stack justify="start" align="start" wrap="wrap" gap="sm">
-				<RangeControl
-					__next40pxDefaultSize
-					label={ title }
-					value={ editorOptions.lineDecorationsWidth }
-					min={ 0 }
-					max={ 30 }
-					allowReset
-					onChange={ onChange }
-				/>
-				<ItemHelp
-					onChange={ onChange }
-					title={ title }
-					image="editor-options/line-decorations-width.gif"
-					value={ editorOptions.lineDecorationsWidth }
-				/>
-			</Stack>
-		</div>
+		<Stack
+			className="chbe-admin-editor-config__setting-item"
+			justify="start"
+			align="start"
+			wrap="wrap"
+			gap="sm"
+		>
+			<RangeControl
+				__next40pxDefaultSize
+				label={ title }
+				value={ editorOptions.lineDecorationsWidth }
+				min={ 0 }
+				max={ 30 }
+				allowReset
+				onChange={ onChange }
+			/>
+			<ItemHelp
+				onChange={ onChange }
+				title={ title }
+				image="editor-options/line-decorations-width.gif"
+				value={ editorOptions.lineDecorationsWidth }
+			/>
+		</Stack>
 	);
 }

--- a/src/admin/editor-config/editor-options/line-decorations-width.tsx
+++ b/src/admin/editor-config/editor-options/line-decorations-width.tsx
@@ -3,7 +3,8 @@
  */
 import { __ } from '@wordpress/i18n';
 import { useContext } from '@wordpress/element';
-import { RangeControl, __experimentalHStack as HStack } from '@wordpress/components';
+import { RangeControl } from '@wordpress/components';
+import { Stack } from '@wordpress/ui';
 
 /**
  * Internal dependencies
@@ -32,7 +33,7 @@ export default function LineDecorationsWidth() {
 
 	return (
 		<div className="chbe-admin-editor-config__setting-item">
-			<HStack justify="start" alignment="start" wrap>
+			<Stack justify="start" align="start" wrap="wrap" gap="sm">
 				<RangeControl
 					__next40pxDefaultSize
 					label={ title }
@@ -48,7 +49,7 @@ export default function LineDecorationsWidth() {
 					image="editor-options/line-decorations-width.gif"
 					value={ editorOptions.lineDecorationsWidth }
 				/>
-			</HStack>
+			</Stack>
 		</div>
 	);
 }

--- a/src/admin/editor-config/editor-options/line-numbers-min-chars.tsx
+++ b/src/admin/editor-config/editor-options/line-numbers-min-chars.tsx
@@ -3,7 +3,8 @@
  */
 import { __ } from '@wordpress/i18n';
 import { useContext } from '@wordpress/element';
-import { RangeControl, __experimentalHStack as HStack } from '@wordpress/components';
+import { RangeControl } from '@wordpress/components';
+import { Stack } from '@wordpress/ui';
 
 /**
  * Internal dependencies
@@ -32,7 +33,7 @@ export default function LineNumbersMinChars() {
 
 	return (
 		<div className="chbe-admin-editor-config__setting-item">
-			<HStack justify="start" alignment="start" wrap>
+			<Stack justify="start" align="start" wrap="wrap" gap="sm">
 				<RangeControl
 					__next40pxDefaultSize
 					label={ title }
@@ -43,7 +44,7 @@ export default function LineNumbersMinChars() {
 					onChange={ onChange }
 				/>
 				<ItemHelp title={ title } image="editor-options/line-numbers-min-chars.gif" />
-			</HStack>
+			</Stack>
 		</div>
 	);
 }

--- a/src/admin/editor-config/editor-options/line-numbers-min-chars.tsx
+++ b/src/admin/editor-config/editor-options/line-numbers-min-chars.tsx
@@ -32,19 +32,23 @@ export default function LineNumbersMinChars() {
 	};
 
 	return (
-		<div className="chbe-admin-editor-config__setting-item">
-			<Stack justify="start" align="start" wrap="wrap" gap="sm">
-				<RangeControl
-					__next40pxDefaultSize
-					label={ title }
-					value={ editorOptions.lineNumbersMinChars }
-					min={ 1 }
-					max={ 10 }
-					allowReset
-					onChange={ onChange }
-				/>
-				<ItemHelp title={ title } image="editor-options/line-numbers-min-chars.gif" />
-			</Stack>
-		</div>
+		<Stack
+			className="chbe-admin-editor-config__setting-item"
+			justify="start"
+			align="start"
+			wrap="wrap"
+			gap="sm"
+		>
+			<RangeControl
+				__next40pxDefaultSize
+				label={ title }
+				value={ editorOptions.lineNumbersMinChars }
+				min={ 1 }
+				max={ 10 }
+				allowReset
+				onChange={ onChange }
+			/>
+			<ItemHelp title={ title } image="editor-options/line-numbers-min-chars.gif" />
+		</Stack>
 	);
 }

--- a/src/admin/editor-config/editor-options/line-numbers.tsx
+++ b/src/admin/editor-config/editor-options/line-numbers.tsx
@@ -56,23 +56,27 @@ export default function LineNumbers() {
 	};
 
 	return (
-		<div className="chbe-admin-editor-config__setting-item">
-			<Stack justify="start" align="start" wrap="wrap" gap="sm">
-				<SelectControl< EditorOptions[ 'lineNumbers' ] >
-					__next40pxDefaultSize
-					label={ title }
-					value={ editorOptions.lineNumbers }
-					options={ items.map( ( { label, value } ) => ( { label, value } ) ) }
-					onChange={ onChange }
-				/>
-				<ItemHelp
-					onChange={ onChange }
-					title={ title }
-					items={ items }
-					colCount="4"
-					value={ editorOptions.lineNumbers }
-				/>
-			</Stack>
-		</div>
+		<Stack
+			className="chbe-admin-editor-config__setting-item"
+			justify="start"
+			align="start"
+			wrap="wrap"
+			gap="sm"
+		>
+			<SelectControl< EditorOptions[ 'lineNumbers' ] >
+				__next40pxDefaultSize
+				label={ title }
+				value={ editorOptions.lineNumbers }
+				options={ items.map( ( { label, value } ) => ( { label, value } ) ) }
+				onChange={ onChange }
+			/>
+			<ItemHelp
+				onChange={ onChange }
+				title={ title }
+				items={ items }
+				colCount="4"
+				value={ editorOptions.lineNumbers }
+			/>
+		</Stack>
 	);
 }

--- a/src/admin/editor-config/editor-options/line-numbers.tsx
+++ b/src/admin/editor-config/editor-options/line-numbers.tsx
@@ -3,7 +3,8 @@
  */
 import { __ } from '@wordpress/i18n';
 import { useContext } from '@wordpress/element';
-import { SelectControl, __experimentalHStack as HStack } from '@wordpress/components';
+import { SelectControl } from '@wordpress/components';
+import { Stack } from '@wordpress/ui';
 
 /**
  * Internal dependencies
@@ -56,7 +57,7 @@ export default function LineNumbers() {
 
 	return (
 		<div className="chbe-admin-editor-config__setting-item">
-			<HStack justify="start" alignment="start" wrap>
+			<Stack justify="start" align="start" wrap="wrap" gap="sm">
 				<SelectControl< EditorOptions[ 'lineNumbers' ] >
 					__next40pxDefaultSize
 					label={ title }
@@ -71,7 +72,7 @@ export default function LineNumbers() {
 					colCount="4"
 					value={ editorOptions.lineNumbers }
 				/>
-			</HStack>
+			</Stack>
 		</div>
 	);
 }

--- a/src/admin/editor-config/editor-options/links.tsx
+++ b/src/admin/editor-config/editor-options/links.tsx
@@ -3,7 +3,8 @@
  */
 import { __ } from '@wordpress/i18n';
 import { useContext } from '@wordpress/element';
-import { ToggleControl, __experimentalHStack as HStack } from '@wordpress/components';
+import { ToggleControl } from '@wordpress/components';
+import { Stack } from '@wordpress/ui';
 
 /**
  * Internal dependencies
@@ -34,7 +35,7 @@ export default function Links() {
 
 	return (
 		<div className="chbe-admin-editor-config__setting-item">
-			<HStack justify="start" alignment="start" wrap>
+			<Stack justify="start" align="start" wrap="wrap" gap="sm">
 				<ToggleControl label={ title } checked={ editorOptions.links } onChange={ onChange } />
 				<ItemHelp
 					onChange={ onChange }
@@ -54,7 +55,7 @@ export default function Links() {
 					] }
 					value={ editorOptions.links }
 				/>
-			</HStack>
+			</Stack>
 		</div>
 	);
 }

--- a/src/admin/editor-config/editor-options/links.tsx
+++ b/src/admin/editor-config/editor-options/links.tsx
@@ -34,28 +34,32 @@ export default function Links() {
 	};
 
 	return (
-		<div className="chbe-admin-editor-config__setting-item">
-			<Stack justify="start" align="start" wrap="wrap" gap="sm">
-				<ToggleControl label={ title } checked={ editorOptions.links } onChange={ onChange } />
-				<ItemHelp
-					onChange={ onChange }
-					title={ title }
-					items={ [
-						{
-							label: __( 'Enable', 'custom-html-block-extension' ),
-							image: 'editor-options/links_1.jpg',
-							value: true,
-							isDefault: true,
-						},
-						{
-							label: __( 'Disable', 'custom-html-block-extension' ),
-							image: 'editor-options/links_2.jpg',
-							value: false,
-						},
-					] }
-					value={ editorOptions.links }
-				/>
-			</Stack>
-		</div>
+		<Stack
+			className="chbe-admin-editor-config__setting-item"
+			justify="start"
+			align="start"
+			wrap="wrap"
+			gap="sm"
+		>
+			<ToggleControl label={ title } checked={ editorOptions.links } onChange={ onChange } />
+			<ItemHelp
+				onChange={ onChange }
+				title={ title }
+				items={ [
+					{
+						label: __( 'Enable', 'custom-html-block-extension' ),
+						image: 'editor-options/links_1.jpg',
+						value: true,
+						isDefault: true,
+					},
+					{
+						label: __( 'Disable', 'custom-html-block-extension' ),
+						image: 'editor-options/links_2.jpg',
+						value: false,
+					},
+				] }
+				value={ editorOptions.links }
+			/>
+		</Stack>
 	);
 }

--- a/src/admin/editor-config/editor-options/match-brackets.tsx
+++ b/src/admin/editor-config/editor-options/match-brackets.tsx
@@ -51,23 +51,27 @@ export default function MatchBrackets() {
 	};
 
 	return (
-		<div className="chbe-admin-editor-config__setting-item">
-			<Stack justify="start" align="start" wrap="wrap" gap="sm">
-				<SelectControl< EditorOptions[ 'matchBrackets' ] >
-					__next40pxDefaultSize
-					label={ title }
-					value={ editorOptions.matchBrackets }
-					options={ items.map( ( { label, value } ) => ( { label, value } ) ) }
-					onChange={ onChange }
-				/>
-				<ItemHelp
-					onChange={ onChange }
-					title={ title }
-					items={ items }
-					colCount="3"
-					value={ editorOptions.matchBrackets }
-				/>
-			</Stack>
-		</div>
+		<Stack
+			className="chbe-admin-editor-config__setting-item"
+			justify="start"
+			align="start"
+			wrap="wrap"
+			gap="sm"
+		>
+			<SelectControl< EditorOptions[ 'matchBrackets' ] >
+				__next40pxDefaultSize
+				label={ title }
+				value={ editorOptions.matchBrackets }
+				options={ items.map( ( { label, value } ) => ( { label, value } ) ) }
+				onChange={ onChange }
+			/>
+			<ItemHelp
+				onChange={ onChange }
+				title={ title }
+				items={ items }
+				colCount="3"
+				value={ editorOptions.matchBrackets }
+			/>
+		</Stack>
 	);
 }

--- a/src/admin/editor-config/editor-options/match-brackets.tsx
+++ b/src/admin/editor-config/editor-options/match-brackets.tsx
@@ -3,7 +3,8 @@
  */
 import { __ } from '@wordpress/i18n';
 import { useContext } from '@wordpress/element';
-import { SelectControl, __experimentalHStack as HStack } from '@wordpress/components';
+import { SelectControl } from '@wordpress/components';
+import { Stack } from '@wordpress/ui';
 
 /**
  * Internal dependencies
@@ -51,7 +52,7 @@ export default function MatchBrackets() {
 
 	return (
 		<div className="chbe-admin-editor-config__setting-item">
-			<HStack justify="start" alignment="start" wrap>
+			<Stack justify="start" align="start" wrap="wrap" gap="sm">
 				<SelectControl< EditorOptions[ 'matchBrackets' ] >
 					__next40pxDefaultSize
 					label={ title }
@@ -66,7 +67,7 @@ export default function MatchBrackets() {
 					colCount="3"
 					value={ editorOptions.matchBrackets }
 				/>
-			</HStack>
+			</Stack>
 		</div>
 	);
 }

--- a/src/admin/editor-config/editor-options/minimap/enabled.tsx
+++ b/src/admin/editor-config/editor-options/minimap/enabled.tsx
@@ -3,7 +3,8 @@
  */
 import { __ } from '@wordpress/i18n';
 import { useContext } from '@wordpress/element';
-import { ToggleControl, __experimentalHStack as HStack } from '@wordpress/components';
+import { ToggleControl } from '@wordpress/components';
+import { Stack } from '@wordpress/ui';
 
 /**
  * Internal dependencies
@@ -34,7 +35,7 @@ export default function MinimapEnabled() {
 
 	return (
 		<div className="chbe-admin-editor-config__setting-item">
-			<HStack justify="start" alignment="start" wrap>
+			<Stack justify="start" align="start" wrap="wrap" gap="sm">
 				<ToggleControl
 					label={ title }
 					checked={ editorOptions.minimap.enabled }
@@ -52,7 +53,7 @@ export default function MinimapEnabled() {
 					image="editor-options/minimap/enabled.gif"
 					value={ editorOptions.minimap.enabled }
 				/>
-			</HStack>
+			</Stack>
 		</div>
 	);
 }

--- a/src/admin/editor-config/editor-options/minimap/enabled.tsx
+++ b/src/admin/editor-config/editor-options/minimap/enabled.tsx
@@ -34,26 +34,30 @@ export default function MinimapEnabled() {
 	};
 
 	return (
-		<div className="chbe-admin-editor-config__setting-item">
-			<Stack justify="start" align="start" wrap="wrap" gap="sm">
-				<ToggleControl
-					label={ title }
-					checked={ editorOptions.minimap.enabled }
-					onChange={ onChange }
-				/>
-				<ItemHelp
-					onChange={ onChange }
-					title={ title }
-					description={ __(
-						'Minimap gives you a high-level overview of your source code, which is useful for quick navigation and code understanding. You can click or drag the shaded area to quickly jump to different sections.',
-						'custom-html-block-extension'
-					) }
-					isToggle
-					defaultToggle
-					image="editor-options/minimap/enabled.gif"
-					value={ editorOptions.minimap.enabled }
-				/>
-			</Stack>
-		</div>
+		<Stack
+			className="chbe-admin-editor-config__setting-item"
+			justify="start"
+			align="start"
+			wrap="wrap"
+			gap="sm"
+		>
+			<ToggleControl
+				label={ title }
+				checked={ editorOptions.minimap.enabled }
+				onChange={ onChange }
+			/>
+			<ItemHelp
+				onChange={ onChange }
+				title={ title }
+				description={ __(
+					'Minimap gives you a high-level overview of your source code, which is useful for quick navigation and code understanding. You can click or drag the shaded area to quickly jump to different sections.',
+					'custom-html-block-extension'
+				) }
+				isToggle
+				defaultToggle
+				image="editor-options/minimap/enabled.gif"
+				value={ editorOptions.minimap.enabled }
+			/>
+		</Stack>
 	);
 }

--- a/src/admin/editor-config/editor-options/minimap/max-column.tsx
+++ b/src/admin/editor-config/editor-options/minimap/max-column.tsx
@@ -35,19 +35,23 @@ export default function MinimapMaxColumn() {
 	};
 
 	return (
-		<div className="chbe-admin-editor-config__setting-item">
-			<Stack justify="start" align="start" wrap="wrap" gap="sm">
-				<RangeControl
-					__next40pxDefaultSize
-					label={ title }
-					value={ editorOptions.minimap.maxColumn }
-					min={ 10 }
-					max={ 60 }
-					allowReset
-					onChange={ onChange }
-				/>
-				<ItemHelp title={ title } image="editor-options/minimap/max-column.gif" />
-			</Stack>
-		</div>
+		<Stack
+			className="chbe-admin-editor-config__setting-item"
+			justify="start"
+			align="start"
+			wrap="wrap"
+			gap="sm"
+		>
+			<RangeControl
+				__next40pxDefaultSize
+				label={ title }
+				value={ editorOptions.minimap.maxColumn }
+				min={ 10 }
+				max={ 60 }
+				allowReset
+				onChange={ onChange }
+			/>
+			<ItemHelp title={ title } image="editor-options/minimap/max-column.gif" />
+		</Stack>
 	);
 }

--- a/src/admin/editor-config/editor-options/minimap/max-column.tsx
+++ b/src/admin/editor-config/editor-options/minimap/max-column.tsx
@@ -3,7 +3,8 @@
  */
 import { __ } from '@wordpress/i18n';
 import { useContext } from '@wordpress/element';
-import { RangeControl, __experimentalHStack as HStack } from '@wordpress/components';
+import { RangeControl } from '@wordpress/components';
+import { Stack } from '@wordpress/ui';
 
 /**
  * Internal dependencies
@@ -35,7 +36,7 @@ export default function MinimapMaxColumn() {
 
 	return (
 		<div className="chbe-admin-editor-config__setting-item">
-			<HStack justify="start" alignment="start" wrap>
+			<Stack justify="start" align="start" wrap="wrap" gap="sm">
 				<RangeControl
 					__next40pxDefaultSize
 					label={ title }
@@ -46,7 +47,7 @@ export default function MinimapMaxColumn() {
 					onChange={ onChange }
 				/>
 				<ItemHelp title={ title } image="editor-options/minimap/max-column.gif" />
-			</HStack>
+			</Stack>
 		</div>
 	);
 }

--- a/src/admin/editor-config/editor-options/minimap/render-characters.tsx
+++ b/src/admin/editor-config/editor-options/minimap/render-characters.tsx
@@ -34,38 +34,42 @@ export default function MinimapRenderCharacters() {
 	};
 
 	return (
-		<div className="chbe-admin-editor-config__setting-item">
-			<Stack justify="start" align="start" wrap="wrap" gap="sm">
-				<ToggleControl
-					label={ title }
-					checked={ editorOptions.minimap.renderCharacters }
-					onChange={ onChange }
-				/>
-				<ItemHelp
-					onChange={ onChange }
-					title={ title }
-					description={ __(
-						'By default, the minimap shows blocks. You can change this to show actual characters.',
-						'custom-html-block-extension'
-					) }
-					items={ [
-						{
-							label: __( 'Enable', 'custom-html-block-extension' ),
-							value: true,
-							description: __( 'Show characters.', 'custom-html-block-extension' ),
-							image: 'editor-options/minimap/render-characters_1.jpg',
-							isDefault: true,
-						},
-						{
-							label: __( 'Disable', 'custom-html-block-extension' ),
-							value: false,
-							description: __( 'Show blocks.', 'custom-html-block-extension' ),
-							image: 'editor-options/minimap/render-characters_2.jpg',
-						},
-					] }
-					value={ editorOptions.minimap.renderCharacters }
-				/>
-			</Stack>
-		</div>
+		<Stack
+			className="chbe-admin-editor-config__setting-item"
+			justify="start"
+			align="start"
+			wrap="wrap"
+			gap="sm"
+		>
+			<ToggleControl
+				label={ title }
+				checked={ editorOptions.minimap.renderCharacters }
+				onChange={ onChange }
+			/>
+			<ItemHelp
+				onChange={ onChange }
+				title={ title }
+				description={ __(
+					'By default, the minimap shows blocks. You can change this to show actual characters.',
+					'custom-html-block-extension'
+				) }
+				items={ [
+					{
+						label: __( 'Enable', 'custom-html-block-extension' ),
+						value: true,
+						description: __( 'Show characters.', 'custom-html-block-extension' ),
+						image: 'editor-options/minimap/render-characters_1.jpg',
+						isDefault: true,
+					},
+					{
+						label: __( 'Disable', 'custom-html-block-extension' ),
+						value: false,
+						description: __( 'Show blocks.', 'custom-html-block-extension' ),
+						image: 'editor-options/minimap/render-characters_2.jpg',
+					},
+				] }
+				value={ editorOptions.minimap.renderCharacters }
+			/>
+		</Stack>
 	);
 }

--- a/src/admin/editor-config/editor-options/minimap/render-characters.tsx
+++ b/src/admin/editor-config/editor-options/minimap/render-characters.tsx
@@ -3,7 +3,8 @@
  */
 import { __ } from '@wordpress/i18n';
 import { useContext } from '@wordpress/element';
-import { ToggleControl, __experimentalHStack as HStack } from '@wordpress/components';
+import { ToggleControl } from '@wordpress/components';
+import { Stack } from '@wordpress/ui';
 
 /**
  * Internal dependencies
@@ -34,7 +35,7 @@ export default function MinimapRenderCharacters() {
 
 	return (
 		<div className="chbe-admin-editor-config__setting-item">
-			<HStack justify="start" alignment="start" wrap>
+			<Stack justify="start" align="start" wrap="wrap" gap="sm">
 				<ToggleControl
 					label={ title }
 					checked={ editorOptions.minimap.renderCharacters }
@@ -64,7 +65,7 @@ export default function MinimapRenderCharacters() {
 					] }
 					value={ editorOptions.minimap.renderCharacters }
 				/>
-			</HStack>
+			</Stack>
 		</div>
 	);
 }

--- a/src/admin/editor-config/editor-options/minimap/scale.tsx
+++ b/src/admin/editor-config/editor-options/minimap/scale.tsx
@@ -35,24 +35,28 @@ export default function MinimapScale() {
 	};
 
 	return (
-		<div className="chbe-admin-editor-config__setting-item">
-			<Stack justify="start" align="start" wrap="wrap" gap="sm">
-				<RangeControl
-					__next40pxDefaultSize
-					label={ title }
-					value={ editorOptions.minimap.scale }
-					min={ 1 }
-					max={ 3 }
-					allowReset
-					onChange={ onChange }
-				/>
-				<ItemHelp
-					onChange={ onChange }
-					title={ title }
-					image="editor-options/minimap/scale.gif"
-					value={ editorOptions.minimap.scale }
-				/>
-			</Stack>
-		</div>
+		<Stack
+			className="chbe-admin-editor-config__setting-item"
+			justify="start"
+			align="start"
+			wrap="wrap"
+			gap="sm"
+		>
+			<RangeControl
+				__next40pxDefaultSize
+				label={ title }
+				value={ editorOptions.minimap.scale }
+				min={ 1 }
+				max={ 3 }
+				allowReset
+				onChange={ onChange }
+			/>
+			<ItemHelp
+				onChange={ onChange }
+				title={ title }
+				image="editor-options/minimap/scale.gif"
+				value={ editorOptions.minimap.scale }
+			/>
+		</Stack>
 	);
 }

--- a/src/admin/editor-config/editor-options/minimap/scale.tsx
+++ b/src/admin/editor-config/editor-options/minimap/scale.tsx
@@ -3,7 +3,8 @@
  */
 import { __ } from '@wordpress/i18n';
 import { useContext } from '@wordpress/element';
-import { RangeControl, __experimentalHStack as HStack } from '@wordpress/components';
+import { RangeControl } from '@wordpress/components';
+import { Stack } from '@wordpress/ui';
 
 /**
  * Internal dependencies
@@ -35,7 +36,7 @@ export default function MinimapScale() {
 
 	return (
 		<div className="chbe-admin-editor-config__setting-item">
-			<HStack justify="start" alignment="start" wrap>
+			<Stack justify="start" align="start" wrap="wrap" gap="sm">
 				<RangeControl
 					__next40pxDefaultSize
 					label={ title }
@@ -51,7 +52,7 @@ export default function MinimapScale() {
 					image="editor-options/minimap/scale.gif"
 					value={ editorOptions.minimap.scale }
 				/>
-			</HStack>
+			</Stack>
 		</div>
 	);
 }

--- a/src/admin/editor-config/editor-options/minimap/show-slider.tsx
+++ b/src/admin/editor-config/editor-options/minimap/show-slider.tsx
@@ -49,22 +49,26 @@ export default function MinimapShowSlider() {
 	};
 
 	return (
-		<div className="chbe-admin-editor-config__setting-item">
-			<Stack justify="start" align="start" wrap="wrap" gap="sm">
-				<SelectControl< EditorOptions[ 'minimap' ][ 'showSlider' ] >
-					__next40pxDefaultSize
-					label={ title }
-					value={ editorOptions.minimap.showSlider }
-					options={ items.map( ( { label, value } ) => ( { label, value } ) ) }
-					onChange={ onChange }
-				/>
-				<ItemHelp
-					onChange={ onChange }
-					title={ title }
-					items={ items }
-					value={ editorOptions.minimap.showSlider }
-				/>
-			</Stack>
-		</div>
+		<Stack
+			className="chbe-admin-editor-config__setting-item"
+			justify="start"
+			align="start"
+			wrap="wrap"
+			gap="sm"
+		>
+			<SelectControl< EditorOptions[ 'minimap' ][ 'showSlider' ] >
+				__next40pxDefaultSize
+				label={ title }
+				value={ editorOptions.minimap.showSlider }
+				options={ items.map( ( { label, value } ) => ( { label, value } ) ) }
+				onChange={ onChange }
+			/>
+			<ItemHelp
+				onChange={ onChange }
+				title={ title }
+				items={ items }
+				value={ editorOptions.minimap.showSlider }
+			/>
+		</Stack>
 	);
 }

--- a/src/admin/editor-config/editor-options/minimap/show-slider.tsx
+++ b/src/admin/editor-config/editor-options/minimap/show-slider.tsx
@@ -3,7 +3,8 @@
  */
 import { __ } from '@wordpress/i18n';
 import { useContext } from '@wordpress/element';
-import { SelectControl, __experimentalHStack as HStack } from '@wordpress/components';
+import { SelectControl } from '@wordpress/components';
+import { Stack } from '@wordpress/ui';
 
 /**
  * Internal dependencies
@@ -49,7 +50,7 @@ export default function MinimapShowSlider() {
 
 	return (
 		<div className="chbe-admin-editor-config__setting-item">
-			<HStack justify="start" alignment="start" wrap>
+			<Stack justify="start" align="start" wrap="wrap" gap="sm">
 				<SelectControl< EditorOptions[ 'minimap' ][ 'showSlider' ] >
 					__next40pxDefaultSize
 					label={ title }
@@ -63,7 +64,7 @@ export default function MinimapShowSlider() {
 					items={ items }
 					value={ editorOptions.minimap.showSlider }
 				/>
-			</HStack>
+			</Stack>
 		</div>
 	);
 }

--- a/src/admin/editor-config/editor-options/minimap/side.tsx
+++ b/src/admin/editor-config/editor-options/minimap/side.tsx
@@ -52,30 +52,30 @@ export default function MinimapSide() {
 	};
 
 	return (
-		<div className="chbe-admin-editor-config__setting-item">
-			<Stack justify="start" align="start" wrap="wrap" gap="sm">
-				<ToggleGroupControl
-					size="__unstable-large"
-					label={ title }
-					value={ editorOptions.minimap.side }
-					onChange={ onChange }
-					isBlock
-				>
-					{ items.map( ( item ) => (
-						<ToggleGroupControlOption
-							key={ item.value }
-							value={ item.value }
-							label={ item.label }
-						/>
-					) ) }
-				</ToggleGroupControl>
-				<ItemHelp
-					onChange={ onChange }
-					title={ title }
-					items={ items }
-					value={ editorOptions.minimap.side }
-				/>
-			</Stack>
-		</div>
+		<Stack
+			className="chbe-admin-editor-config__setting-item"
+			justify="start"
+			align="start"
+			wrap="wrap"
+			gap="sm"
+		>
+			<ToggleGroupControl
+				size="__unstable-large"
+				label={ title }
+				value={ editorOptions.minimap.side }
+				onChange={ onChange }
+				isBlock
+			>
+				{ items.map( ( item ) => (
+					<ToggleGroupControlOption key={ item.value } value={ item.value } label={ item.label } />
+				) ) }
+			</ToggleGroupControl>
+			<ItemHelp
+				onChange={ onChange }
+				title={ title }
+				items={ items }
+				value={ editorOptions.minimap.side }
+			/>
+		</Stack>
 	);
 }

--- a/src/admin/editor-config/editor-options/minimap/side.tsx
+++ b/src/admin/editor-config/editor-options/minimap/side.tsx
@@ -11,10 +11,10 @@ import type { EditorOptions } from '../../../../types';
 import { AdminContext } from '../../../index';
 import { useSearchVisibility } from '../../index';
 import {
-	__experimentalHStack as HStack,
 	__experimentalToggleGroupControl as ToggleGroupControl,
 	__experimentalToggleGroupControlOption as ToggleGroupControlOption,
 } from '@wordpress/components';
+import { Stack } from '@wordpress/ui';
 import ItemHelp from '../../components/item-help';
 
 export default function MinimapSide() {
@@ -53,7 +53,7 @@ export default function MinimapSide() {
 
 	return (
 		<div className="chbe-admin-editor-config__setting-item">
-			<HStack justify="start" alignment="start" wrap>
+			<Stack justify="start" align="start" wrap="wrap" gap="sm">
 				<ToggleGroupControl
 					size="__unstable-large"
 					label={ title }
@@ -75,7 +75,7 @@ export default function MinimapSide() {
 					items={ items }
 					value={ editorOptions.minimap.side }
 				/>
-			</HStack>
+			</Stack>
 		</div>
 	);
 }

--- a/src/admin/editor-config/editor-options/minimap/size.tsx
+++ b/src/admin/editor-config/editor-options/minimap/size.tsx
@@ -3,7 +3,8 @@
  */
 import { __ } from '@wordpress/i18n';
 import { useContext } from '@wordpress/element';
-import { SelectControl, __experimentalHStack as HStack } from '@wordpress/components';
+import { SelectControl } from '@wordpress/components';
+import { Stack } from '@wordpress/ui';
 
 /**
  * Internal dependencies
@@ -66,7 +67,7 @@ export default function MinimapSize() {
 
 	return (
 		<div className="chbe-admin-editor-config__setting-item">
-			<HStack justify="start" alignment="start" wrap>
+			<Stack justify="start" align="start" wrap="wrap" gap="sm">
 				<SelectControl< EditorOptions[ 'minimap' ][ 'size' ] >
 					__next40pxDefaultSize
 					label={ title }
@@ -81,7 +82,7 @@ export default function MinimapSize() {
 					colCount="3"
 					value={ editorOptions.minimap.size }
 				/>
-			</HStack>
+			</Stack>
 		</div>
 	);
 }

--- a/src/admin/editor-config/editor-options/minimap/size.tsx
+++ b/src/admin/editor-config/editor-options/minimap/size.tsx
@@ -66,23 +66,27 @@ export default function MinimapSize() {
 	};
 
 	return (
-		<div className="chbe-admin-editor-config__setting-item">
-			<Stack justify="start" align="start" wrap="wrap" gap="sm">
-				<SelectControl< EditorOptions[ 'minimap' ][ 'size' ] >
-					__next40pxDefaultSize
-					label={ title }
-					value={ editorOptions.minimap.size }
-					options={ items.map( ( { label, value } ) => ( { label, value } ) ) }
-					onChange={ onChange }
-				/>
-				<ItemHelp
-					onChange={ onChange }
-					title={ title }
-					items={ items }
-					colCount="3"
-					value={ editorOptions.minimap.size }
-				/>
-			</Stack>
-		</div>
+		<Stack
+			className="chbe-admin-editor-config__setting-item"
+			justify="start"
+			align="start"
+			wrap="wrap"
+			gap="sm"
+		>
+			<SelectControl< EditorOptions[ 'minimap' ][ 'size' ] >
+				__next40pxDefaultSize
+				label={ title }
+				value={ editorOptions.minimap.size }
+				options={ items.map( ( { label, value } ) => ( { label, value } ) ) }
+				onChange={ onChange }
+			/>
+			<ItemHelp
+				onChange={ onChange }
+				title={ title }
+				items={ items }
+				colCount="3"
+				value={ editorOptions.minimap.size }
+			/>
+		</Stack>
 	);
 }

--- a/src/admin/editor-config/editor-options/mouse-wheel-zoom.tsx
+++ b/src/admin/editor-config/editor-options/mouse-wheel-zoom.tsx
@@ -31,22 +31,26 @@ export default function MouseWheelZoom() {
 	};
 
 	return (
-		<div className="chbe-admin-editor-config__setting-item">
-			<Stack justify="start" align="start" wrap="wrap" gap="sm">
-				<ToggleControl
-					label={ title }
-					checked={ editorOptions.mouseWheelZoom }
-					onChange={ onChange }
-				/>
-				<ItemHelp
-					onChange={ onChange }
-					title={ title }
-					isToggle
-					defaultToggle={ false }
-					image="editor-options/mouse-wheel-zoom.gif"
-					value={ editorOptions.mouseWheelZoom }
-				/>
-			</Stack>
-		</div>
+		<Stack
+			className="chbe-admin-editor-config__setting-item"
+			justify="start"
+			align="start"
+			wrap="wrap"
+			gap="sm"
+		>
+			<ToggleControl
+				label={ title }
+				checked={ editorOptions.mouseWheelZoom }
+				onChange={ onChange }
+			/>
+			<ItemHelp
+				onChange={ onChange }
+				title={ title }
+				isToggle
+				defaultToggle={ false }
+				image="editor-options/mouse-wheel-zoom.gif"
+				value={ editorOptions.mouseWheelZoom }
+			/>
+		</Stack>
 	);
 }

--- a/src/admin/editor-config/editor-options/mouse-wheel-zoom.tsx
+++ b/src/admin/editor-config/editor-options/mouse-wheel-zoom.tsx
@@ -3,7 +3,8 @@
  */
 import { __ } from '@wordpress/i18n';
 import { useContext } from '@wordpress/element';
-import { ToggleControl, __experimentalHStack as HStack } from '@wordpress/components';
+import { ToggleControl } from '@wordpress/components';
+import { Stack } from '@wordpress/ui';
 
 /**
  * Internal dependencies
@@ -31,7 +32,7 @@ export default function MouseWheelZoom() {
 
 	return (
 		<div className="chbe-admin-editor-config__setting-item">
-			<HStack justify="start" alignment="start" wrap>
+			<Stack justify="start" align="start" wrap="wrap" gap="sm">
 				<ToggleControl
 					label={ title }
 					checked={ editorOptions.mouseWheelZoom }
@@ -45,7 +46,7 @@ export default function MouseWheelZoom() {
 					image="editor-options/mouse-wheel-zoom.gif"
 					value={ editorOptions.mouseWheelZoom }
 				/>
-			</HStack>
+			</Stack>
 		</div>
 	);
 }

--- a/src/admin/editor-config/editor-options/multi-cursor-modifier.tsx
+++ b/src/admin/editor-config/editor-options/multi-cursor-modifier.tsx
@@ -51,33 +51,33 @@ export default function MultiCursorModifier() {
 	};
 
 	return (
-		<div className="chbe-admin-editor-config__setting-item">
-			<Stack justify="start" align="start" wrap="wrap" gap="sm">
-				<ToggleGroupControl
-					size="__unstable-large"
-					label={ title }
-					value={ editorOptions.multiCursorModifier }
-					onChange={ onChange }
-					isBlock
-				>
-					{ items.map( ( item ) => (
-						<ToggleGroupControlOption
-							key={ item.value }
-							value={ item.value }
-							label={ item.label }
-						/>
-					) ) }
-				</ToggleGroupControl>
-				<ItemHelp
-					onChange={ onChange }
-					title={ title }
-					description={ __(
-						'You can use multiple cursors for faster editing. Sets the key for applying multiple cursors with modifier key + Click.',
-						'custom-html-block-extension'
-					) }
-					image="editor-options/multi-cursor-modifier.gif"
-				/>
-			</Stack>
-		</div>
+		<Stack
+			className="chbe-admin-editor-config__setting-item"
+			justify="start"
+			align="start"
+			wrap="wrap"
+			gap="sm"
+		>
+			<ToggleGroupControl
+				size="__unstable-large"
+				label={ title }
+				value={ editorOptions.multiCursorModifier }
+				onChange={ onChange }
+				isBlock
+			>
+				{ items.map( ( item ) => (
+					<ToggleGroupControlOption key={ item.value } value={ item.value } label={ item.label } />
+				) ) }
+			</ToggleGroupControl>
+			<ItemHelp
+				onChange={ onChange }
+				title={ title }
+				description={ __(
+					'You can use multiple cursors for faster editing. Sets the key for applying multiple cursors with modifier key + Click.',
+					'custom-html-block-extension'
+				) }
+				image="editor-options/multi-cursor-modifier.gif"
+			/>
+		</Stack>
 	);
 }

--- a/src/admin/editor-config/editor-options/multi-cursor-modifier.tsx
+++ b/src/admin/editor-config/editor-options/multi-cursor-modifier.tsx
@@ -4,10 +4,10 @@
 import { __ } from '@wordpress/i18n';
 import { useContext } from '@wordpress/element';
 import {
-	__experimentalHStack as HStack,
 	__experimentalToggleGroupControl as ToggleGroupControl,
 	__experimentalToggleGroupControlOption as ToggleGroupControlOption,
 } from '@wordpress/components';
+import { Stack } from '@wordpress/ui';
 import { isAppleOS } from '@wordpress/keycodes';
 
 /**
@@ -52,7 +52,7 @@ export default function MultiCursorModifier() {
 
 	return (
 		<div className="chbe-admin-editor-config__setting-item">
-			<HStack justify="start" alignment="start" wrap>
+			<Stack justify="start" align="start" wrap="wrap" gap="sm">
 				<ToggleGroupControl
 					size="__unstable-large"
 					label={ title }
@@ -77,7 +77,7 @@ export default function MultiCursorModifier() {
 					) }
 					image="editor-options/multi-cursor-modifier.gif"
 				/>
-			</HStack>
+			</Stack>
 		</div>
 	);
 }

--- a/src/admin/editor-config/editor-options/multi-cursor-paste.tsx
+++ b/src/admin/editor-config/editor-options/multi-cursor-paste.tsx
@@ -4,10 +4,10 @@
 import { __ } from '@wordpress/i18n';
 import { useContext } from '@wordpress/element';
 import {
-	__experimentalHStack as HStack,
 	__experimentalToggleGroupControl as ToggleGroupControl,
 	__experimentalToggleGroupControlOption as ToggleGroupControlOption,
 } from '@wordpress/components';
+import { Stack } from '@wordpress/ui';
 
 /**
  * Internal dependencies
@@ -52,7 +52,7 @@ export default function MultiCursorPaste() {
 
 	return (
 		<div className="chbe-admin-editor-config__setting-item">
-			<HStack justify="start" alignment="start" wrap>
+			<Stack justify="start" align="start" wrap="wrap" gap="sm">
 				<ToggleGroupControl
 					size="__unstable-large"
 					label={ title }
@@ -74,7 +74,7 @@ export default function MultiCursorPaste() {
 					items={ items }
 					value={ editorOptions.multiCursorPaste }
 				/>
-			</HStack>
+			</Stack>
 		</div>
 	);
 }

--- a/src/admin/editor-config/editor-options/multi-cursor-paste.tsx
+++ b/src/admin/editor-config/editor-options/multi-cursor-paste.tsx
@@ -51,30 +51,30 @@ export default function MultiCursorPaste() {
 	};
 
 	return (
-		<div className="chbe-admin-editor-config__setting-item">
-			<Stack justify="start" align="start" wrap="wrap" gap="sm">
-				<ToggleGroupControl
-					size="__unstable-large"
-					label={ title }
-					value={ editorOptions.multiCursorPaste }
-					onChange={ onChange }
-					isBlock
-				>
-					{ items.map( ( item ) => (
-						<ToggleGroupControlOption
-							key={ item.value }
-							value={ item.value }
-							label={ item.label }
-						/>
-					) ) }
-				</ToggleGroupControl>
-				<ItemHelp
-					onChange={ onChange }
-					title={ title }
-					items={ items }
-					value={ editorOptions.multiCursorPaste }
-				/>
-			</Stack>
-		</div>
+		<Stack
+			className="chbe-admin-editor-config__setting-item"
+			justify="start"
+			align="start"
+			wrap="wrap"
+			gap="sm"
+		>
+			<ToggleGroupControl
+				size="__unstable-large"
+				label={ title }
+				value={ editorOptions.multiCursorPaste }
+				onChange={ onChange }
+				isBlock
+			>
+				{ items.map( ( item ) => (
+					<ToggleGroupControlOption key={ item.value } value={ item.value } label={ item.label } />
+				) ) }
+			</ToggleGroupControl>
+			<ItemHelp
+				onChange={ onChange }
+				title={ title }
+				items={ items }
+				value={ editorOptions.multiCursorPaste }
+			/>
+		</Stack>
 	);
 }

--- a/src/admin/editor-config/editor-options/occurrences-highlight.tsx
+++ b/src/admin/editor-config/editor-options/occurrences-highlight.tsx
@@ -36,28 +36,32 @@ export default function OccurrencesHighlight() {
 	};
 
 	return (
-		<div className="chbe-admin-editor-config__setting-item">
-			<Stack justify="start" align="start" wrap="wrap" gap="sm">
-				<ToggleControl label={ title } checked={ isEnabled } onChange={ onChange } />
-				<ItemHelp
-					onChange={ onChange }
-					title={ title }
-					items={ [
-						{
-							label: __( 'Enable', 'custom-html-block-extension' ),
-							value: true,
-							image: 'editor-options/occurrences-highlight_1.jpg',
-							isDefault: true,
-						},
-						{
-							label: __( 'Disable', 'custom-html-block-extension' ),
-							value: false,
-							image: 'editor-options/occurrences-highlight_2.jpg',
-						},
-					] }
-					value={ isEnabled }
-				/>
-			</Stack>
-		</div>
+		<Stack
+			className="chbe-admin-editor-config__setting-item"
+			justify="start"
+			align="start"
+			wrap="wrap"
+			gap="sm"
+		>
+			<ToggleControl label={ title } checked={ isEnabled } onChange={ onChange } />
+			<ItemHelp
+				onChange={ onChange }
+				title={ title }
+				items={ [
+					{
+						label: __( 'Enable', 'custom-html-block-extension' ),
+						value: true,
+						image: 'editor-options/occurrences-highlight_1.jpg',
+						isDefault: true,
+					},
+					{
+						label: __( 'Disable', 'custom-html-block-extension' ),
+						value: false,
+						image: 'editor-options/occurrences-highlight_2.jpg',
+					},
+				] }
+				value={ isEnabled }
+			/>
+		</Stack>
 	);
 }

--- a/src/admin/editor-config/editor-options/occurrences-highlight.tsx
+++ b/src/admin/editor-config/editor-options/occurrences-highlight.tsx
@@ -3,7 +3,8 @@
  */
 import { __ } from '@wordpress/i18n';
 import { useContext } from '@wordpress/element';
-import { ToggleControl, __experimentalHStack as HStack } from '@wordpress/components';
+import { ToggleControl } from '@wordpress/components';
+import { Stack } from '@wordpress/ui';
 
 /**
  * Internal dependencies
@@ -36,7 +37,7 @@ export default function OccurrencesHighlight() {
 
 	return (
 		<div className="chbe-admin-editor-config__setting-item">
-			<HStack justify="start" alignment="start" wrap>
+			<Stack justify="start" align="start" wrap="wrap" gap="sm">
 				<ToggleControl label={ title } checked={ isEnabled } onChange={ onChange } />
 				<ItemHelp
 					onChange={ onChange }
@@ -56,7 +57,7 @@ export default function OccurrencesHighlight() {
 					] }
 					value={ isEnabled }
 				/>
-			</HStack>
+			</Stack>
 		</div>
 	);
 }

--- a/src/admin/editor-config/editor-options/overview-ruler-border.tsx
+++ b/src/admin/editor-config/editor-options/overview-ruler-border.tsx
@@ -3,7 +3,8 @@
  */
 import { __ } from '@wordpress/i18n';
 import { useContext } from '@wordpress/element';
-import { ToggleControl, __experimentalHStack as HStack } from '@wordpress/components';
+import { ToggleControl } from '@wordpress/components';
+import { Stack } from '@wordpress/ui';
 
 /**
  * Internal dependencies
@@ -31,7 +32,7 @@ export default function OverviewRulerBorder() {
 
 	return (
 		<div className="chbe-admin-editor-config__setting-item">
-			<HStack justify="start" alignment="start" wrap>
+			<Stack justify="start" align="start" wrap="wrap" gap="sm">
 				<ToggleControl
 					label={ title }
 					checked={ editorOptions.overviewRulerBorder }
@@ -55,7 +56,7 @@ export default function OverviewRulerBorder() {
 					] }
 					value={ editorOptions.overviewRulerBorder }
 				/>
-			</HStack>
+			</Stack>
 		</div>
 	);
 }

--- a/src/admin/editor-config/editor-options/overview-ruler-border.tsx
+++ b/src/admin/editor-config/editor-options/overview-ruler-border.tsx
@@ -31,32 +31,36 @@ export default function OverviewRulerBorder() {
 	};
 
 	return (
-		<div className="chbe-admin-editor-config__setting-item">
-			<Stack justify="start" align="start" wrap="wrap" gap="sm">
-				<ToggleControl
-					label={ title }
-					checked={ editorOptions.overviewRulerBorder }
-					onChange={ onChange }
-				/>
-				<ItemHelp
-					onChange={ onChange }
-					title={ title }
-					items={ [
-						{
-							label: __( 'Enable', 'custom-html-block-extension' ),
-							image: 'editor-options/overview-ruler-border_1.jpg',
-							value: true,
-							isDefault: true,
-						},
-						{
-							label: __( 'Disable', 'custom-html-block-extension' ),
-							image: 'editor-options/overview-ruler-border_2.jpg',
-							value: false,
-						},
-					] }
-					value={ editorOptions.overviewRulerBorder }
-				/>
-			</Stack>
-		</div>
+		<Stack
+			className="chbe-admin-editor-config__setting-item"
+			justify="start"
+			align="start"
+			wrap="wrap"
+			gap="sm"
+		>
+			<ToggleControl
+				label={ title }
+				checked={ editorOptions.overviewRulerBorder }
+				onChange={ onChange }
+			/>
+			<ItemHelp
+				onChange={ onChange }
+				title={ title }
+				items={ [
+					{
+						label: __( 'Enable', 'custom-html-block-extension' ),
+						image: 'editor-options/overview-ruler-border_1.jpg',
+						value: true,
+						isDefault: true,
+					},
+					{
+						label: __( 'Disable', 'custom-html-block-extension' ),
+						image: 'editor-options/overview-ruler-border_2.jpg',
+						value: false,
+					},
+				] }
+				value={ editorOptions.overviewRulerBorder }
+			/>
+		</Stack>
 	);
 }

--- a/src/admin/editor-config/editor-options/padding/bottom.tsx
+++ b/src/admin/editor-config/editor-options/padding/bottom.tsx
@@ -36,27 +36,31 @@ export default function PaddingBottom() {
 	};
 
 	return (
-		<div className="chbe-admin-editor-config__setting-item">
-			<Stack justify="start" align="start" wrap="wrap" gap="sm">
-				<RangeControl
-					__next40pxDefaultSize
-					label={ title }
-					value={ editorOptions.padding.bottom }
-					min={ 0 }
-					max={ 50 }
-					allowReset
-					onChange={ onChange }
-				/>
-				<ItemHelp
-					onChange={ onChange }
-					title={ title }
-					description={ __(
-						'Spacing between bottom edge of editor and last line. This setting will not work if "Scroll past the last line" is enabled in "Mouse and Scroll" category.',
-						'custom-html-block-extension'
-					) }
-					image="editor-options/padding/bottom.gif"
-				/>
-			</Stack>
-		</div>
+		<Stack
+			className="chbe-admin-editor-config__setting-item"
+			justify="start"
+			align="start"
+			wrap="wrap"
+			gap="sm"
+		>
+			<RangeControl
+				__next40pxDefaultSize
+				label={ title }
+				value={ editorOptions.padding.bottom }
+				min={ 0 }
+				max={ 50 }
+				allowReset
+				onChange={ onChange }
+			/>
+			<ItemHelp
+				onChange={ onChange }
+				title={ title }
+				description={ __(
+					'Spacing between bottom edge of editor and last line. This setting will not work if "Scroll past the last line" is enabled in "Mouse and Scroll" category.',
+					'custom-html-block-extension'
+				) }
+				image="editor-options/padding/bottom.gif"
+			/>
+		</Stack>
 	);
 }

--- a/src/admin/editor-config/editor-options/padding/bottom.tsx
+++ b/src/admin/editor-config/editor-options/padding/bottom.tsx
@@ -3,7 +3,8 @@
  */
 import { __ } from '@wordpress/i18n';
 import { useContext } from '@wordpress/element';
-import { RangeControl, __experimentalHStack as HStack } from '@wordpress/components';
+import { RangeControl } from '@wordpress/components';
+import { Stack } from '@wordpress/ui';
 
 /**
  * Internal dependencies
@@ -36,7 +37,7 @@ export default function PaddingBottom() {
 
 	return (
 		<div className="chbe-admin-editor-config__setting-item">
-			<HStack justify="start" alignment="start" wrap>
+			<Stack justify="start" align="start" wrap="wrap" gap="sm">
 				<RangeControl
 					__next40pxDefaultSize
 					label={ title }
@@ -55,7 +56,7 @@ export default function PaddingBottom() {
 					) }
 					image="editor-options/padding/bottom.gif"
 				/>
-			</HStack>
+			</Stack>
 		</div>
 	);
 }

--- a/src/admin/editor-config/editor-options/padding/top.tsx
+++ b/src/admin/editor-config/editor-options/padding/top.tsx
@@ -36,27 +36,31 @@ export default function PaddingTop() {
 	};
 
 	return (
-		<div className="chbe-admin-editor-config__setting-item">
-			<Stack justify="start" align="start" wrap="wrap" gap="sm">
-				<RangeControl
-					__next40pxDefaultSize
-					label={ title }
-					value={ editorOptions.padding.top }
-					min={ 0 }
-					max={ 50 }
-					allowReset
-					onChange={ onChange }
-				/>
-				<ItemHelp
-					onChange={ onChange }
-					title={ title }
-					description={ __(
-						'Spacing between top edge of editor and first line.',
-						'custom-html-block-extension'
-					) }
-					image="editor-options/padding/top.gif"
-				/>
-			</Stack>
-		</div>
+		<Stack
+			className="chbe-admin-editor-config__setting-item"
+			justify="start"
+			align="start"
+			wrap="wrap"
+			gap="sm"
+		>
+			<RangeControl
+				__next40pxDefaultSize
+				label={ title }
+				value={ editorOptions.padding.top }
+				min={ 0 }
+				max={ 50 }
+				allowReset
+				onChange={ onChange }
+			/>
+			<ItemHelp
+				onChange={ onChange }
+				title={ title }
+				description={ __(
+					'Spacing between top edge of editor and first line.',
+					'custom-html-block-extension'
+				) }
+				image="editor-options/padding/top.gif"
+			/>
+		</Stack>
 	);
 }

--- a/src/admin/editor-config/editor-options/padding/top.tsx
+++ b/src/admin/editor-config/editor-options/padding/top.tsx
@@ -3,7 +3,8 @@
  */
 import { __ } from '@wordpress/i18n';
 import { useContext } from '@wordpress/element';
-import { RangeControl, __experimentalHStack as HStack } from '@wordpress/components';
+import { RangeControl } from '@wordpress/components';
+import { Stack } from '@wordpress/ui';
 
 /**
  * Internal dependencies
@@ -36,7 +37,7 @@ export default function PaddingTop() {
 
 	return (
 		<div className="chbe-admin-editor-config__setting-item">
-			<HStack justify="start" alignment="start" wrap>
+			<Stack justify="start" align="start" wrap="wrap" gap="sm">
 				<RangeControl
 					__next40pxDefaultSize
 					label={ title }
@@ -55,7 +56,7 @@ export default function PaddingTop() {
 					) }
 					image="editor-options/padding/top.gif"
 				/>
-			</HStack>
+			</Stack>
 		</div>
 	);
 }

--- a/src/admin/editor-config/editor-options/quick-suggestions-delay.tsx
+++ b/src/admin/editor-config/editor-options/quick-suggestions-delay.tsx
@@ -32,43 +32,47 @@ export default function QuickSuggestionsDelay() {
 	};
 
 	return (
-		<div className="chbe-admin-editor-config__setting-item">
-			<Stack justify="start" align="start" wrap="wrap" gap="sm">
-				<RangeControl
-					__next40pxDefaultSize
-					label={ title }
-					value={ editorOptions.quickSuggestionsDelay }
-					min={ 0 }
-					max={ 1000 }
-					allowReset
-					onChange={ onChange }
-				/>
-				<ItemHelp
-					onChange={ onChange }
-					title={ title }
-					items={ [
-						{
-							label: sprintf(
-								/* translators: %s is replaced with the number. */
-								__( 'Example: Set the value to %s', 'custom-html-block-extension' ),
-								'10'
-							),
-							image: 'editor-options/quick-suggestions-delay_1.gif',
-							value: 10,
-						},
-						{
-							label: sprintf(
-								/* translators: %s is replaced with the number. */
-								__( 'Example: Set the value to %s', 'custom-html-block-extension' ),
-								'1000'
-							),
-							image: 'editor-options/quick-suggestions-delay_2.gif',
-							value: 1000,
-						},
-					] }
-					value={ editorOptions.quickSuggestionsDelay }
-				/>
-			</Stack>
-		</div>
+		<Stack
+			className="chbe-admin-editor-config__setting-item"
+			justify="start"
+			align="start"
+			wrap="wrap"
+			gap="sm"
+		>
+			<RangeControl
+				__next40pxDefaultSize
+				label={ title }
+				value={ editorOptions.quickSuggestionsDelay }
+				min={ 0 }
+				max={ 1000 }
+				allowReset
+				onChange={ onChange }
+			/>
+			<ItemHelp
+				onChange={ onChange }
+				title={ title }
+				items={ [
+					{
+						label: sprintf(
+							/* translators: %s is replaced with the number. */
+							__( 'Example: Set the value to %s', 'custom-html-block-extension' ),
+							'10'
+						),
+						image: 'editor-options/quick-suggestions-delay_1.gif',
+						value: 10,
+					},
+					{
+						label: sprintf(
+							/* translators: %s is replaced with the number. */
+							__( 'Example: Set the value to %s', 'custom-html-block-extension' ),
+							'1000'
+						),
+						image: 'editor-options/quick-suggestions-delay_2.gif',
+						value: 1000,
+					},
+				] }
+				value={ editorOptions.quickSuggestionsDelay }
+			/>
+		</Stack>
 	);
 }

--- a/src/admin/editor-config/editor-options/quick-suggestions-delay.tsx
+++ b/src/admin/editor-config/editor-options/quick-suggestions-delay.tsx
@@ -3,7 +3,8 @@
  */
 import { __, sprintf } from '@wordpress/i18n';
 import { useContext } from '@wordpress/element';
-import { RangeControl, __experimentalHStack as HStack } from '@wordpress/components';
+import { RangeControl } from '@wordpress/components';
+import { Stack } from '@wordpress/ui';
 
 /**
  * Internal dependencies
@@ -32,7 +33,7 @@ export default function QuickSuggestionsDelay() {
 
 	return (
 		<div className="chbe-admin-editor-config__setting-item">
-			<HStack justify="start" alignment="start" wrap>
+			<Stack justify="start" align="start" wrap="wrap" gap="sm">
 				<RangeControl
 					__next40pxDefaultSize
 					label={ title }
@@ -67,7 +68,7 @@ export default function QuickSuggestionsDelay() {
 					] }
 					value={ editorOptions.quickSuggestionsDelay }
 				/>
-			</HStack>
+			</Stack>
 		</div>
 	);
 }

--- a/src/admin/editor-config/editor-options/quick-suggestions.tsx
+++ b/src/admin/editor-config/editor-options/quick-suggestions.tsx
@@ -3,7 +3,8 @@
  */
 import { __ } from '@wordpress/i18n';
 import { useContext } from '@wordpress/element';
-import { ToggleControl, __experimentalHStack as HStack } from '@wordpress/components';
+import { ToggleControl } from '@wordpress/components';
+import { Stack } from '@wordpress/ui';
 
 /**
  * Internal dependencies
@@ -32,7 +33,7 @@ export default function QuickSuggestions() {
 
 	return (
 		<div className="chbe-admin-editor-config__setting-item">
-			<HStack justify="start" alignment="start" wrap>
+			<Stack justify="start" align="start" wrap="wrap" gap="sm">
 				<ToggleControl
 					label={ title }
 					checked={ editorOptions.quickSuggestions }
@@ -50,7 +51,7 @@ export default function QuickSuggestions() {
 					image="editor-options/quick-suggestions.gif"
 					value={ editorOptions.quickSuggestions }
 				/>
-			</HStack>
+			</Stack>
 		</div>
 	);
 }

--- a/src/admin/editor-config/editor-options/quick-suggestions.tsx
+++ b/src/admin/editor-config/editor-options/quick-suggestions.tsx
@@ -32,26 +32,30 @@ export default function QuickSuggestions() {
 	};
 
 	return (
-		<div className="chbe-admin-editor-config__setting-item">
-			<Stack justify="start" align="start" wrap="wrap" gap="sm">
-				<ToggleControl
-					label={ title }
-					checked={ editorOptions.quickSuggestions }
-					onChange={ onChange }
-				/>
-				<ItemHelp
-					onChange={ onChange }
-					title={ title }
-					description={ __(
-						'Get suggestions as you type codes. Accepting suggestions will autocomplete code and help faster coding.',
-						'custom-html-block-extension'
-					) }
-					isToggle
-					defaultToggle
-					image="editor-options/quick-suggestions.gif"
-					value={ editorOptions.quickSuggestions }
-				/>
-			</Stack>
-		</div>
+		<Stack
+			className="chbe-admin-editor-config__setting-item"
+			justify="start"
+			align="start"
+			wrap="wrap"
+			gap="sm"
+		>
+			<ToggleControl
+				label={ title }
+				checked={ editorOptions.quickSuggestions }
+				onChange={ onChange }
+			/>
+			<ItemHelp
+				onChange={ onChange }
+				title={ title }
+				description={ __(
+					'Get suggestions as you type codes. Accepting suggestions will autocomplete code and help faster coding.',
+					'custom-html-block-extension'
+				) }
+				isToggle
+				defaultToggle
+				image="editor-options/quick-suggestions.gif"
+				value={ editorOptions.quickSuggestions }
+			/>
+		</Stack>
 	);
 }

--- a/src/admin/editor-config/editor-options/render-control-characters.tsx
+++ b/src/admin/editor-config/editor-options/render-control-characters.tsx
@@ -31,32 +31,36 @@ export default function RenderControlCharacters() {
 	};
 
 	return (
-		<div className="chbe-admin-editor-config__setting-item">
-			<Stack justify="start" align="start" wrap="wrap" gap="sm">
-				<ToggleControl
-					label={ title }
-					checked={ editorOptions.renderControlCharacters }
-					onChange={ onChange }
-				/>
-				<ItemHelp
-					onChange={ onChange }
-					title={ title }
-					items={ [
-						{
-							label: __( 'Enable', 'custom-html-block-extension' ),
-							value: true,
-							image: 'editor-options/render-control-characters_1.jpg',
-						},
-						{
-							label: __( 'Disable', 'custom-html-block-extension' ),
-							value: false,
-							image: 'editor-options/render-control-characters_2.jpg',
-							isDefault: true,
-						},
-					] }
-					value={ editorOptions.renderControlCharacters }
-				/>
-			</Stack>
-		</div>
+		<Stack
+			className="chbe-admin-editor-config__setting-item"
+			justify="start"
+			align="start"
+			wrap="wrap"
+			gap="sm"
+		>
+			<ToggleControl
+				label={ title }
+				checked={ editorOptions.renderControlCharacters }
+				onChange={ onChange }
+			/>
+			<ItemHelp
+				onChange={ onChange }
+				title={ title }
+				items={ [
+					{
+						label: __( 'Enable', 'custom-html-block-extension' ),
+						value: true,
+						image: 'editor-options/render-control-characters_1.jpg',
+					},
+					{
+						label: __( 'Disable', 'custom-html-block-extension' ),
+						value: false,
+						image: 'editor-options/render-control-characters_2.jpg',
+						isDefault: true,
+					},
+				] }
+				value={ editorOptions.renderControlCharacters }
+			/>
+		</Stack>
 	);
 }

--- a/src/admin/editor-config/editor-options/render-control-characters.tsx
+++ b/src/admin/editor-config/editor-options/render-control-characters.tsx
@@ -3,7 +3,8 @@
  */
 import { __ } from '@wordpress/i18n';
 import { useContext } from '@wordpress/element';
-import { ToggleControl, __experimentalHStack as HStack } from '@wordpress/components';
+import { ToggleControl } from '@wordpress/components';
+import { Stack } from '@wordpress/ui';
 
 /**
  * Internal dependencies
@@ -31,7 +32,7 @@ export default function RenderControlCharacters() {
 
 	return (
 		<div className="chbe-admin-editor-config__setting-item">
-			<HStack justify="start" alignment="start" wrap>
+			<Stack justify="start" align="start" wrap="wrap" gap="sm">
 				<ToggleControl
 					label={ title }
 					checked={ editorOptions.renderControlCharacters }
@@ -55,7 +56,7 @@ export default function RenderControlCharacters() {
 					] }
 					value={ editorOptions.renderControlCharacters }
 				/>
-			</HStack>
+			</Stack>
 		</div>
 	);
 }

--- a/src/admin/editor-config/editor-options/render-final-newline.tsx
+++ b/src/admin/editor-config/editor-options/render-final-newline.tsx
@@ -38,28 +38,32 @@ export default function RenderFinalNewline() {
 	};
 
 	return (
-		<div className="chbe-admin-editor-config__setting-item">
-			<Stack justify="start" align="start" wrap="wrap" gap="sm">
-				<ToggleControl label={ title } checked={ isEnabled } onChange={ onChange } />
-				<ItemHelp
-					onChange={ onChange }
-					title={ title }
-					items={ [
-						{
-							label: __( 'Enable', 'custom-html-block-extension' ),
-							value: true,
-							image: 'editor-options/render-final-newline_1.jpg',
-							isDefault: true,
-						},
-						{
-							label: __( 'Disable', 'custom-html-block-extension' ),
-							value: false,
-							image: 'editor-options/render-final-newline_2.jpg',
-						},
-					] }
-					value={ isEnabled }
-				/>
-			</Stack>
-		</div>
+		<Stack
+			className="chbe-admin-editor-config__setting-item"
+			justify="start"
+			align="start"
+			wrap="wrap"
+			gap="sm"
+		>
+			<ToggleControl label={ title } checked={ isEnabled } onChange={ onChange } />
+			<ItemHelp
+				onChange={ onChange }
+				title={ title }
+				items={ [
+					{
+						label: __( 'Enable', 'custom-html-block-extension' ),
+						value: true,
+						image: 'editor-options/render-final-newline_1.jpg',
+						isDefault: true,
+					},
+					{
+						label: __( 'Disable', 'custom-html-block-extension' ),
+						value: false,
+						image: 'editor-options/render-final-newline_2.jpg',
+					},
+				] }
+				value={ isEnabled }
+			/>
+		</Stack>
 	);
 }

--- a/src/admin/editor-config/editor-options/render-final-newline.tsx
+++ b/src/admin/editor-config/editor-options/render-final-newline.tsx
@@ -3,7 +3,8 @@
  */
 import { __ } from '@wordpress/i18n';
 import { useContext } from '@wordpress/element';
-import { ToggleControl, __experimentalHStack as HStack } from '@wordpress/components';
+import { ToggleControl } from '@wordpress/components';
+import { Stack } from '@wordpress/ui';
 
 /**
  * Internal dependencies
@@ -38,7 +39,7 @@ export default function RenderFinalNewline() {
 
 	return (
 		<div className="chbe-admin-editor-config__setting-item">
-			<HStack justify="start" alignment="start" wrap>
+			<Stack justify="start" align="start" wrap="wrap" gap="sm">
 				<ToggleControl label={ title } checked={ isEnabled } onChange={ onChange } />
 				<ItemHelp
 					onChange={ onChange }
@@ -58,7 +59,7 @@ export default function RenderFinalNewline() {
 					] }
 					value={ isEnabled }
 				/>
-			</HStack>
+			</Stack>
 		</div>
 	);
 }

--- a/src/admin/editor-config/editor-options/render-indent-guides.tsx
+++ b/src/admin/editor-config/editor-options/render-indent-guides.tsx
@@ -3,7 +3,8 @@
  */
 import { __ } from '@wordpress/i18n';
 import { useContext } from '@wordpress/element';
-import { ToggleControl, __experimentalHStack as HStack } from '@wordpress/components';
+import { ToggleControl } from '@wordpress/components';
+import { Stack } from '@wordpress/ui';
 
 /**
  * Internal dependencies
@@ -31,7 +32,7 @@ export default function RenderIndentGuides() {
 
 	return (
 		<div className="chbe-admin-editor-config__setting-item">
-			<HStack justify="start" alignment="start" wrap>
+			<Stack justify="start" align="start" wrap="wrap" gap="sm">
 				<ToggleControl
 					label={ title }
 					checked={ editorOptions.renderIndentGuides }
@@ -55,7 +56,7 @@ export default function RenderIndentGuides() {
 					] }
 					value={ editorOptions.renderIndentGuides }
 				/>
-			</HStack>
+			</Stack>
 		</div>
 	);
 }

--- a/src/admin/editor-config/editor-options/render-indent-guides.tsx
+++ b/src/admin/editor-config/editor-options/render-indent-guides.tsx
@@ -31,32 +31,36 @@ export default function RenderIndentGuides() {
 	};
 
 	return (
-		<div className="chbe-admin-editor-config__setting-item">
-			<Stack justify="start" align="start" wrap="wrap" gap="sm">
-				<ToggleControl
-					label={ title }
-					checked={ editorOptions.renderIndentGuides }
-					onChange={ onChange }
-				/>
-				<ItemHelp
-					onChange={ onChange }
-					title={ title }
-					items={ [
-						{
-							label: __( 'Enable', 'custom-html-block-extension' ),
-							value: true,
-							image: 'editor-options/render-indent-guides_1.jpg',
-							isDefault: true,
-						},
-						{
-							label: __( 'Disable', 'custom-html-block-extension' ),
-							value: false,
-							image: 'editor-options/render-indent-guides_2.jpg',
-						},
-					] }
-					value={ editorOptions.renderIndentGuides }
-				/>
-			</Stack>
-		</div>
+		<Stack
+			className="chbe-admin-editor-config__setting-item"
+			justify="start"
+			align="start"
+			wrap="wrap"
+			gap="sm"
+		>
+			<ToggleControl
+				label={ title }
+				checked={ editorOptions.renderIndentGuides }
+				onChange={ onChange }
+			/>
+			<ItemHelp
+				onChange={ onChange }
+				title={ title }
+				items={ [
+					{
+						label: __( 'Enable', 'custom-html-block-extension' ),
+						value: true,
+						image: 'editor-options/render-indent-guides_1.jpg',
+						isDefault: true,
+					},
+					{
+						label: __( 'Disable', 'custom-html-block-extension' ),
+						value: false,
+						image: 'editor-options/render-indent-guides_2.jpg',
+					},
+				] }
+				value={ editorOptions.renderIndentGuides }
+			/>
+		</Stack>
 	);
 }

--- a/src/admin/editor-config/editor-options/render-line-highlight-only-when-focus.tsx
+++ b/src/admin/editor-config/editor-options/render-line-highlight-only-when-focus.tsx
@@ -34,32 +34,36 @@ export default function RenderLineHighlightOnlyWhenFocus() {
 	};
 
 	return (
-		<div className="chbe-admin-editor-config__setting-item">
-			<Stack justify="start" align="start" wrap="wrap" gap="sm">
-				<ToggleControl
-					label={ title }
-					checked={ editorOptions.renderLineHighlightOnlyWhenFocus }
-					onChange={ onChange }
-				/>
-				<ItemHelp
-					onChange={ onChange }
-					title={ title }
-					items={ [
-						{
-							label: __( 'Enable', 'custom-html-block-extension' ),
-							value: true,
-							image: 'editor-options/render-line-highlight-only-when-focus_1.gif',
-						},
-						{
-							label: __( 'Disable', 'custom-html-block-extension' ),
-							value: false,
-							image: 'editor-options/render-line-highlight-only-when-focus_2.gif',
-							isDefault: true,
-						},
-					] }
-					value={ editorOptions.renderLineHighlightOnlyWhenFocus }
-				/>
-			</Stack>
-		</div>
+		<Stack
+			className="chbe-admin-editor-config__setting-item"
+			justify="start"
+			align="start"
+			wrap="wrap"
+			gap="sm"
+		>
+			<ToggleControl
+				label={ title }
+				checked={ editorOptions.renderLineHighlightOnlyWhenFocus }
+				onChange={ onChange }
+			/>
+			<ItemHelp
+				onChange={ onChange }
+				title={ title }
+				items={ [
+					{
+						label: __( 'Enable', 'custom-html-block-extension' ),
+						value: true,
+						image: 'editor-options/render-line-highlight-only-when-focus_1.gif',
+					},
+					{
+						label: __( 'Disable', 'custom-html-block-extension' ),
+						value: false,
+						image: 'editor-options/render-line-highlight-only-when-focus_2.gif',
+						isDefault: true,
+					},
+				] }
+				value={ editorOptions.renderLineHighlightOnlyWhenFocus }
+			/>
+		</Stack>
 	);
 }

--- a/src/admin/editor-config/editor-options/render-line-highlight-only-when-focus.tsx
+++ b/src/admin/editor-config/editor-options/render-line-highlight-only-when-focus.tsx
@@ -3,7 +3,8 @@
  */
 import { __ } from '@wordpress/i18n';
 import { useContext } from '@wordpress/element';
-import { ToggleControl, __experimentalHStack as HStack } from '@wordpress/components';
+import { ToggleControl } from '@wordpress/components';
+import { Stack } from '@wordpress/ui';
 
 /**
  * Internal dependencies
@@ -34,7 +35,7 @@ export default function RenderLineHighlightOnlyWhenFocus() {
 
 	return (
 		<div className="chbe-admin-editor-config__setting-item">
-			<HStack justify="start" alignment="start" wrap>
+			<Stack justify="start" align="start" wrap="wrap" gap="sm">
 				<ToggleControl
 					label={ title }
 					checked={ editorOptions.renderLineHighlightOnlyWhenFocus }
@@ -58,7 +59,7 @@ export default function RenderLineHighlightOnlyWhenFocus() {
 					] }
 					value={ editorOptions.renderLineHighlightOnlyWhenFocus }
 				/>
-			</HStack>
+			</Stack>
 		</div>
 	);
 }

--- a/src/admin/editor-config/editor-options/render-line-highlight.tsx
+++ b/src/admin/editor-config/editor-options/render-line-highlight.tsx
@@ -3,7 +3,8 @@
  */
 import { __ } from '@wordpress/i18n';
 import { useContext } from '@wordpress/element';
-import { SelectControl, __experimentalHStack as HStack } from '@wordpress/components';
+import { SelectControl } from '@wordpress/components';
+import { Stack } from '@wordpress/ui';
 
 /**
  * Internal dependencies
@@ -56,7 +57,7 @@ export default function RenderLineHighlight() {
 
 	return (
 		<div className="chbe-admin-editor-config__setting-item">
-			<HStack justify="start" alignment="start" wrap>
+			<Stack justify="start" align="start" wrap="wrap" gap="sm">
 				<SelectControl< EditorOptions[ 'renderLineHighlight' ] >
 					__next40pxDefaultSize
 					label={ title }
@@ -70,7 +71,7 @@ export default function RenderLineHighlight() {
 					items={ items }
 					value={ editorOptions.renderLineHighlight }
 				/>
-			</HStack>
+			</Stack>
 		</div>
 	);
 }

--- a/src/admin/editor-config/editor-options/render-line-highlight.tsx
+++ b/src/admin/editor-config/editor-options/render-line-highlight.tsx
@@ -56,22 +56,26 @@ export default function RenderLineHighlight() {
 	};
 
 	return (
-		<div className="chbe-admin-editor-config__setting-item">
-			<Stack justify="start" align="start" wrap="wrap" gap="sm">
-				<SelectControl< EditorOptions[ 'renderLineHighlight' ] >
-					__next40pxDefaultSize
-					label={ title }
-					value={ editorOptions.renderLineHighlight }
-					options={ items.map( ( { label, value } ) => ( { label, value } ) ) }
-					onChange={ onChange }
-				/>
-				<ItemHelp
-					onChange={ onChange }
-					title={ title }
-					items={ items }
-					value={ editorOptions.renderLineHighlight }
-				/>
-			</Stack>
-		</div>
+		<Stack
+			className="chbe-admin-editor-config__setting-item"
+			justify="start"
+			align="start"
+			wrap="wrap"
+			gap="sm"
+		>
+			<SelectControl< EditorOptions[ 'renderLineHighlight' ] >
+				__next40pxDefaultSize
+				label={ title }
+				value={ editorOptions.renderLineHighlight }
+				options={ items.map( ( { label, value } ) => ( { label, value } ) ) }
+				onChange={ onChange }
+			/>
+			<ItemHelp
+				onChange={ onChange }
+				title={ title }
+				items={ items }
+				value={ editorOptions.renderLineHighlight }
+			/>
+		</Stack>
 	);
 }

--- a/src/admin/editor-config/editor-options/render-whitespace.tsx
+++ b/src/admin/editor-config/editor-options/render-whitespace.tsx
@@ -64,22 +64,26 @@ export default function RenderWhitespace() {
 	};
 
 	return (
-		<div className="chbe-admin-editor-config__setting-item">
-			<Stack justify="start" align="start" wrap="wrap" gap="sm">
-				<SelectControl< EditorOptions[ 'renderWhitespace' ] >
-					__next40pxDefaultSize
-					label={ title }
-					value={ editorOptions.renderWhitespace }
-					options={ items.map( ( { label, value } ) => ( { label, value } ) ) }
-					onChange={ onChange }
-				/>
-				<ItemHelp
-					onChange={ onChange }
-					title={ title }
-					items={ items }
-					value={ editorOptions.renderWhitespace }
-				/>
-			</Stack>
-		</div>
+		<Stack
+			className="chbe-admin-editor-config__setting-item"
+			justify="start"
+			align="start"
+			wrap="wrap"
+			gap="sm"
+		>
+			<SelectControl< EditorOptions[ 'renderWhitespace' ] >
+				__next40pxDefaultSize
+				label={ title }
+				value={ editorOptions.renderWhitespace }
+				options={ items.map( ( { label, value } ) => ( { label, value } ) ) }
+				onChange={ onChange }
+			/>
+			<ItemHelp
+				onChange={ onChange }
+				title={ title }
+				items={ items }
+				value={ editorOptions.renderWhitespace }
+			/>
+		</Stack>
 	);
 }

--- a/src/admin/editor-config/editor-options/render-whitespace.tsx
+++ b/src/admin/editor-config/editor-options/render-whitespace.tsx
@@ -3,7 +3,8 @@
  */
 import { __ } from '@wordpress/i18n';
 import { useContext } from '@wordpress/element';
-import { SelectControl, __experimentalHStack as HStack } from '@wordpress/components';
+import { SelectControl } from '@wordpress/components';
+import { Stack } from '@wordpress/ui';
 
 /**
  * Internal dependencies
@@ -64,7 +65,7 @@ export default function RenderWhitespace() {
 
 	return (
 		<div className="chbe-admin-editor-config__setting-item">
-			<HStack justify="start" alignment="start" wrap>
+			<Stack justify="start" align="start" wrap="wrap" gap="sm">
 				<SelectControl< EditorOptions[ 'renderWhitespace' ] >
 					__next40pxDefaultSize
 					label={ title }
@@ -78,7 +79,7 @@ export default function RenderWhitespace() {
 					items={ items }
 					value={ editorOptions.renderWhitespace }
 				/>
-			</HStack>
+			</Stack>
 		</div>
 	);
 }

--- a/src/admin/editor-config/editor-options/rounded-selection.tsx
+++ b/src/admin/editor-config/editor-options/rounded-selection.tsx
@@ -3,7 +3,8 @@
  */
 import { __ } from '@wordpress/i18n';
 import { useContext } from '@wordpress/element';
-import { ToggleControl, __experimentalHStack as HStack } from '@wordpress/components';
+import { ToggleControl } from '@wordpress/components';
+import { Stack } from '@wordpress/ui';
 
 /**
  * Internal dependencies
@@ -31,7 +32,7 @@ export default function RoundedSelection() {
 
 	return (
 		<div className="chbe-admin-editor-config__setting-item">
-			<HStack justify="start" alignment="start" wrap>
+			<Stack justify="start" align="start" wrap="wrap" gap="sm">
 				<ToggleControl
 					label={ title }
 					checked={ editorOptions.roundedSelection }
@@ -55,7 +56,7 @@ export default function RoundedSelection() {
 					] }
 					value={ editorOptions.roundedSelection }
 				/>
-			</HStack>
+			</Stack>
 		</div>
 	);
 }

--- a/src/admin/editor-config/editor-options/rounded-selection.tsx
+++ b/src/admin/editor-config/editor-options/rounded-selection.tsx
@@ -31,32 +31,36 @@ export default function RoundedSelection() {
 	};
 
 	return (
-		<div className="chbe-admin-editor-config__setting-item">
-			<Stack justify="start" align="start" wrap="wrap" gap="sm">
-				<ToggleControl
-					label={ title }
-					checked={ editorOptions.roundedSelection }
-					onChange={ onChange }
-				/>
-				<ItemHelp
-					onChange={ onChange }
-					title={ title }
-					items={ [
-						{
-							label: __( 'Enable', 'custom-html-block-extension' ),
-							value: true,
-							image: 'editor-options/rounded-selection_1.jpg',
-						},
-						{
-							label: __( 'Disable', 'custom-html-block-extension' ),
-							value: false,
-							isDefault: true,
-							image: 'editor-options/rounded-selection_2.jpg',
-						},
-					] }
-					value={ editorOptions.roundedSelection }
-				/>
-			</Stack>
-		</div>
+		<Stack
+			className="chbe-admin-editor-config__setting-item"
+			justify="start"
+			align="start"
+			wrap="wrap"
+			gap="sm"
+		>
+			<ToggleControl
+				label={ title }
+				checked={ editorOptions.roundedSelection }
+				onChange={ onChange }
+			/>
+			<ItemHelp
+				onChange={ onChange }
+				title={ title }
+				items={ [
+					{
+						label: __( 'Enable', 'custom-html-block-extension' ),
+						value: true,
+						image: 'editor-options/rounded-selection_1.jpg',
+					},
+					{
+						label: __( 'Disable', 'custom-html-block-extension' ),
+						value: false,
+						isDefault: true,
+						image: 'editor-options/rounded-selection_2.jpg',
+					},
+				] }
+				value={ editorOptions.roundedSelection }
+			/>
+		</Stack>
 	);
 }

--- a/src/admin/editor-config/editor-options/rulers.tsx
+++ b/src/admin/editor-config/editor-options/rulers.tsx
@@ -3,7 +3,8 @@
  */
 import { __ } from '@wordpress/i18n';
 import { useContext } from '@wordpress/element';
-import { RangeControl, __experimentalHStack as HStack } from '@wordpress/components';
+import { RangeControl } from '@wordpress/components';
+import { Stack } from '@wordpress/ui';
 
 /**
  * Internal dependencies
@@ -33,7 +34,7 @@ export default function Rulers() {
 
 	return (
 		<div className="chbe-admin-editor-config__setting-item">
-			<HStack justify="start" alignment="start" wrap>
+			<Stack justify="start" align="start" wrap="wrap" gap="sm">
 				<RangeControl
 					__next40pxDefaultSize
 					label={ title }
@@ -44,7 +45,7 @@ export default function Rulers() {
 					onChange={ onChange }
 				/>
 				<ItemHelp onChange={ onChange } title={ title } image="editor-options/rulers.gif" />
-			</HStack>
+			</Stack>
 		</div>
 	);
 }

--- a/src/admin/editor-config/editor-options/rulers.tsx
+++ b/src/admin/editor-config/editor-options/rulers.tsx
@@ -33,19 +33,23 @@ export default function Rulers() {
 	};
 
 	return (
-		<div className="chbe-admin-editor-config__setting-item">
-			<Stack justify="start" align="start" wrap="wrap" gap="sm">
-				<RangeControl
-					__next40pxDefaultSize
-					label={ title }
-					value={ editorOptions.rulers.length ? editorOptions.rulers[ 0 ] : 0 }
-					min={ 0 }
-					max={ 80 }
-					allowReset
-					onChange={ onChange }
-				/>
-				<ItemHelp onChange={ onChange } title={ title } image="editor-options/rulers.gif" />
-			</Stack>
-		</div>
+		<Stack
+			className="chbe-admin-editor-config__setting-item"
+			justify="start"
+			align="start"
+			wrap="wrap"
+			gap="sm"
+		>
+			<RangeControl
+				__next40pxDefaultSize
+				label={ title }
+				value={ editorOptions.rulers.length ? editorOptions.rulers[ 0 ] : 0 }
+				min={ 0 }
+				max={ 80 }
+				allowReset
+				onChange={ onChange }
+			/>
+			<ItemHelp onChange={ onChange } title={ title } image="editor-options/rulers.gif" />
+		</Stack>
 	);
 }

--- a/src/admin/editor-config/editor-options/scroll-beyond-last-column.tsx
+++ b/src/admin/editor-config/editor-options/scroll-beyond-last-column.tsx
@@ -35,43 +35,47 @@ export default function ScrollBeyondLastColumn() {
 	};
 
 	return (
-		<div className="chbe-admin-editor-config__setting-item">
-			<Stack justify="start" align="start" wrap="wrap" gap="sm">
-				<RangeControl
-					__next40pxDefaultSize
-					label={ title }
-					value={ editorOptions.scrollBeyondLastColumn }
-					min={ 0 }
-					max={ 20 }
-					allowReset
-					onChange={ onChange }
-				/>
-				<ItemHelp
-					onChange={ onChange }
-					title={ title }
-					items={ [
-						{
-							label: sprintf(
-								/* translators: %s is replaced with the number. */
-								__( 'Example: Set the value to %s', 'custom-html-block-extension' ),
-								'0'
-							),
-							image: 'editor-options/suggest-line-height_1.jpg',
-							value: 0,
-						},
-						{
-							label: sprintf(
-								/* translators: %s is replaced with the number. */
-								__( 'Example: Set the value to %s', 'custom-html-block-extension' ),
-								'20'
-							),
-							image: 'editor-options/suggest-line-height_2.jpg',
-							value: 20,
-						},
-					] }
-					value={ editorOptions.scrollBeyondLastColumn }
-				/>
-			</Stack>
-		</div>
+		<Stack
+			className="chbe-admin-editor-config__setting-item"
+			justify="start"
+			align="start"
+			wrap="wrap"
+			gap="sm"
+		>
+			<RangeControl
+				__next40pxDefaultSize
+				label={ title }
+				value={ editorOptions.scrollBeyondLastColumn }
+				min={ 0 }
+				max={ 20 }
+				allowReset
+				onChange={ onChange }
+			/>
+			<ItemHelp
+				onChange={ onChange }
+				title={ title }
+				items={ [
+					{
+						label: sprintf(
+							/* translators: %s is replaced with the number. */
+							__( 'Example: Set the value to %s', 'custom-html-block-extension' ),
+							'0'
+						),
+						image: 'editor-options/suggest-line-height_1.jpg',
+						value: 0,
+					},
+					{
+						label: sprintf(
+							/* translators: %s is replaced with the number. */
+							__( 'Example: Set the value to %s', 'custom-html-block-extension' ),
+							'20'
+						),
+						image: 'editor-options/suggest-line-height_2.jpg',
+						value: 20,
+					},
+				] }
+				value={ editorOptions.scrollBeyondLastColumn }
+			/>
+		</Stack>
 	);
 }

--- a/src/admin/editor-config/editor-options/scroll-beyond-last-column.tsx
+++ b/src/admin/editor-config/editor-options/scroll-beyond-last-column.tsx
@@ -3,7 +3,8 @@
  */
 import { __, sprintf } from '@wordpress/i18n';
 import { useContext } from '@wordpress/element';
-import { RangeControl, __experimentalHStack as HStack } from '@wordpress/components';
+import { RangeControl } from '@wordpress/components';
+import { Stack } from '@wordpress/ui';
 
 /**
  * Internal dependencies
@@ -35,7 +36,7 @@ export default function ScrollBeyondLastColumn() {
 
 	return (
 		<div className="chbe-admin-editor-config__setting-item">
-			<HStack justify="start" alignment="start" wrap>
+			<Stack justify="start" align="start" wrap="wrap" gap="sm">
 				<RangeControl
 					__next40pxDefaultSize
 					label={ title }
@@ -70,7 +71,7 @@ export default function ScrollBeyondLastColumn() {
 					] }
 					value={ editorOptions.scrollBeyondLastColumn }
 				/>
-			</HStack>
+			</Stack>
 		</div>
 	);
 }

--- a/src/admin/editor-config/editor-options/scroll-beyond-last-line.tsx
+++ b/src/admin/editor-config/editor-options/scroll-beyond-last-line.tsx
@@ -3,7 +3,8 @@
  */
 import { __ } from '@wordpress/i18n';
 import { useContext } from '@wordpress/element';
-import { ToggleControl, __experimentalHStack as HStack } from '@wordpress/components';
+import { ToggleControl } from '@wordpress/components';
+import { Stack } from '@wordpress/ui';
 
 /**
  * Internal dependencies
@@ -31,7 +32,7 @@ export default function ScrollBeyondLastLine() {
 
 	return (
 		<div className="chbe-admin-editor-config__setting-item">
-			<HStack justify="start" alignment="start" wrap>
+			<Stack justify="start" align="start" wrap="wrap" gap="sm">
 				<ToggleControl
 					label={ title }
 					checked={ editorOptions.scrollBeyondLastLine }
@@ -55,7 +56,7 @@ export default function ScrollBeyondLastLine() {
 					] }
 					value={ editorOptions.scrollBeyondLastLine }
 				/>
-			</HStack>
+			</Stack>
 		</div>
 	);
 }

--- a/src/admin/editor-config/editor-options/scroll-beyond-last-line.tsx
+++ b/src/admin/editor-config/editor-options/scroll-beyond-last-line.tsx
@@ -31,32 +31,36 @@ export default function ScrollBeyondLastLine() {
 	};
 
 	return (
-		<div className="chbe-admin-editor-config__setting-item">
-			<Stack justify="start" align="start" wrap="wrap" gap="sm">
-				<ToggleControl
-					label={ title }
-					checked={ editorOptions.scrollBeyondLastLine }
-					onChange={ onChange }
-				/>
-				<ItemHelp
-					onChange={ onChange }
-					title={ title }
-					items={ [
-						{
-							label: __( 'Enable', 'custom-html-block-extension' ),
-							value: true,
-							image: 'editor-options/scroll-beyond-last-line_1.gif',
-							isDefault: true,
-						},
-						{
-							label: __( 'Disable', 'custom-html-block-extension' ),
-							value: false,
-							image: 'editor-options/scroll-beyond-last-line_2.gif',
-						},
-					] }
-					value={ editorOptions.scrollBeyondLastLine }
-				/>
-			</Stack>
-		</div>
+		<Stack
+			className="chbe-admin-editor-config__setting-item"
+			justify="start"
+			align="start"
+			wrap="wrap"
+			gap="sm"
+		>
+			<ToggleControl
+				label={ title }
+				checked={ editorOptions.scrollBeyondLastLine }
+				onChange={ onChange }
+			/>
+			<ItemHelp
+				onChange={ onChange }
+				title={ title }
+				items={ [
+					{
+						label: __( 'Enable', 'custom-html-block-extension' ),
+						value: true,
+						image: 'editor-options/scroll-beyond-last-line_1.gif',
+						isDefault: true,
+					},
+					{
+						label: __( 'Disable', 'custom-html-block-extension' ),
+						value: false,
+						image: 'editor-options/scroll-beyond-last-line_2.gif',
+					},
+				] }
+				value={ editorOptions.scrollBeyondLastLine }
+			/>
+		</Stack>
 	);
 }

--- a/src/admin/editor-config/editor-options/scrollbar/always-consume-mouse-wheel.tsx
+++ b/src/admin/editor-config/editor-options/scrollbar/always-consume-mouse-wheel.tsx
@@ -3,7 +3,8 @@
  */
 import { __ } from '@wordpress/i18n';
 import { useContext } from '@wordpress/element';
-import { ToggleControl, __experimentalHStack as HStack } from '@wordpress/components';
+import { ToggleControl } from '@wordpress/components';
+import { Stack } from '@wordpress/ui';
 
 /**
  * Internal dependencies
@@ -36,7 +37,7 @@ export default function ScrollbarAlwaysConsumeMouseWheel() {
 
 	return (
 		<div className="chbe-admin-editor-config__setting-item">
-			<HStack justify="start" alignment="start" wrap>
+			<Stack justify="start" align="start" wrap="wrap" gap="sm">
 				<ToggleControl
 					label={ title }
 					checked={ editorOptions.scrollbar.alwaysConsumeMouseWheel }
@@ -68,7 +69,7 @@ export default function ScrollbarAlwaysConsumeMouseWheel() {
 					] }
 					value={ editorOptions.scrollbar.alwaysConsumeMouseWheel }
 				/>
-			</HStack>
+			</Stack>
 		</div>
 	);
 }

--- a/src/admin/editor-config/editor-options/scrollbar/always-consume-mouse-wheel.tsx
+++ b/src/admin/editor-config/editor-options/scrollbar/always-consume-mouse-wheel.tsx
@@ -36,40 +36,44 @@ export default function ScrollbarAlwaysConsumeMouseWheel() {
 	};
 
 	return (
-		<div className="chbe-admin-editor-config__setting-item">
-			<Stack justify="start" align="start" wrap="wrap" gap="sm">
-				<ToggleControl
-					label={ title }
-					checked={ editorOptions.scrollbar.alwaysConsumeMouseWheel }
-					onChange={ onChange }
-				/>
-				<ItemHelp
-					onChange={ onChange }
-					title={ title }
-					items={ [
-						{
-							label: __( 'Enable', 'custom-html-block-extension' ),
-							value: true,
-							isDefault: true,
-							description: __(
-								'Browser does not scroll when mouse wheel reaches the beginning or end.',
-								'custom-html-block-extension'
-							),
-							image: 'editor-options/scrollbar/always-consume-mouse-wheel_1.gif',
-						},
-						{
-							label: __( 'Disable', 'custom-html-block-extension' ),
-							value: false,
-							description: __(
-								'Browser will scroll when mouse wheel reaches the beginning or end.',
-								'custom-html-block-extension'
-							),
-							image: 'editor-options/scrollbar/always-consume-mouse-wheel_2.gif',
-						},
-					] }
-					value={ editorOptions.scrollbar.alwaysConsumeMouseWheel }
-				/>
-			</Stack>
-		</div>
+		<Stack
+			className="chbe-admin-editor-config__setting-item"
+			justify="start"
+			align="start"
+			wrap="wrap"
+			gap="sm"
+		>
+			<ToggleControl
+				label={ title }
+				checked={ editorOptions.scrollbar.alwaysConsumeMouseWheel }
+				onChange={ onChange }
+			/>
+			<ItemHelp
+				onChange={ onChange }
+				title={ title }
+				items={ [
+					{
+						label: __( 'Enable', 'custom-html-block-extension' ),
+						value: true,
+						isDefault: true,
+						description: __(
+							'Browser does not scroll when mouse wheel reaches the beginning or end.',
+							'custom-html-block-extension'
+						),
+						image: 'editor-options/scrollbar/always-consume-mouse-wheel_1.gif',
+					},
+					{
+						label: __( 'Disable', 'custom-html-block-extension' ),
+						value: false,
+						description: __(
+							'Browser will scroll when mouse wheel reaches the beginning or end.',
+							'custom-html-block-extension'
+						),
+						image: 'editor-options/scrollbar/always-consume-mouse-wheel_2.gif',
+					},
+				] }
+				value={ editorOptions.scrollbar.alwaysConsumeMouseWheel }
+			/>
+		</Stack>
 	);
 }

--- a/src/admin/editor-config/editor-options/scrollbar/arrow-size.tsx
+++ b/src/admin/editor-config/editor-options/scrollbar/arrow-size.tsx
@@ -3,7 +3,8 @@
  */
 import { __, sprintf } from '@wordpress/i18n';
 import { useCallback, useContext, useState } from '@wordpress/element';
-import { RangeControl, __experimentalHStack as HStack } from '@wordpress/components';
+import { RangeControl } from '@wordpress/components';
+import { Stack } from '@wordpress/ui';
 import { useDebounce } from '@wordpress/compose';
 
 /**
@@ -50,7 +51,7 @@ export default function ScrollbarArrowSize() {
 
 	return (
 		<div className="chbe-admin-editor-config__setting-item">
-			<HStack justify="start" alignment="start" wrap>
+			<Stack justify="start" align="start" wrap="wrap" gap="sm">
 				<RangeControl
 					__next40pxDefaultSize
 					label={ title }
@@ -85,7 +86,7 @@ export default function ScrollbarArrowSize() {
 					] }
 					value={ value }
 				/>
-			</HStack>
+			</Stack>
 		</div>
 	);
 }

--- a/src/admin/editor-config/editor-options/scrollbar/arrow-size.tsx
+++ b/src/admin/editor-config/editor-options/scrollbar/arrow-size.tsx
@@ -50,43 +50,47 @@ export default function ScrollbarArrowSize() {
 	};
 
 	return (
-		<div className="chbe-admin-editor-config__setting-item">
-			<Stack justify="start" align="start" wrap="wrap" gap="sm">
-				<RangeControl
-					__next40pxDefaultSize
-					label={ title }
-					value={ value }
-					min={ 5 }
-					max={ 50 }
-					allowReset
-					onChange={ onChange }
-				/>
-				<ItemHelp
-					onChange={ onChange }
-					title={ title }
-					items={ [
-						{
-							label: sprintf(
-								/* translators: %s is replaced with the number. */
-								__( 'Example: Set the value to %s', 'custom-html-block-extension' ),
-								'10'
-							),
-							image: 'editor-options/scrollbar/arrow-size_1.jpg',
-							value: 10,
-						},
-						{
-							label: sprintf(
-								/* translators: %s is replaced with the number. */
-								__( 'Example: Set the value to %s', 'custom-html-block-extension' ),
-								'30'
-							),
-							image: 'editor-options/scrollbar/arrow-size_2.jpg',
-							value: 30,
-						},
-					] }
-					value={ value }
-				/>
-			</Stack>
-		</div>
+		<Stack
+			className="chbe-admin-editor-config__setting-item"
+			justify="start"
+			align="start"
+			wrap="wrap"
+			gap="sm"
+		>
+			<RangeControl
+				__next40pxDefaultSize
+				label={ title }
+				value={ value }
+				min={ 5 }
+				max={ 50 }
+				allowReset
+				onChange={ onChange }
+			/>
+			<ItemHelp
+				onChange={ onChange }
+				title={ title }
+				items={ [
+					{
+						label: sprintf(
+							/* translators: %s is replaced with the number. */
+							__( 'Example: Set the value to %s', 'custom-html-block-extension' ),
+							'10'
+						),
+						image: 'editor-options/scrollbar/arrow-size_1.jpg',
+						value: 10,
+					},
+					{
+						label: sprintf(
+							/* translators: %s is replaced with the number. */
+							__( 'Example: Set the value to %s', 'custom-html-block-extension' ),
+							'30'
+						),
+						image: 'editor-options/scrollbar/arrow-size_2.jpg',
+						value: 30,
+					},
+				] }
+				value={ value }
+			/>
+		</Stack>
 	);
 }

--- a/src/admin/editor-config/editor-options/scrollbar/horizontal-has-arrows.tsx
+++ b/src/admin/editor-config/editor-options/scrollbar/horizontal-has-arrows.tsx
@@ -3,7 +3,8 @@
  */
 import { __ } from '@wordpress/i18n';
 import { useContext } from '@wordpress/element';
-import { ToggleControl, __experimentalHStack as HStack } from '@wordpress/components';
+import { ToggleControl } from '@wordpress/components';
+import { Stack } from '@wordpress/ui';
 
 /**
  * Internal dependencies
@@ -36,7 +37,7 @@ export default function ScrollbarHorizontalHasArrows() {
 
 	return (
 		<div className="chbe-admin-editor-config__setting-item">
-			<HStack justify="start" alignment="start" wrap>
+			<Stack justify="start" align="start" wrap="wrap" gap="sm">
 				<ToggleControl
 					label={ title }
 					checked={ editorOptions.scrollbar.horizontalHasArrows }
@@ -60,7 +61,7 @@ export default function ScrollbarHorizontalHasArrows() {
 					] }
 					value={ editorOptions.scrollbar.horizontalHasArrows }
 				/>
-			</HStack>
+			</Stack>
 		</div>
 	);
 }

--- a/src/admin/editor-config/editor-options/scrollbar/horizontal-has-arrows.tsx
+++ b/src/admin/editor-config/editor-options/scrollbar/horizontal-has-arrows.tsx
@@ -36,32 +36,36 @@ export default function ScrollbarHorizontalHasArrows() {
 	};
 
 	return (
-		<div className="chbe-admin-editor-config__setting-item">
-			<Stack justify="start" align="start" wrap="wrap" gap="sm">
-				<ToggleControl
-					label={ title }
-					checked={ editorOptions.scrollbar.horizontalHasArrows }
-					onChange={ onChange }
-				/>
-				<ItemHelp
-					onChange={ onChange }
-					title={ title }
-					items={ [
-						{
-							label: __( 'Enable', 'custom-html-block-extension' ),
-							image: 'editor-options/scrollbar/horizontal-has-arrows_1.jpg',
-							value: true,
-						},
-						{
-							label: __( 'Disable', 'custom-html-block-extension' ),
-							image: 'editor-options/scrollbar/horizontal-has-arrows_2.jpg',
-							value: false,
-							isDefault: true,
-						},
-					] }
-					value={ editorOptions.scrollbar.horizontalHasArrows }
-				/>
-			</Stack>
-		</div>
+		<Stack
+			className="chbe-admin-editor-config__setting-item"
+			justify="start"
+			align="start"
+			wrap="wrap"
+			gap="sm"
+		>
+			<ToggleControl
+				label={ title }
+				checked={ editorOptions.scrollbar.horizontalHasArrows }
+				onChange={ onChange }
+			/>
+			<ItemHelp
+				onChange={ onChange }
+				title={ title }
+				items={ [
+					{
+						label: __( 'Enable', 'custom-html-block-extension' ),
+						image: 'editor-options/scrollbar/horizontal-has-arrows_1.jpg',
+						value: true,
+					},
+					{
+						label: __( 'Disable', 'custom-html-block-extension' ),
+						image: 'editor-options/scrollbar/horizontal-has-arrows_2.jpg',
+						value: false,
+						isDefault: true,
+					},
+				] }
+				value={ editorOptions.scrollbar.horizontalHasArrows }
+			/>
+		</Stack>
 	);
 }

--- a/src/admin/editor-config/editor-options/scrollbar/horizontal-scrollbar-size.tsx
+++ b/src/admin/editor-config/editor-options/scrollbar/horizontal-scrollbar-size.tsx
@@ -3,7 +3,8 @@
  */
 import { __, sprintf } from '@wordpress/i18n';
 import { useCallback, useContext, useState } from '@wordpress/element';
-import { RangeControl, __experimentalHStack as HStack } from '@wordpress/components';
+import { RangeControl } from '@wordpress/components';
+import { Stack } from '@wordpress/ui';
 import { useDebounce } from '@wordpress/compose';
 
 /**
@@ -50,7 +51,7 @@ export default function ScrollbarHorizontalScrollbarSize() {
 
 	return (
 		<div className="chbe-admin-editor-config__setting-item">
-			<HStack justify="start" alignment="start" wrap>
+			<Stack justify="start" align="start" wrap="wrap" gap="sm">
 				<RangeControl
 					__next40pxDefaultSize
 					label={ title }
@@ -85,7 +86,7 @@ export default function ScrollbarHorizontalScrollbarSize() {
 					] }
 					value={ value }
 				/>
-			</HStack>
+			</Stack>
 		</div>
 	);
 }

--- a/src/admin/editor-config/editor-options/scrollbar/horizontal-scrollbar-size.tsx
+++ b/src/admin/editor-config/editor-options/scrollbar/horizontal-scrollbar-size.tsx
@@ -50,43 +50,47 @@ export default function ScrollbarHorizontalScrollbarSize() {
 	};
 
 	return (
-		<div className="chbe-admin-editor-config__setting-item">
-			<Stack justify="start" align="start" wrap="wrap" gap="sm">
-				<RangeControl
-					__next40pxDefaultSize
-					label={ title }
-					value={ value }
-					min={ 5 }
-					max={ 30 }
-					allowReset
-					onChange={ onChange }
-				/>
-				<ItemHelp
-					onChange={ onChange }
-					title={ title }
-					items={ [
-						{
-							label: sprintf(
-								/* translators: %s is replaced with the number. */
-								__( 'Example: Set the value to %s', 'custom-html-block-extension' ),
-								'10'
-							),
-							image: 'editor-options/scrollbar/horizontal-scrollbar-size_1.jpg',
-							value: 10,
-						},
-						{
-							label: sprintf(
-								/* translators: %s is replaced with the number. */
-								__( 'Example: Set the value to %s', 'custom-html-block-extension' ),
-								'30'
-							),
-							image: 'editor-options/scrollbar/horizontal-scrollbar-size_2.jpg',
-							value: 30,
-						},
-					] }
-					value={ value }
-				/>
-			</Stack>
-		</div>
+		<Stack
+			className="chbe-admin-editor-config__setting-item"
+			justify="start"
+			align="start"
+			wrap="wrap"
+			gap="sm"
+		>
+			<RangeControl
+				__next40pxDefaultSize
+				label={ title }
+				value={ value }
+				min={ 5 }
+				max={ 30 }
+				allowReset
+				onChange={ onChange }
+			/>
+			<ItemHelp
+				onChange={ onChange }
+				title={ title }
+				items={ [
+					{
+						label: sprintf(
+							/* translators: %s is replaced with the number. */
+							__( 'Example: Set the value to %s', 'custom-html-block-extension' ),
+							'10'
+						),
+						image: 'editor-options/scrollbar/horizontal-scrollbar-size_1.jpg',
+						value: 10,
+					},
+					{
+						label: sprintf(
+							/* translators: %s is replaced with the number. */
+							__( 'Example: Set the value to %s', 'custom-html-block-extension' ),
+							'30'
+						),
+						image: 'editor-options/scrollbar/horizontal-scrollbar-size_2.jpg',
+						value: 30,
+					},
+				] }
+				value={ value }
+			/>
+		</Stack>
 	);
 }

--- a/src/admin/editor-config/editor-options/scrollbar/horizontal.tsx
+++ b/src/admin/editor-config/editor-options/scrollbar/horizontal.tsx
@@ -3,7 +3,8 @@
  */
 import { __ } from '@wordpress/i18n';
 import { useContext } from '@wordpress/element';
-import { SelectControl, __experimentalHStack as HStack } from '@wordpress/components';
+import { SelectControl } from '@wordpress/components';
+import { Stack } from '@wordpress/ui';
 
 /**
  * Internal dependencies
@@ -56,7 +57,7 @@ export default function ScrollbarHorizontal() {
 
 	return (
 		<div className="chbe-admin-editor-config__setting-item">
-			<HStack justify="start" alignment="start" wrap>
+			<Stack justify="start" align="start" wrap="wrap" gap="sm">
 				<SelectControl< EditorOptions[ 'scrollbar' ][ 'horizontal' ] >
 					__next40pxDefaultSize
 					label={ title }
@@ -71,7 +72,7 @@ export default function ScrollbarHorizontal() {
 					colCount="3"
 					value={ editorOptions.scrollbar.horizontal }
 				/>
-			</HStack>
+			</Stack>
 		</div>
 	);
 }

--- a/src/admin/editor-config/editor-options/scrollbar/horizontal.tsx
+++ b/src/admin/editor-config/editor-options/scrollbar/horizontal.tsx
@@ -56,23 +56,27 @@ export default function ScrollbarHorizontal() {
 	};
 
 	return (
-		<div className="chbe-admin-editor-config__setting-item">
-			<Stack justify="start" align="start" wrap="wrap" gap="sm">
-				<SelectControl< EditorOptions[ 'scrollbar' ][ 'horizontal' ] >
-					__next40pxDefaultSize
-					label={ title }
-					value={ editorOptions.scrollbar.horizontal }
-					options={ items.map( ( { label, value } ) => ( { label, value } ) ) }
-					onChange={ onChange }
-				/>
-				<ItemHelp
-					onChange={ onChange }
-					title={ title }
-					items={ items }
-					colCount="3"
-					value={ editorOptions.scrollbar.horizontal }
-				/>
-			</Stack>
-		</div>
+		<Stack
+			className="chbe-admin-editor-config__setting-item"
+			justify="start"
+			align="start"
+			wrap="wrap"
+			gap="sm"
+		>
+			<SelectControl< EditorOptions[ 'scrollbar' ][ 'horizontal' ] >
+				__next40pxDefaultSize
+				label={ title }
+				value={ editorOptions.scrollbar.horizontal }
+				options={ items.map( ( { label, value } ) => ( { label, value } ) ) }
+				onChange={ onChange }
+			/>
+			<ItemHelp
+				onChange={ onChange }
+				title={ title }
+				items={ items }
+				colCount="3"
+				value={ editorOptions.scrollbar.horizontal }
+			/>
+		</Stack>
 	);
 }

--- a/src/admin/editor-config/editor-options/scrollbar/scroll-by-page.tsx
+++ b/src/admin/editor-config/editor-options/scrollbar/scroll-by-page.tsx
@@ -3,7 +3,8 @@
  */
 import { __ } from '@wordpress/i18n';
 import { useContext } from '@wordpress/element';
-import { ToggleControl, __experimentalHStack as HStack } from '@wordpress/components';
+import { ToggleControl } from '@wordpress/components';
+import { Stack } from '@wordpress/ui';
 
 /**
  * Internal dependencies
@@ -36,7 +37,7 @@ export default function ScrollbarScrollByPage() {
 
 	return (
 		<div className="chbe-admin-editor-config__setting-item">
-			<HStack justify="start" alignment="start" wrap>
+			<Stack justify="start" align="start" wrap="wrap" gap="sm">
 				<ToggleControl
 					label={ title }
 					checked={ editorOptions.scrollbar.scrollByPage }
@@ -54,7 +55,7 @@ export default function ScrollbarScrollByPage() {
 					image="editor-options/scrollbar/scroll-by-page.gif"
 					value={ editorOptions.scrollbar.scrollByPage }
 				/>
-			</HStack>
+			</Stack>
 		</div>
 	);
 }

--- a/src/admin/editor-config/editor-options/scrollbar/scroll-by-page.tsx
+++ b/src/admin/editor-config/editor-options/scrollbar/scroll-by-page.tsx
@@ -36,26 +36,30 @@ export default function ScrollbarScrollByPage() {
 	};
 
 	return (
-		<div className="chbe-admin-editor-config__setting-item">
-			<Stack justify="start" align="start" wrap="wrap" gap="sm">
-				<ToggleControl
-					label={ title }
-					checked={ editorOptions.scrollbar.scrollByPage }
-					onChange={ onChange }
-				/>
-				<ItemHelp
-					onChange={ onChange }
-					title={ title }
-					description={ __(
-						'Scroll by page when the scroll bar is clicked.',
-						'custom-html-block-extension'
-					) }
-					isToggle
-					defaultToggle={ false }
-					image="editor-options/scrollbar/scroll-by-page.gif"
-					value={ editorOptions.scrollbar.scrollByPage }
-				/>
-			</Stack>
-		</div>
+		<Stack
+			className="chbe-admin-editor-config__setting-item"
+			justify="start"
+			align="start"
+			wrap="wrap"
+			gap="sm"
+		>
+			<ToggleControl
+				label={ title }
+				checked={ editorOptions.scrollbar.scrollByPage }
+				onChange={ onChange }
+			/>
+			<ItemHelp
+				onChange={ onChange }
+				title={ title }
+				description={ __(
+					'Scroll by page when the scroll bar is clicked.',
+					'custom-html-block-extension'
+				) }
+				isToggle
+				defaultToggle={ false }
+				image="editor-options/scrollbar/scroll-by-page.gif"
+				value={ editorOptions.scrollbar.scrollByPage }
+			/>
+		</Stack>
 	);
 }

--- a/src/admin/editor-config/editor-options/scrollbar/use-shadows.tsx
+++ b/src/admin/editor-config/editor-options/scrollbar/use-shadows.tsx
@@ -34,32 +34,36 @@ export default function ScrollbarUseShadows() {
 	};
 
 	return (
-		<div className="chbe-admin-editor-config__setting-item">
-			<Stack justify="start" align="start" wrap="wrap" gap="sm">
-				<ToggleControl
-					label={ title }
-					checked={ editorOptions.scrollbar.useShadows }
-					onChange={ onChange }
-				/>
-				<ItemHelp
-					onChange={ onChange }
-					title={ title }
-					items={ [
-						{
-							label: __( 'Enable', 'custom-html-block-extension' ),
-							image: 'editor-options/scrollbar/use-shadows_1.jpg',
-							value: true,
-							isDefault: true,
-						},
-						{
-							label: __( 'Disable', 'custom-html-block-extension' ),
-							image: 'editor-options/scrollbar/use-shadows_2.jpg',
-							value: false,
-						},
-					] }
-					value={ editorOptions.scrollbar.useShadows }
-				/>
-			</Stack>
-		</div>
+		<Stack
+			className="chbe-admin-editor-config__setting-item"
+			justify="start"
+			align="start"
+			wrap="wrap"
+			gap="sm"
+		>
+			<ToggleControl
+				label={ title }
+				checked={ editorOptions.scrollbar.useShadows }
+				onChange={ onChange }
+			/>
+			<ItemHelp
+				onChange={ onChange }
+				title={ title }
+				items={ [
+					{
+						label: __( 'Enable', 'custom-html-block-extension' ),
+						image: 'editor-options/scrollbar/use-shadows_1.jpg',
+						value: true,
+						isDefault: true,
+					},
+					{
+						label: __( 'Disable', 'custom-html-block-extension' ),
+						image: 'editor-options/scrollbar/use-shadows_2.jpg',
+						value: false,
+					},
+				] }
+				value={ editorOptions.scrollbar.useShadows }
+			/>
+		</Stack>
 	);
 }

--- a/src/admin/editor-config/editor-options/scrollbar/use-shadows.tsx
+++ b/src/admin/editor-config/editor-options/scrollbar/use-shadows.tsx
@@ -3,7 +3,8 @@
  */
 import { __ } from '@wordpress/i18n';
 import { useContext } from '@wordpress/element';
-import { ToggleControl, __experimentalHStack as HStack } from '@wordpress/components';
+import { ToggleControl } from '@wordpress/components';
+import { Stack } from '@wordpress/ui';
 
 /**
  * Internal dependencies
@@ -34,7 +35,7 @@ export default function ScrollbarUseShadows() {
 
 	return (
 		<div className="chbe-admin-editor-config__setting-item">
-			<HStack justify="start" alignment="start" wrap>
+			<Stack justify="start" align="start" wrap="wrap" gap="sm">
 				<ToggleControl
 					label={ title }
 					checked={ editorOptions.scrollbar.useShadows }
@@ -58,7 +59,7 @@ export default function ScrollbarUseShadows() {
 					] }
 					value={ editorOptions.scrollbar.useShadows }
 				/>
-			</HStack>
+			</Stack>
 		</div>
 	);
 }

--- a/src/admin/editor-config/editor-options/scrollbar/vertical-has-arrows.tsx
+++ b/src/admin/editor-config/editor-options/scrollbar/vertical-has-arrows.tsx
@@ -36,32 +36,36 @@ export default function ScrollbarVerticalHasArrows() {
 	};
 
 	return (
-		<div className="chbe-admin-editor-config__setting-item">
-			<Stack justify="start" align="start" wrap="wrap" gap="sm">
-				<ToggleControl
-					label={ title }
-					checked={ editorOptions.scrollbar.verticalHasArrows }
-					onChange={ onChange }
-				/>
-				<ItemHelp
-					onChange={ onChange }
-					title={ title }
-					items={ [
-						{
-							label: __( 'Enable', 'custom-html-block-extension' ),
-							image: 'editor-options/scrollbar/vertical-has-arrows_1.jpg',
-							value: true,
-						},
-						{
-							label: __( 'Disable', 'custom-html-block-extension' ),
-							image: 'editor-options/scrollbar/vertical-has-arrows_2.jpg',
-							value: false,
-							isDefault: true,
-						},
-					] }
-					value={ editorOptions.scrollbar.verticalHasArrows }
-				/>
-			</Stack>
-		</div>
+		<Stack
+			className="chbe-admin-editor-config__setting-item"
+			justify="start"
+			align="start"
+			wrap="wrap"
+			gap="sm"
+		>
+			<ToggleControl
+				label={ title }
+				checked={ editorOptions.scrollbar.verticalHasArrows }
+				onChange={ onChange }
+			/>
+			<ItemHelp
+				onChange={ onChange }
+				title={ title }
+				items={ [
+					{
+						label: __( 'Enable', 'custom-html-block-extension' ),
+						image: 'editor-options/scrollbar/vertical-has-arrows_1.jpg',
+						value: true,
+					},
+					{
+						label: __( 'Disable', 'custom-html-block-extension' ),
+						image: 'editor-options/scrollbar/vertical-has-arrows_2.jpg',
+						value: false,
+						isDefault: true,
+					},
+				] }
+				value={ editorOptions.scrollbar.verticalHasArrows }
+			/>
+		</Stack>
 	);
 }

--- a/src/admin/editor-config/editor-options/scrollbar/vertical-has-arrows.tsx
+++ b/src/admin/editor-config/editor-options/scrollbar/vertical-has-arrows.tsx
@@ -3,7 +3,8 @@
  */
 import { __ } from '@wordpress/i18n';
 import { useContext } from '@wordpress/element';
-import { ToggleControl, __experimentalHStack as HStack } from '@wordpress/components';
+import { ToggleControl } from '@wordpress/components';
+import { Stack } from '@wordpress/ui';
 
 /**
  * Internal dependencies
@@ -36,7 +37,7 @@ export default function ScrollbarVerticalHasArrows() {
 
 	return (
 		<div className="chbe-admin-editor-config__setting-item">
-			<HStack justify="start" alignment="start" wrap>
+			<Stack justify="start" align="start" wrap="wrap" gap="sm">
 				<ToggleControl
 					label={ title }
 					checked={ editorOptions.scrollbar.verticalHasArrows }
@@ -60,7 +61,7 @@ export default function ScrollbarVerticalHasArrows() {
 					] }
 					value={ editorOptions.scrollbar.verticalHasArrows }
 				/>
-			</HStack>
+			</Stack>
 		</div>
 	);
 }

--- a/src/admin/editor-config/editor-options/scrollbar/vertical-scrollbar-size.tsx
+++ b/src/admin/editor-config/editor-options/scrollbar/vertical-scrollbar-size.tsx
@@ -3,7 +3,8 @@
  */
 import { __, sprintf } from '@wordpress/i18n';
 import { useCallback, useContext, useState } from '@wordpress/element';
-import { RangeControl, __experimentalHStack as HStack } from '@wordpress/components';
+import { RangeControl } from '@wordpress/components';
+import { Stack } from '@wordpress/ui';
 import { useDebounce } from '@wordpress/compose';
 
 /**
@@ -50,7 +51,7 @@ export default function ScrollbarVerticalScrollbarSize() {
 
 	return (
 		<div className="chbe-admin-editor-config__setting-item">
-			<HStack justify="start" alignment="start" wrap>
+			<Stack justify="start" align="start" wrap="wrap" gap="sm">
 				<RangeControl
 					__next40pxDefaultSize
 					label={ title }
@@ -85,7 +86,7 @@ export default function ScrollbarVerticalScrollbarSize() {
 					] }
 					value={ value }
 				/>
-			</HStack>
+			</Stack>
 		</div>
 	);
 }

--- a/src/admin/editor-config/editor-options/scrollbar/vertical-scrollbar-size.tsx
+++ b/src/admin/editor-config/editor-options/scrollbar/vertical-scrollbar-size.tsx
@@ -50,43 +50,47 @@ export default function ScrollbarVerticalScrollbarSize() {
 	};
 
 	return (
-		<div className="chbe-admin-editor-config__setting-item">
-			<Stack justify="start" align="start" wrap="wrap" gap="sm">
-				<RangeControl
-					__next40pxDefaultSize
-					label={ title }
-					value={ value }
-					min={ 5 }
-					max={ 30 }
-					allowReset
-					onChange={ onChange }
-				/>
-				<ItemHelp
-					onChange={ onChange }
-					title={ title }
-					items={ [
-						{
-							label: sprintf(
-								/* translators: %s is replaced with the number. */
-								__( 'Example: Set the value to %s', 'custom-html-block-extension' ),
-								'10'
-							),
-							image: 'editor-options/scrollbar/vertical-scrollbar-size_1.jpg',
-							value: 10,
-						},
-						{
-							label: sprintf(
-								/* translators: %s is replaced with the number. */
-								__( 'Example: Set the value to %s', 'custom-html-block-extension' ),
-								'30'
-							),
-							image: 'editor-options/scrollbar/vertical-scrollbar-size_2.jpg',
-							value: 30,
-						},
-					] }
-					value={ value }
-				/>
-			</Stack>
-		</div>
+		<Stack
+			className="chbe-admin-editor-config__setting-item"
+			justify="start"
+			align="start"
+			wrap="wrap"
+			gap="sm"
+		>
+			<RangeControl
+				__next40pxDefaultSize
+				label={ title }
+				value={ value }
+				min={ 5 }
+				max={ 30 }
+				allowReset
+				onChange={ onChange }
+			/>
+			<ItemHelp
+				onChange={ onChange }
+				title={ title }
+				items={ [
+					{
+						label: sprintf(
+							/* translators: %s is replaced with the number. */
+							__( 'Example: Set the value to %s', 'custom-html-block-extension' ),
+							'10'
+						),
+						image: 'editor-options/scrollbar/vertical-scrollbar-size_1.jpg',
+						value: 10,
+					},
+					{
+						label: sprintf(
+							/* translators: %s is replaced with the number. */
+							__( 'Example: Set the value to %s', 'custom-html-block-extension' ),
+							'30'
+						),
+						image: 'editor-options/scrollbar/vertical-scrollbar-size_2.jpg',
+						value: 30,
+					},
+				] }
+				value={ value }
+			/>
+		</Stack>
 	);
 }

--- a/src/admin/editor-config/editor-options/scrollbar/vertical.tsx
+++ b/src/admin/editor-config/editor-options/scrollbar/vertical.tsx
@@ -56,23 +56,27 @@ export default function ScrollbarVertical() {
 	};
 
 	return (
-		<div className="chbe-admin-editor-config__setting-item">
-			<Stack justify="start" align="start" wrap="wrap" gap="sm">
-				<SelectControl< EditorOptions[ 'scrollbar' ][ 'vertical' ] >
-					__next40pxDefaultSize
-					label={ title }
-					value={ editorOptions.scrollbar.vertical }
-					options={ items.map( ( { label, value } ) => ( { label, value } ) ) }
-					onChange={ onChange }
-				/>
-				<ItemHelp
-					onChange={ onChange }
-					title={ title }
-					items={ items }
-					colCount="3"
-					value={ editorOptions.scrollbar.vertical }
-				/>
-			</Stack>
-		</div>
+		<Stack
+			className="chbe-admin-editor-config__setting-item"
+			justify="start"
+			align="start"
+			wrap="wrap"
+			gap="sm"
+		>
+			<SelectControl< EditorOptions[ 'scrollbar' ][ 'vertical' ] >
+				__next40pxDefaultSize
+				label={ title }
+				value={ editorOptions.scrollbar.vertical }
+				options={ items.map( ( { label, value } ) => ( { label, value } ) ) }
+				onChange={ onChange }
+			/>
+			<ItemHelp
+				onChange={ onChange }
+				title={ title }
+				items={ items }
+				colCount="3"
+				value={ editorOptions.scrollbar.vertical }
+			/>
+		</Stack>
 	);
 }

--- a/src/admin/editor-config/editor-options/scrollbar/vertical.tsx
+++ b/src/admin/editor-config/editor-options/scrollbar/vertical.tsx
@@ -3,7 +3,8 @@
  */
 import { __ } from '@wordpress/i18n';
 import { useContext } from '@wordpress/element';
-import { SelectControl, __experimentalHStack as HStack } from '@wordpress/components';
+import { SelectControl } from '@wordpress/components';
+import { Stack } from '@wordpress/ui';
 
 /**
  * Internal dependencies
@@ -56,7 +57,7 @@ export default function ScrollbarVertical() {
 
 	return (
 		<div className="chbe-admin-editor-config__setting-item">
-			<HStack justify="start" alignment="start" wrap>
+			<Stack justify="start" align="start" wrap="wrap" gap="sm">
 				<SelectControl< EditorOptions[ 'scrollbar' ][ 'vertical' ] >
 					__next40pxDefaultSize
 					label={ title }
@@ -71,7 +72,7 @@ export default function ScrollbarVertical() {
 					colCount="3"
 					value={ editorOptions.scrollbar.vertical }
 				/>
-			</HStack>
+			</Stack>
 		</div>
 	);
 }

--- a/src/admin/editor-config/editor-options/select-on-line-numbers.tsx
+++ b/src/admin/editor-config/editor-options/select-on-line-numbers.tsx
@@ -3,7 +3,8 @@
  */
 import { __ } from '@wordpress/i18n';
 import { useContext } from '@wordpress/element';
-import { ToggleControl, __experimentalHStack as HStack } from '@wordpress/components';
+import { ToggleControl } from '@wordpress/components';
+import { Stack } from '@wordpress/ui';
 
 /**
  * Internal dependencies
@@ -34,7 +35,7 @@ export default function SelectOnLineNumbers() {
 
 	return (
 		<div className="chbe-admin-editor-config__setting-item">
-			<HStack justify="start" alignment="start" wrap>
+			<Stack justify="start" align="start" wrap="wrap" gap="sm">
 				<ToggleControl
 					label={ title }
 					checked={ editorOptions.selectOnLineNumbers }
@@ -58,7 +59,7 @@ export default function SelectOnLineNumbers() {
 					] }
 					value={ editorOptions.selectOnLineNumbers }
 				/>
-			</HStack>
+			</Stack>
 		</div>
 	);
 }

--- a/src/admin/editor-config/editor-options/select-on-line-numbers.tsx
+++ b/src/admin/editor-config/editor-options/select-on-line-numbers.tsx
@@ -34,32 +34,36 @@ export default function SelectOnLineNumbers() {
 	};
 
 	return (
-		<div className="chbe-admin-editor-config__setting-item">
-			<Stack justify="start" align="start" wrap="wrap" gap="sm">
-				<ToggleControl
-					label={ title }
-					checked={ editorOptions.selectOnLineNumbers }
-					onChange={ onChange }
-				/>
-				<ItemHelp
-					onChange={ onChange }
-					title={ title }
-					items={ [
-						{
-							label: __( 'Enable', 'custom-html-block-extension' ),
-							value: true,
-							image: 'editor-options/select-on-line-numbers_1.gif',
-							isDefault: true,
-						},
-						{
-							label: __( 'Disable', 'custom-html-block-extension' ),
-							value: false,
-							image: 'editor-options/select-on-line-numbers_2.gif',
-						},
-					] }
-					value={ editorOptions.selectOnLineNumbers }
-				/>
-			</Stack>
-		</div>
+		<Stack
+			className="chbe-admin-editor-config__setting-item"
+			justify="start"
+			align="start"
+			wrap="wrap"
+			gap="sm"
+		>
+			<ToggleControl
+				label={ title }
+				checked={ editorOptions.selectOnLineNumbers }
+				onChange={ onChange }
+			/>
+			<ItemHelp
+				onChange={ onChange }
+				title={ title }
+				items={ [
+					{
+						label: __( 'Enable', 'custom-html-block-extension' ),
+						value: true,
+						image: 'editor-options/select-on-line-numbers_1.gif',
+						isDefault: true,
+					},
+					{
+						label: __( 'Disable', 'custom-html-block-extension' ),
+						value: false,
+						image: 'editor-options/select-on-line-numbers_2.gif',
+					},
+				] }
+				value={ editorOptions.selectOnLineNumbers }
+			/>
+		</Stack>
 	);
 }

--- a/src/admin/editor-config/editor-options/selection-highlight.tsx
+++ b/src/admin/editor-config/editor-options/selection-highlight.tsx
@@ -3,7 +3,8 @@
  */
 import { __ } from '@wordpress/i18n';
 import { useContext } from '@wordpress/element';
-import { ToggleControl, __experimentalHStack as HStack } from '@wordpress/components';
+import { ToggleControl } from '@wordpress/components';
+import { Stack } from '@wordpress/ui';
 
 /**
  * Internal dependencies
@@ -31,7 +32,7 @@ export default function SelectionHighlight() {
 
 	return (
 		<div className="chbe-admin-editor-config__setting-item">
-			<HStack justify="start" alignment="start" wrap>
+			<Stack justify="start" align="start" wrap="wrap" gap="sm">
 				<ToggleControl
 					label={ title }
 					checked={ editorOptions.selectionHighlight }
@@ -55,7 +56,7 @@ export default function SelectionHighlight() {
 					] }
 					value={ editorOptions.selectionHighlight }
 				/>
-			</HStack>
+			</Stack>
 		</div>
 	);
 }

--- a/src/admin/editor-config/editor-options/selection-highlight.tsx
+++ b/src/admin/editor-config/editor-options/selection-highlight.tsx
@@ -31,32 +31,36 @@ export default function SelectionHighlight() {
 	};
 
 	return (
-		<div className="chbe-admin-editor-config__setting-item">
-			<Stack justify="start" align="start" wrap="wrap" gap="sm">
-				<ToggleControl
-					label={ title }
-					checked={ editorOptions.selectionHighlight }
-					onChange={ onChange }
-				/>
-				<ItemHelp
-					onChange={ onChange }
-					title={ title }
-					items={ [
-						{
-							label: __( 'Enable', 'custom-html-block-extension' ),
-							value: true,
-							image: 'editor-options/selection-highlight_1.jpg',
-							isDefault: true,
-						},
-						{
-							label: __( 'Disable', 'custom-html-block-extension' ),
-							value: false,
-							image: 'editor-options/selection-highlight_2.jpg',
-						},
-					] }
-					value={ editorOptions.selectionHighlight }
-				/>
-			</Stack>
-		</div>
+		<Stack
+			className="chbe-admin-editor-config__setting-item"
+			justify="start"
+			align="start"
+			wrap="wrap"
+			gap="sm"
+		>
+			<ToggleControl
+				label={ title }
+				checked={ editorOptions.selectionHighlight }
+				onChange={ onChange }
+			/>
+			<ItemHelp
+				onChange={ onChange }
+				title={ title }
+				items={ [
+					{
+						label: __( 'Enable', 'custom-html-block-extension' ),
+						value: true,
+						image: 'editor-options/selection-highlight_1.jpg',
+						isDefault: true,
+					},
+					{
+						label: __( 'Disable', 'custom-html-block-extension' ),
+						value: false,
+						image: 'editor-options/selection-highlight_2.jpg',
+					},
+				] }
+				value={ editorOptions.selectionHighlight }
+			/>
+		</Stack>
 	);
 }

--- a/src/admin/editor-config/editor-options/show-folding-controls.tsx
+++ b/src/admin/editor-config/editor-options/show-folding-controls.tsx
@@ -46,22 +46,26 @@ export default function ShowFoldingControls() {
 	};
 
 	return (
-		<div className="chbe-admin-editor-config__setting-item">
-			<Stack justify="start" align="start" wrap="wrap" gap="sm">
-				<SelectControl< EditorOptions[ 'showFoldingControls' ] >
-					__next40pxDefaultSize
-					label={ title }
-					value={ editorOptions.showFoldingControls }
-					options={ items.map( ( { label, value } ) => ( { label, value } ) ) }
-					onChange={ onChange }
-				/>
-				<ItemHelp
-					onChange={ onChange }
-					title={ title }
-					items={ items }
-					value={ editorOptions.showFoldingControls }
-				/>
-			</Stack>
-		</div>
+		<Stack
+			className="chbe-admin-editor-config__setting-item"
+			justify="start"
+			align="start"
+			wrap="wrap"
+			gap="sm"
+		>
+			<SelectControl< EditorOptions[ 'showFoldingControls' ] >
+				__next40pxDefaultSize
+				label={ title }
+				value={ editorOptions.showFoldingControls }
+				options={ items.map( ( { label, value } ) => ( { label, value } ) ) }
+				onChange={ onChange }
+			/>
+			<ItemHelp
+				onChange={ onChange }
+				title={ title }
+				items={ items }
+				value={ editorOptions.showFoldingControls }
+			/>
+		</Stack>
 	);
 }

--- a/src/admin/editor-config/editor-options/show-folding-controls.tsx
+++ b/src/admin/editor-config/editor-options/show-folding-controls.tsx
@@ -3,7 +3,8 @@
  */
 import { __ } from '@wordpress/i18n';
 import { useContext } from '@wordpress/element';
-import { SelectControl, __experimentalHStack as HStack } from '@wordpress/components';
+import { SelectControl } from '@wordpress/components';
+import { Stack } from '@wordpress/ui';
 
 /**
  * Internal dependencies
@@ -46,7 +47,7 @@ export default function ShowFoldingControls() {
 
 	return (
 		<div className="chbe-admin-editor-config__setting-item">
-			<HStack justify="start" alignment="start" wrap>
+			<Stack justify="start" align="start" wrap="wrap" gap="sm">
 				<SelectControl< EditorOptions[ 'showFoldingControls' ] >
 					__next40pxDefaultSize
 					label={ title }
@@ -60,7 +61,7 @@ export default function ShowFoldingControls() {
 					items={ items }
 					value={ editorOptions.showFoldingControls }
 				/>
-			</HStack>
+			</Stack>
 		</div>
 	);
 }

--- a/src/admin/editor-config/editor-options/smooth-scrolling.tsx
+++ b/src/admin/editor-config/editor-options/smooth-scrolling.tsx
@@ -3,7 +3,8 @@
  */
 import { __ } from '@wordpress/i18n';
 import { useContext } from '@wordpress/element';
-import { ToggleControl, __experimentalHStack as HStack } from '@wordpress/components';
+import { ToggleControl } from '@wordpress/components';
+import { Stack } from '@wordpress/ui';
 
 /**
  * Internal dependencies
@@ -31,7 +32,7 @@ export default function SmoothScrolling() {
 
 	return (
 		<div className="chbe-admin-editor-config__setting-item">
-			<HStack justify="start" alignment="start" wrap>
+			<Stack justify="start" align="start" wrap="wrap" gap="sm">
 				<ToggleControl
 					label={ title }
 					checked={ editorOptions.smoothScrolling }
@@ -55,7 +56,7 @@ export default function SmoothScrolling() {
 					] }
 					value={ editorOptions.smoothScrolling }
 				/>
-			</HStack>
+			</Stack>
 		</div>
 	);
 }

--- a/src/admin/editor-config/editor-options/smooth-scrolling.tsx
+++ b/src/admin/editor-config/editor-options/smooth-scrolling.tsx
@@ -31,32 +31,36 @@ export default function SmoothScrolling() {
 	};
 
 	return (
-		<div className="chbe-admin-editor-config__setting-item">
-			<Stack justify="start" align="start" wrap="wrap" gap="sm">
-				<ToggleControl
-					label={ title }
-					checked={ editorOptions.smoothScrolling }
-					onChange={ onChange }
-				/>
-				<ItemHelp
-					onChange={ onChange }
-					title={ title }
-					items={ [
-						{
-							label: __( 'Enable', 'custom-html-block-extension' ),
-							value: true,
-							image: 'editor-options/smooth-scrolling_1.gif',
-						},
-						{
-							label: __( 'Disable', 'custom-html-block-extension' ),
-							value: false,
-							image: 'editor-options/smooth-scrolling_2.gif',
-							isDefault: true,
-						},
-					] }
-					value={ editorOptions.smoothScrolling }
-				/>
-			</Stack>
-		</div>
+		<Stack
+			className="chbe-admin-editor-config__setting-item"
+			justify="start"
+			align="start"
+			wrap="wrap"
+			gap="sm"
+		>
+			<ToggleControl
+				label={ title }
+				checked={ editorOptions.smoothScrolling }
+				onChange={ onChange }
+			/>
+			<ItemHelp
+				onChange={ onChange }
+				title={ title }
+				items={ [
+					{
+						label: __( 'Enable', 'custom-html-block-extension' ),
+						value: true,
+						image: 'editor-options/smooth-scrolling_1.gif',
+					},
+					{
+						label: __( 'Disable', 'custom-html-block-extension' ),
+						value: false,
+						image: 'editor-options/smooth-scrolling_2.gif',
+						isDefault: true,
+					},
+				] }
+				value={ editorOptions.smoothScrolling }
+			/>
+		</Stack>
 	);
 }

--- a/src/admin/editor-config/editor-options/sticky-tab-stops.tsx
+++ b/src/admin/editor-config/editor-options/sticky-tab-stops.tsx
@@ -31,32 +31,36 @@ export default function StickyTabStops() {
 	};
 
 	return (
-		<div className="chbe-admin-editor-config__setting-item">
-			<Stack justify="start" align="start" wrap="wrap" gap="sm">
-				<ToggleControl
-					label={ title }
-					checked={ editorOptions.stickyTabStops }
-					onChange={ onChange }
-				/>
-				<ItemHelp
-					onChange={ onChange }
-					title={ title }
-					items={ [
-						{
-							label: __( 'Enable', 'custom-html-block-extension' ),
-							value: true,
-							image: 'editor-options/sticky-tab-stops_1.gif',
-						},
-						{
-							label: __( 'Disable', 'custom-html-block-extension' ),
-							value: false,
-							image: 'editor-options/sticky-tab-stops_2.gif',
-							isDefault: true,
-						},
-					] }
-					value={ editorOptions.stickyTabStops }
-				/>
-			</Stack>
-		</div>
+		<Stack
+			className="chbe-admin-editor-config__setting-item"
+			justify="start"
+			align="start"
+			wrap="wrap"
+			gap="sm"
+		>
+			<ToggleControl
+				label={ title }
+				checked={ editorOptions.stickyTabStops }
+				onChange={ onChange }
+			/>
+			<ItemHelp
+				onChange={ onChange }
+				title={ title }
+				items={ [
+					{
+						label: __( 'Enable', 'custom-html-block-extension' ),
+						value: true,
+						image: 'editor-options/sticky-tab-stops_1.gif',
+					},
+					{
+						label: __( 'Disable', 'custom-html-block-extension' ),
+						value: false,
+						image: 'editor-options/sticky-tab-stops_2.gif',
+						isDefault: true,
+					},
+				] }
+				value={ editorOptions.stickyTabStops }
+			/>
+		</Stack>
 	);
 }

--- a/src/admin/editor-config/editor-options/sticky-tab-stops.tsx
+++ b/src/admin/editor-config/editor-options/sticky-tab-stops.tsx
@@ -3,7 +3,8 @@
  */
 import { __ } from '@wordpress/i18n';
 import { useContext } from '@wordpress/element';
-import { ToggleControl, __experimentalHStack as HStack } from '@wordpress/components';
+import { ToggleControl } from '@wordpress/components';
+import { Stack } from '@wordpress/ui';
 
 /**
  * Internal dependencies
@@ -31,7 +32,7 @@ export default function StickyTabStops() {
 
 	return (
 		<div className="chbe-admin-editor-config__setting-item">
-			<HStack justify="start" alignment="start" wrap>
+			<Stack justify="start" align="start" wrap="wrap" gap="sm">
 				<ToggleControl
 					label={ title }
 					checked={ editorOptions.stickyTabStops }
@@ -55,7 +56,7 @@ export default function StickyTabStops() {
 					] }
 					value={ editorOptions.stickyTabStops }
 				/>
-			</HStack>
+			</Stack>
 		</div>
 	);
 }

--- a/src/admin/editor-config/editor-options/suggest-font-size.tsx
+++ b/src/admin/editor-config/editor-options/suggest-font-size.tsx
@@ -32,43 +32,47 @@ export default function SuggestFontSize() {
 	};
 
 	return (
-		<div className="chbe-admin-editor-config__setting-item">
-			<Stack justify="start" align="start" wrap="wrap" gap="sm">
-				<RangeControl
-					__next40pxDefaultSize
-					label={ title }
-					value={ editorOptions.suggestFontSize }
-					min={ 10 }
-					max={ 30 }
-					allowReset
-					onChange={ onChange }
-				/>
-				<ItemHelp
-					onChange={ onChange }
-					title={ title }
-					items={ [
-						{
-							label: sprintf(
-								/* translators: %s is replaced with the number. */
-								__( 'Example: Set the value to %s', 'custom-html-block-extension' ),
-								'10'
-							),
-							image: 'editor-options/suggest-font-size_1.jpg',
-							value: 10,
-						},
-						{
-							label: sprintf(
-								/* translators: %s is replaced with the number. */
-								__( 'Example: Set the value to %s', 'custom-html-block-extension' ),
-								'30'
-							),
-							image: 'editor-options/suggest-font-size_2.jpg',
-							value: 30,
-						},
-					] }
-					value={ editorOptions.suggestFontSize }
-				/>
-			</Stack>
-		</div>
+		<Stack
+			className="chbe-admin-editor-config__setting-item"
+			justify="start"
+			align="start"
+			wrap="wrap"
+			gap="sm"
+		>
+			<RangeControl
+				__next40pxDefaultSize
+				label={ title }
+				value={ editorOptions.suggestFontSize }
+				min={ 10 }
+				max={ 30 }
+				allowReset
+				onChange={ onChange }
+			/>
+			<ItemHelp
+				onChange={ onChange }
+				title={ title }
+				items={ [
+					{
+						label: sprintf(
+							/* translators: %s is replaced with the number. */
+							__( 'Example: Set the value to %s', 'custom-html-block-extension' ),
+							'10'
+						),
+						image: 'editor-options/suggest-font-size_1.jpg',
+						value: 10,
+					},
+					{
+						label: sprintf(
+							/* translators: %s is replaced with the number. */
+							__( 'Example: Set the value to %s', 'custom-html-block-extension' ),
+							'30'
+						),
+						image: 'editor-options/suggest-font-size_2.jpg',
+						value: 30,
+					},
+				] }
+				value={ editorOptions.suggestFontSize }
+			/>
+		</Stack>
 	);
 }

--- a/src/admin/editor-config/editor-options/suggest-font-size.tsx
+++ b/src/admin/editor-config/editor-options/suggest-font-size.tsx
@@ -3,7 +3,8 @@
  */
 import { __, sprintf } from '@wordpress/i18n';
 import { useContext } from '@wordpress/element';
-import { RangeControl, __experimentalHStack as HStack } from '@wordpress/components';
+import { RangeControl } from '@wordpress/components';
+import { Stack } from '@wordpress/ui';
 
 /**
  * Internal dependencies
@@ -32,7 +33,7 @@ export default function SuggestFontSize() {
 
 	return (
 		<div className="chbe-admin-editor-config__setting-item">
-			<HStack justify="start" alignment="start" wrap>
+			<Stack justify="start" align="start" wrap="wrap" gap="sm">
 				<RangeControl
 					__next40pxDefaultSize
 					label={ title }
@@ -67,7 +68,7 @@ export default function SuggestFontSize() {
 					] }
 					value={ editorOptions.suggestFontSize }
 				/>
-			</HStack>
+			</Stack>
 		</div>
 	);
 }

--- a/src/admin/editor-config/editor-options/suggest-line-height.tsx
+++ b/src/admin/editor-config/editor-options/suggest-line-height.tsx
@@ -3,7 +3,8 @@
  */
 import { __, sprintf } from '@wordpress/i18n';
 import { useContext } from '@wordpress/element';
-import { RangeControl, __experimentalHStack as HStack } from '@wordpress/components';
+import { RangeControl } from '@wordpress/components';
+import { Stack } from '@wordpress/ui';
 
 /**
  * Internal dependencies
@@ -32,7 +33,7 @@ export default function SuggestLineHeight() {
 
 	return (
 		<div className="chbe-admin-editor-config__setting-item">
-			<HStack justify="start" alignment="start" wrap>
+			<Stack justify="start" align="start" wrap="wrap" gap="sm">
 				<RangeControl
 					__next40pxDefaultSize
 					label={ title }
@@ -67,7 +68,7 @@ export default function SuggestLineHeight() {
 					] }
 					value={ editorOptions.suggestLineHeight }
 				/>
-			</HStack>
+			</Stack>
 		</div>
 	);
 }

--- a/src/admin/editor-config/editor-options/suggest-line-height.tsx
+++ b/src/admin/editor-config/editor-options/suggest-line-height.tsx
@@ -32,43 +32,47 @@ export default function SuggestLineHeight() {
 	};
 
 	return (
-		<div className="chbe-admin-editor-config__setting-item">
-			<Stack justify="start" align="start" wrap="wrap" gap="sm">
-				<RangeControl
-					__next40pxDefaultSize
-					label={ title }
-					value={ editorOptions.suggestLineHeight }
-					min={ 10 }
-					max={ 60 }
-					allowReset
-					onChange={ onChange }
-				/>
-				<ItemHelp
-					onChange={ onChange }
-					title={ title }
-					items={ [
-						{
-							label: sprintf(
-								/* translators: %s is replaced with the number. */
-								__( 'Example: Set the value to %s', 'custom-html-block-extension' ),
-								'10'
-							),
-							image: 'editor-options/suggest-line-height_1.jpg',
-							value: 10,
-						},
-						{
-							label: sprintf(
-								/* translators: %s is replaced with the number. */
-								__( 'Example: Set the value to %s', 'custom-html-block-extension' ),
-								'30'
-							),
-							image: 'editor-options/suggest-line-height_2.jpg',
-							value: 30,
-						},
-					] }
-					value={ editorOptions.suggestLineHeight }
-				/>
-			</Stack>
-		</div>
+		<Stack
+			className="chbe-admin-editor-config__setting-item"
+			justify="start"
+			align="start"
+			wrap="wrap"
+			gap="sm"
+		>
+			<RangeControl
+				__next40pxDefaultSize
+				label={ title }
+				value={ editorOptions.suggestLineHeight }
+				min={ 10 }
+				max={ 60 }
+				allowReset
+				onChange={ onChange }
+			/>
+			<ItemHelp
+				onChange={ onChange }
+				title={ title }
+				items={ [
+					{
+						label: sprintf(
+							/* translators: %s is replaced with the number. */
+							__( 'Example: Set the value to %s', 'custom-html-block-extension' ),
+							'10'
+						),
+						image: 'editor-options/suggest-line-height_1.jpg',
+						value: 10,
+					},
+					{
+						label: sprintf(
+							/* translators: %s is replaced with the number. */
+							__( 'Example: Set the value to %s', 'custom-html-block-extension' ),
+							'30'
+						),
+						image: 'editor-options/suggest-line-height_2.jpg',
+						value: 30,
+					},
+				] }
+				value={ editorOptions.suggestLineHeight }
+			/>
+		</Stack>
 	);
 }

--- a/src/admin/editor-config/editor-options/suggest/show-icons.tsx
+++ b/src/admin/editor-config/editor-options/suggest/show-icons.tsx
@@ -3,7 +3,8 @@
  */
 import { __ } from '@wordpress/i18n';
 import { useContext } from '@wordpress/element';
-import { ToggleControl, __experimentalHStack as HStack } from '@wordpress/components';
+import { ToggleControl } from '@wordpress/components';
+import { Stack } from '@wordpress/ui';
 
 /**
  * Internal dependencies
@@ -34,7 +35,7 @@ export default function SuggestShowIcons() {
 
 	return (
 		<div className="chbe-admin-editor-config__setting-item">
-			<HStack justify="start" alignment="start" wrap>
+			<Stack justify="start" align="start" wrap="wrap" gap="sm">
 				<ToggleControl
 					label={ title }
 					checked={ editorOptions.suggest.showIcons }
@@ -58,7 +59,7 @@ export default function SuggestShowIcons() {
 					] }
 					value={ editorOptions.suggest.showIcons }
 				/>
-			</HStack>
+			</Stack>
 		</div>
 	);
 }

--- a/src/admin/editor-config/editor-options/suggest/show-icons.tsx
+++ b/src/admin/editor-config/editor-options/suggest/show-icons.tsx
@@ -34,32 +34,36 @@ export default function SuggestShowIcons() {
 	};
 
 	return (
-		<div className="chbe-admin-editor-config__setting-item">
-			<Stack justify="start" align="start" wrap="wrap" gap="sm">
-				<ToggleControl
-					label={ title }
-					checked={ editorOptions.suggest.showIcons }
-					onChange={ onChange }
-				/>
-				<ItemHelp
-					onChange={ onChange }
-					title={ title }
-					items={ [
-						{
-							label: __( 'Enable', 'custom-html-block-extension' ),
-							image: 'editor-options/suggest/show-icons_1.jpg',
-							value: true,
-							isDefault: true,
-						},
-						{
-							label: __( 'Disable', 'custom-html-block-extension' ),
-							image: 'editor-options/suggest/show-icons_2.jpg',
-							value: false,
-						},
-					] }
-					value={ editorOptions.suggest.showIcons }
-				/>
-			</Stack>
-		</div>
+		<Stack
+			className="chbe-admin-editor-config__setting-item"
+			justify="start"
+			align="start"
+			wrap="wrap"
+			gap="sm"
+		>
+			<ToggleControl
+				label={ title }
+				checked={ editorOptions.suggest.showIcons }
+				onChange={ onChange }
+			/>
+			<ItemHelp
+				onChange={ onChange }
+				title={ title }
+				items={ [
+					{
+						label: __( 'Enable', 'custom-html-block-extension' ),
+						image: 'editor-options/suggest/show-icons_1.jpg',
+						value: true,
+						isDefault: true,
+					},
+					{
+						label: __( 'Disable', 'custom-html-block-extension' ),
+						image: 'editor-options/suggest/show-icons_2.jpg',
+						value: false,
+					},
+				] }
+				value={ editorOptions.suggest.showIcons }
+			/>
+		</Stack>
 	);
 }

--- a/src/admin/editor-config/editor-options/unfold-on-click-after-end-of-line.tsx
+++ b/src/admin/editor-config/editor-options/unfold-on-click-after-end-of-line.tsx
@@ -34,22 +34,26 @@ export default function UnfoldOnClickAfterEndOfLine() {
 	};
 
 	return (
-		<div className="chbe-admin-editor-config__setting-item">
-			<Stack justify="start" align="start" wrap="wrap" gap="sm">
-				<ToggleControl
-					label={ title }
-					checked={ editorOptions.unfoldOnClickAfterEndOfLine }
-					onChange={ onChange }
-				/>
-				<ItemHelp
-					onChange={ onChange }
-					title={ title }
-					isToggle
-					image="editor-options/unfold-on-click-after-end-of-line.gif"
-					defaultToggle={ false }
-					value={ editorOptions.unfoldOnClickAfterEndOfLine }
-				/>
-			</Stack>
-		</div>
+		<Stack
+			className="chbe-admin-editor-config__setting-item"
+			justify="start"
+			align="start"
+			wrap="wrap"
+			gap="sm"
+		>
+			<ToggleControl
+				label={ title }
+				checked={ editorOptions.unfoldOnClickAfterEndOfLine }
+				onChange={ onChange }
+			/>
+			<ItemHelp
+				onChange={ onChange }
+				title={ title }
+				isToggle
+				image="editor-options/unfold-on-click-after-end-of-line.gif"
+				defaultToggle={ false }
+				value={ editorOptions.unfoldOnClickAfterEndOfLine }
+			/>
+		</Stack>
 	);
 }

--- a/src/admin/editor-config/editor-options/unfold-on-click-after-end-of-line.tsx
+++ b/src/admin/editor-config/editor-options/unfold-on-click-after-end-of-line.tsx
@@ -3,7 +3,8 @@
  */
 import { __ } from '@wordpress/i18n';
 import { useContext } from '@wordpress/element';
-import { ToggleControl, __experimentalHStack as HStack } from '@wordpress/components';
+import { ToggleControl } from '@wordpress/components';
+import { Stack } from '@wordpress/ui';
 
 /**
  * Internal dependencies
@@ -34,7 +35,7 @@ export default function UnfoldOnClickAfterEndOfLine() {
 
 	return (
 		<div className="chbe-admin-editor-config__setting-item">
-			<HStack justify="start" alignment="start" wrap>
+			<Stack justify="start" align="start" wrap="wrap" gap="sm">
 				<ToggleControl
 					label={ title }
 					checked={ editorOptions.unfoldOnClickAfterEndOfLine }
@@ -48,7 +49,7 @@ export default function UnfoldOnClickAfterEndOfLine() {
 					defaultToggle={ false }
 					value={ editorOptions.unfoldOnClickAfterEndOfLine }
 				/>
-			</HStack>
+			</Stack>
 		</div>
 	);
 }

--- a/src/admin/editor-config/editor-options/use-tab-stops.tsx
+++ b/src/admin/editor-config/editor-options/use-tab-stops.tsx
@@ -34,32 +34,32 @@ export default function UseTabStops() {
 	};
 
 	return (
-		<div className="chbe-admin-editor-config__setting-item">
-			<Stack justify="start" align="start" wrap="wrap" gap="sm">
-				<ToggleControl
-					label={ title }
-					checked={ editorOptions.useTabStops }
-					onChange={ onChange }
-				/>
-				<ItemHelp
-					onChange={ onChange }
-					title={ title }
-					items={ [
-						{
-							label: __( 'Enable', 'custom-html-block-extension' ),
-							image: 'editor-options/use-tab-stops_1.gif',
-							value: true,
-							isDefault: true,
-						},
-						{
-							label: __( 'Disable', 'custom-html-block-extension' ),
-							image: 'editor-options/use-tab-stops_2.gif',
-							value: false,
-						},
-					] }
-					value={ editorOptions.useTabStops }
-				/>
-			</Stack>
-		</div>
+		<Stack
+			className="chbe-admin-editor-config__setting-item"
+			justify="start"
+			align="start"
+			wrap="wrap"
+			gap="sm"
+		>
+			<ToggleControl label={ title } checked={ editorOptions.useTabStops } onChange={ onChange } />
+			<ItemHelp
+				onChange={ onChange }
+				title={ title }
+				items={ [
+					{
+						label: __( 'Enable', 'custom-html-block-extension' ),
+						image: 'editor-options/use-tab-stops_1.gif',
+						value: true,
+						isDefault: true,
+					},
+					{
+						label: __( 'Disable', 'custom-html-block-extension' ),
+						image: 'editor-options/use-tab-stops_2.gif',
+						value: false,
+					},
+				] }
+				value={ editorOptions.useTabStops }
+			/>
+		</Stack>
 	);
 }

--- a/src/admin/editor-config/editor-options/use-tab-stops.tsx
+++ b/src/admin/editor-config/editor-options/use-tab-stops.tsx
@@ -3,7 +3,8 @@
  */
 import { __ } from '@wordpress/i18n';
 import { useContext } from '@wordpress/element';
-import { ToggleControl, __experimentalHStack as HStack } from '@wordpress/components';
+import { ToggleControl } from '@wordpress/components';
+import { Stack } from '@wordpress/ui';
 
 /**
  * Internal dependencies
@@ -34,7 +35,7 @@ export default function UseTabStops() {
 
 	return (
 		<div className="chbe-admin-editor-config__setting-item">
-			<HStack justify="start" alignment="start" wrap>
+			<Stack justify="start" align="start" wrap="wrap" gap="sm">
 				<ToggleControl
 					label={ title }
 					checked={ editorOptions.useTabStops }
@@ -58,7 +59,7 @@ export default function UseTabStops() {
 					] }
 					value={ editorOptions.useTabStops }
 				/>
-			</HStack>
+			</Stack>
 		</div>
 	);
 }

--- a/src/admin/editor-config/editor-options/word-wrap-column.tsx
+++ b/src/admin/editor-config/editor-options/word-wrap-column.tsx
@@ -32,24 +32,28 @@ export default function WordWrapColumn() {
 	};
 
 	return (
-		<div className="chbe-admin-editor-config__setting-item">
-			<Stack justify="start" align="start" wrap="wrap" gap="sm">
-				<RangeControl
-					__next40pxDefaultSize
-					label={ title }
-					value={ editorOptions.wordWrapColumn }
-					min={ 20 }
-					max={ 200 }
-					allowReset
-					onChange={ onChange }
-				/>
-				<ItemHelp
-					onChange={ onChange }
-					title={ title }
-					image="editor-options/word-wrap-column.gif"
-					value={ editorOptions.wordWrapColumn }
-				/>
-			</Stack>
-		</div>
+		<Stack
+			className="chbe-admin-editor-config__setting-item"
+			justify="start"
+			align="start"
+			wrap="wrap"
+			gap="sm"
+		>
+			<RangeControl
+				__next40pxDefaultSize
+				label={ title }
+				value={ editorOptions.wordWrapColumn }
+				min={ 20 }
+				max={ 200 }
+				allowReset
+				onChange={ onChange }
+			/>
+			<ItemHelp
+				onChange={ onChange }
+				title={ title }
+				image="editor-options/word-wrap-column.gif"
+				value={ editorOptions.wordWrapColumn }
+			/>
+		</Stack>
 	);
 }

--- a/src/admin/editor-config/editor-options/word-wrap-column.tsx
+++ b/src/admin/editor-config/editor-options/word-wrap-column.tsx
@@ -3,7 +3,8 @@
  */
 import { __ } from '@wordpress/i18n';
 import { useContext } from '@wordpress/element';
-import { RangeControl, __experimentalHStack as HStack } from '@wordpress/components';
+import { RangeControl } from '@wordpress/components';
+import { Stack } from '@wordpress/ui';
 
 /**
  * Internal dependencies
@@ -32,7 +33,7 @@ export default function WordWrapColumn() {
 
 	return (
 		<div className="chbe-admin-editor-config__setting-item">
-			<HStack justify="start" alignment="start" wrap>
+			<Stack justify="start" align="start" wrap="wrap" gap="sm">
 				<RangeControl
 					__next40pxDefaultSize
 					label={ title }
@@ -48,7 +49,7 @@ export default function WordWrapColumn() {
 					image="editor-options/word-wrap-column.gif"
 					value={ editorOptions.wordWrapColumn }
 				/>
-			</HStack>
+			</Stack>
 		</div>
 	);
 }

--- a/src/admin/editor-config/editor-options/word-wrap.tsx
+++ b/src/admin/editor-config/editor-options/word-wrap.tsx
@@ -3,7 +3,8 @@
  */
 import { __ } from '@wordpress/i18n';
 import { useContext } from '@wordpress/element';
-import { SelectControl, __experimentalHStack as HStack } from '@wordpress/components';
+import { SelectControl } from '@wordpress/components';
+import { Stack } from '@wordpress/ui';
 
 /**
  * Internal dependencies
@@ -66,7 +67,7 @@ export default function WordWrap() {
 
 	return (
 		<div className="chbe-admin-editor-config__setting-item">
-			<HStack justify="start" alignment="start" wrap>
+			<Stack justify="start" align="start" wrap="wrap" gap="sm">
 				<SelectControl< EditorOptions[ 'wordWrap' ] >
 					__next40pxDefaultSize
 					label={ title }
@@ -80,7 +81,7 @@ export default function WordWrap() {
 					items={ items }
 					value={ editorOptions.wordWrap }
 				/>
-			</HStack>
+			</Stack>
 		</div>
 	);
 }

--- a/src/admin/editor-config/editor-options/word-wrap.tsx
+++ b/src/admin/editor-config/editor-options/word-wrap.tsx
@@ -66,22 +66,26 @@ export default function WordWrap() {
 	};
 
 	return (
-		<div className="chbe-admin-editor-config__setting-item">
-			<Stack justify="start" align="start" wrap="wrap" gap="sm">
-				<SelectControl< EditorOptions[ 'wordWrap' ] >
-					__next40pxDefaultSize
-					label={ title }
-					value={ editorOptions.wordWrap }
-					options={ items.map( ( { label, value } ) => ( { label, value } ) ) }
-					onChange={ onChange }
-				/>
-				<ItemHelp
-					onChange={ onChange }
-					title={ title }
-					items={ items }
-					value={ editorOptions.wordWrap }
-				/>
-			</Stack>
-		</div>
+		<Stack
+			className="chbe-admin-editor-config__setting-item"
+			justify="start"
+			align="start"
+			wrap="wrap"
+			gap="sm"
+		>
+			<SelectControl< EditorOptions[ 'wordWrap' ] >
+				__next40pxDefaultSize
+				label={ title }
+				value={ editorOptions.wordWrap }
+				options={ items.map( ( { label, value } ) => ( { label, value } ) ) }
+				onChange={ onChange }
+			/>
+			<ItemHelp
+				onChange={ onChange }
+				title={ title }
+				items={ items }
+				value={ editorOptions.wordWrap }
+			/>
+		</Stack>
 	);
 }

--- a/src/admin/editor-config/editor-options/wrapping-indent.tsx
+++ b/src/admin/editor-config/editor-options/wrapping-indent.tsx
@@ -3,7 +3,8 @@
  */
 import { __ } from '@wordpress/i18n';
 import { useContext } from '@wordpress/element';
-import { SelectControl, __experimentalHStack as HStack } from '@wordpress/components';
+import { SelectControl } from '@wordpress/components';
+import { Stack } from '@wordpress/ui';
 
 /**
  * Internal dependencies
@@ -56,7 +57,7 @@ export default function WrappingIndent() {
 
 	return (
 		<div className="chbe-admin-editor-config__setting-item">
-			<HStack justify="start" alignment="start" wrap>
+			<Stack justify="start" align="start" wrap="wrap" gap="sm">
 				<SelectControl< EditorOptions[ 'wrappingIndent' ] >
 					__next40pxDefaultSize
 					label={ title }
@@ -70,7 +71,7 @@ export default function WrappingIndent() {
 					items={ items }
 					value={ editorOptions.wrappingIndent }
 				/>
-			</HStack>
+			</Stack>
 		</div>
 	);
 }

--- a/src/admin/editor-config/editor-options/wrapping-indent.tsx
+++ b/src/admin/editor-config/editor-options/wrapping-indent.tsx
@@ -56,22 +56,26 @@ export default function WrappingIndent() {
 	};
 
 	return (
-		<div className="chbe-admin-editor-config__setting-item">
-			<Stack justify="start" align="start" wrap="wrap" gap="sm">
-				<SelectControl< EditorOptions[ 'wrappingIndent' ] >
-					__next40pxDefaultSize
-					label={ title }
-					value={ editorOptions.wrappingIndent }
-					options={ items.map( ( { label, value } ) => ( { label, value } ) ) }
-					onChange={ onChange }
-				/>
-				<ItemHelp
-					onChange={ onChange }
-					title={ title }
-					items={ items }
-					value={ editorOptions.wrappingIndent }
-				/>
-			</Stack>
-		</div>
+		<Stack
+			className="chbe-admin-editor-config__setting-item"
+			justify="start"
+			align="start"
+			wrap="wrap"
+			gap="sm"
+		>
+			<SelectControl< EditorOptions[ 'wrappingIndent' ] >
+				__next40pxDefaultSize
+				label={ title }
+				value={ editorOptions.wrappingIndent }
+				options={ items.map( ( { label, value } ) => ( { label, value } ) ) }
+				onChange={ onChange }
+			/>
+			<ItemHelp
+				onChange={ onChange }
+				title={ title }
+				items={ items }
+				value={ editorOptions.wrappingIndent }
+			/>
+		</Stack>
 	);
 }

--- a/src/admin/editor-config/editor-settings/emmet.tsx
+++ b/src/admin/editor-config/editor-settings/emmet.tsx
@@ -3,13 +3,8 @@
  */
 import { __ } from '@wordpress/i18n';
 import { useContext } from '@wordpress/element';
-import {
-	ExternalLink,
-	Notice,
-	ToggleControl,
-	__experimentalText as Text,
-	__experimentalHStack as HStack,
-} from '@wordpress/components';
+import { Notice, ToggleControl } from '@wordpress/components';
+import { Link, Stack, Text } from '@wordpress/ui';
 
 /**
  * Internal dependencies
@@ -37,20 +32,20 @@ export default function Emmet() {
 
 	return (
 		<div className="chbe-admin-editor-config__setting-item">
-			<HStack justify="start" alignment="start" wrap>
+			<Stack justify="start" align="start" wrap="wrap" gap="sm">
 				<ToggleControl label={ title } checked={ editorSettings.emmet } onChange={ onChange } />
 				<ItemHelp
 					onChange={ onChange }
 					title={ title }
 					description={
 						<>
-							<Text as="p">
+							<Text render={ <p /> }>
 								{ __(
 									'Emmet is a function for the editor that allow for high-speed coding via content assist.',
 									'custom-html-block-extension'
 								) }
 							</Text>
-							<Text as="p">
+							<Text render={ <p /> }>
 								{ __(
 									'Only valid for HTML tags and does not support inline CSS in the block and classic editor.',
 									'custom-html-block-extension'
@@ -61,10 +56,10 @@ export default function Emmet() {
 									'custom-html-block-extension'
 								) }
 							</Text>
-							<Text as="p">
-								<ExternalLink href="https://docs.emmet.io/cheat-sheet/">
+							<Text render={ <p /> }>
+								<Link href="https://docs.emmet.io/cheat-sheet/" openInNewTab>
 									{ __( 'Check cheat sheet', 'custom-html-block-extension' ) }
-								</ExternalLink>
+								</Link>
 							</Text>
 							<Notice status="warning" isDismissible={ false }>
 								{ __(
@@ -79,7 +74,7 @@ export default function Emmet() {
 					image="editor-settings/emmet.gif"
 					value={ editorSettings.emmet }
 				/>
-			</HStack>
+			</Stack>
 		</div>
 	);
 }

--- a/src/admin/editor-config/editor-settings/emmet.tsx
+++ b/src/admin/editor-config/editor-settings/emmet.tsx
@@ -31,50 +31,54 @@ export default function Emmet() {
 	};
 
 	return (
-		<div className="chbe-admin-editor-config__setting-item">
-			<Stack justify="start" align="start" wrap="wrap" gap="sm">
-				<ToggleControl label={ title } checked={ editorSettings.emmet } onChange={ onChange } />
-				<ItemHelp
-					onChange={ onChange }
-					title={ title }
-					description={
-						<>
-							<Text render={ <p /> }>
-								{ __(
-									'Emmet is a function for the editor that allow for high-speed coding via content assist.',
-									'custom-html-block-extension'
-								) }
-							</Text>
-							<Text render={ <p /> }>
-								{ __(
-									'Only valid for HTML tags and does not support inline CSS in the block and classic editor.',
-									'custom-html-block-extension'
-								) }
-								<br />
-								{ __(
-									'You can use Emmet if the file extension is html, php, sass, scss, css, or less in the theme/plugin editor.',
-									'custom-html-block-extension'
-								) }
-							</Text>
-							<Text render={ <p /> }>
-								<Link href="https://docs.emmet.io/cheat-sheet/" openInNewTab>
-									{ __( 'Check cheat sheet', 'custom-html-block-extension' ) }
-								</Link>
-							</Text>
-							<Notice status="warning" isDismissible={ false }>
-								{ __(
-									'Save and reload the browser to reflect this settings in the preview editor area.',
-									'custom-html-block-extension'
-								) }
-							</Notice>
-						</>
-					}
-					isToggle
-					defaultToggle
-					image="editor-settings/emmet.gif"
-					value={ editorSettings.emmet }
-				/>
-			</Stack>
-		</div>
+		<Stack
+			className="chbe-admin-editor-config__setting-item"
+			justify="start"
+			align="start"
+			wrap="wrap"
+			gap="sm"
+		>
+			<ToggleControl label={ title } checked={ editorSettings.emmet } onChange={ onChange } />
+			<ItemHelp
+				onChange={ onChange }
+				title={ title }
+				description={
+					<>
+						<Text render={ <p /> }>
+							{ __(
+								'Emmet is a function for the editor that allow for high-speed coding via content assist.',
+								'custom-html-block-extension'
+							) }
+						</Text>
+						<Text render={ <p /> }>
+							{ __(
+								'Only valid for HTML tags and does not support inline CSS in the block and classic editor.',
+								'custom-html-block-extension'
+							) }
+							<br />
+							{ __(
+								'You can use Emmet if the file extension is html, php, sass, scss, css, or less in the theme/plugin editor.',
+								'custom-html-block-extension'
+							) }
+						</Text>
+						<Text render={ <p /> }>
+							<Link href="https://docs.emmet.io/cheat-sheet/" openInNewTab>
+								{ __( 'Check cheat sheet', 'custom-html-block-extension' ) }
+							</Link>
+						</Text>
+						<Notice status="warning" isDismissible={ false }>
+							{ __(
+								'Save and reload the browser to reflect this settings in the preview editor area.',
+								'custom-html-block-extension'
+							) }
+						</Notice>
+					</>
+				}
+				isToggle
+				defaultToggle
+				image="editor-settings/emmet.gif"
+				value={ editorSettings.emmet }
+			/>
+		</Stack>
 	);
 }

--- a/src/admin/editor-config/editor-settings/insert-spaces.tsx
+++ b/src/admin/editor-config/editor-settings/insert-spaces.tsx
@@ -4,10 +4,10 @@
 import { __ } from '@wordpress/i18n';
 import { useContext } from '@wordpress/element';
 import {
-	__experimentalHStack as HStack,
 	__experimentalToggleGroupControl as ToggleGroupControl,
 	__experimentalToggleGroupControlOption as ToggleGroupControlOption,
 } from '@wordpress/components';
+import { Stack } from '@wordpress/ui';
 
 /**
  * Internal dependencies
@@ -47,7 +47,7 @@ export default function InsertSpaces() {
 
 	return (
 		<div className="chbe-admin-editor-config__setting-item">
-			<HStack>
+			<Stack gap="sm">
 				<ToggleGroupControl
 					size="__unstable-large"
 					label={ __( 'Indent type', 'custom-html-block-extension' ) }
@@ -63,7 +63,7 @@ export default function InsertSpaces() {
 						/>
 					) ) }
 				</ToggleGroupControl>
-			</HStack>
+			</Stack>
 		</div>
 	);
 }

--- a/src/admin/editor-config/editor-settings/insert-spaces.tsx
+++ b/src/admin/editor-config/editor-settings/insert-spaces.tsx
@@ -46,24 +46,18 @@ export default function InsertSpaces() {
 	};
 
 	return (
-		<div className="chbe-admin-editor-config__setting-item">
-			<Stack gap="sm">
-				<ToggleGroupControl
-					size="__unstable-large"
-					label={ __( 'Indent type', 'custom-html-block-extension' ) }
-					value={ editorSettings.insertSpaces ? 'space' : 'tab' }
-					onChange={ onChange }
-					isBlock
-				>
-					{ items.map( ( item ) => (
-						<ToggleGroupControlOption
-							key={ item.value }
-							value={ item.value }
-							label={ item.label }
-						/>
-					) ) }
-				</ToggleGroupControl>
-			</Stack>
-		</div>
+		<Stack className="chbe-admin-editor-config__setting-item" gap="sm">
+			<ToggleGroupControl
+				size="__unstable-large"
+				label={ __( 'Indent type', 'custom-html-block-extension' ) }
+				value={ editorSettings.insertSpaces ? 'space' : 'tab' }
+				onChange={ onChange }
+				isBlock
+			>
+				{ items.map( ( item ) => (
+					<ToggleGroupControlOption key={ item.value } value={ item.value } label={ item.label } />
+				) ) }
+			</ToggleGroupControl>
+		</Stack>
 	);
 }

--- a/src/admin/editor-config/editor-settings/theme.tsx
+++ b/src/admin/editor-config/editor-settings/theme.tsx
@@ -3,7 +3,8 @@
  */
 import { __ } from '@wordpress/i18n';
 import { useContext } from '@wordpress/element';
-import { SelectControl, __experimentalHStack as HStack } from '@wordpress/components';
+import { SelectControl } from '@wordpress/components';
+import { Stack } from '@wordpress/ui';
 
 /**
  * Internal dependencies
@@ -31,7 +32,7 @@ export default function Theme() {
 
 	return (
 		<div className="chbe-admin-editor-config__setting-item">
-			<HStack>
+			<Stack gap="sm">
 				<SelectControl
 					__next40pxDefaultSize
 					label={ title }
@@ -43,7 +44,7 @@ export default function Theme() {
 					] }
 					onChange={ onChange }
 				/>
-			</HStack>
+			</Stack>
 		</div>
 	);
 }

--- a/src/admin/editor-config/editor-settings/theme.tsx
+++ b/src/admin/editor-config/editor-settings/theme.tsx
@@ -31,20 +31,18 @@ export default function Theme() {
 	};
 
 	return (
-		<div className="chbe-admin-editor-config__setting-item">
-			<Stack gap="sm">
-				<SelectControl
-					__next40pxDefaultSize
-					label={ title }
-					value={ editorSettings.theme }
-					options={ [
-						{ label: __( 'Visual Studio Dark', 'custom-html-block-extension' ), value: 'vs-dark' },
-						{ label: __( 'Light', 'custom-html-block-extension' ), value: 'light' },
-						...themes,
-					] }
-					onChange={ onChange }
-				/>
-			</Stack>
-		</div>
+		<Stack className="chbe-admin-editor-config__setting-item" gap="sm">
+			<SelectControl
+				__next40pxDefaultSize
+				label={ title }
+				value={ editorSettings.theme }
+				options={ [
+					{ label: __( 'Visual Studio Dark', 'custom-html-block-extension' ), value: 'vs-dark' },
+					{ label: __( 'Light', 'custom-html-block-extension' ), value: 'light' },
+					...themes,
+				] }
+				onChange={ onChange }
+			/>
+		</Stack>
 	);
 }

--- a/src/admin/editor-config/index.tsx
+++ b/src/admin/editor-config/index.tsx
@@ -9,13 +9,8 @@ import clsx from 'clsx';
 import { __ } from '@wordpress/i18n';
 import apiFetch from '@wordpress/api-fetch';
 import { createContext, useCallback, useContext, useState } from '@wordpress/element';
-import {
-	PanelBody,
-	Disabled,
-	__experimentalHeading as Heading,
-	__experimentalHStack as HStack,
-	__experimentalVStack as VStack,
-} from '@wordpress/components';
+import { PanelBody, Disabled, __experimentalHeading as Heading } from '@wordpress/components';
+import { Stack } from '@wordpress/ui';
 import { useDispatch } from '@wordpress/data';
 import { store as noticesStore } from '@wordpress/notices';
 
@@ -126,14 +121,8 @@ export default function EditorConfig() {
 	}, [] );
 
 	return (
-		<HStack
-			spacing={ 8 }
-			alignment="start"
-			direction="row-reverse"
-			wrap
-			className="chbe-admin-editor-config"
-		>
-			<VStack spacing={ 8 } className="chbe-admin-editor-config__preview">
+		<Stack align="start" wrap="wrap" className="chbe-admin-editor-config" gap="2xl">
+			<Stack direction="column" className="chbe-admin-editor-config__preview" gap="2xl">
 				<Heading as="h2" level="3">
 					{ __( 'Preview', 'custom-html-block-extension' ) }
 				</Heading>
@@ -143,22 +132,23 @@ export default function EditorConfig() {
 					onUpdateOptions={ onUpdateOptions }
 					onResetOptions={ onResetOptions }
 				/>
-			</VStack>
-			<VStack spacing={ 8 } className="chbe-admin-editor-config__settings">
+			</Stack>
+			<Stack direction="column" className="chbe-admin-editor-config__settings" gap="2xl">
 				<Filter
 					editorMode={ editorMode }
 					setEditorMode={ setEditorMode }
 					searchQuery={ searchQuery }
 					setSearchQuery={ setSearchQuery }
 				/>
-				<VStack
+				<Stack
+					direction="column"
 					className={ clsx(
 						editorMode === 'basic' && ! searchQuery
 							? 'chbe-admin-editor-config__basic-settings'
 							: 'chbe-admin-editor-config__advanced-settings',
 						{ 'is-searching': !! searchQuery }
 					) }
-					spacing={ editorMode === 'basic' && ! searchQuery ? 6 : 2 }
+					gap={ editorMode === 'basic' && ! searchQuery ? 'xl' : 'sm' }
 				>
 					<EditorConfigContext.Provider value={ { onRefreshEditor, searchQuery } }>
 						{ 'basic' === editorMode && ! searchQuery && (
@@ -186,7 +176,7 @@ export default function EditorConfig() {
 									initialOpen={ !! searchQuery }
 									scrollAfterOpen={ ! searchQuery }
 								>
-									<VStack spacing={ 4 }>
+									<Stack direction="column" gap="lg">
 										<EditorSettings.Theme />
 										<EditorSettings.TabSize />
 										<EditorSettings.InsertSpaces />
@@ -195,7 +185,7 @@ export default function EditorConfig() {
 										<EditorOptions.GlyphMargin />
 										<EditorOptions.PaddingTop />
 										<EditorOptions.PaddingBottom />
-									</VStack>
+									</Stack>
 								</PanelBody>
 								<PanelBody
 									className="chbe-admin-editor-config__panel"
@@ -203,14 +193,14 @@ export default function EditorConfig() {
 									initialOpen={ !! searchQuery }
 									scrollAfterOpen={ ! searchQuery }
 								>
-									<VStack spacing={ 4 }>
+									<Stack direction="column" gap="lg">
 										<EditorOptions.FontFamily />
 										<EditorOptions.FontWeight fontWeights={ fontWeights } />
 										<EditorOptions.FontLigatures />
 										<EditorOptions.FontSize />
 										<EditorOptions.LineHeight />
 										<EditorOptions.LetterSpacing />
-									</VStack>
+									</Stack>
 								</PanelBody>
 								<PanelBody
 									className="chbe-admin-editor-config__panel"
@@ -218,7 +208,7 @@ export default function EditorConfig() {
 									initialOpen={ !! searchQuery }
 									scrollAfterOpen={ ! searchQuery }
 								>
-									<VStack spacing={ 4 }>
+									<Stack direction="column" gap="lg">
 										<EditorOptions.WordWrap />
 										{ 'on' === editorOptions.wordWrap || 'off' === editorOptions.wordWrap ? (
 											<Disabled>
@@ -234,7 +224,7 @@ export default function EditorConfig() {
 										) : (
 											<EditorOptions.WrappingIndent />
 										) }
-									</VStack>
+									</Stack>
 								</PanelBody>
 								<PanelBody
 									className="chbe-admin-editor-config__panel"
@@ -242,18 +232,18 @@ export default function EditorConfig() {
 									initialOpen={ !! searchQuery }
 									scrollAfterOpen={ ! searchQuery }
 								>
-									<VStack spacing={ 4 }>
+									<Stack direction="column" gap="lg">
 										<EditorOptions.MinimapEnabled />
 										{ ! editorOptions.minimap.enabled ? (
 											<Disabled>
-												<VStack spacing={ 4 }>
+												<Stack direction="column" gap="lg">
 													<EditorOptions.MinimapSide />
 													<EditorOptions.MinimapMaxColumn />
 													<EditorOptions.MinimapScale />
 													<EditorOptions.MinimapShowSlider />
 													<EditorOptions.MinimapSize />
 													<EditorOptions.MinimapRenderCharacters />
-												</VStack>
+												</Stack>
 											</Disabled>
 										) : (
 											<>
@@ -265,7 +255,7 @@ export default function EditorConfig() {
 												<EditorOptions.MinimapRenderCharacters />
 											</>
 										) }
-									</VStack>
+									</Stack>
 								</PanelBody>
 								<PanelBody
 									className="chbe-admin-editor-config__panel"
@@ -273,7 +263,7 @@ export default function EditorConfig() {
 									initialOpen={ !! searchQuery }
 									scrollAfterOpen={ ! searchQuery }
 								>
-									<VStack spacing={ 4 }>
+									<Stack direction="column" gap="lg">
 										<EditorOptions.CursorStyle />
 										{ 'line' !== editorOptions.cursorStyle ? (
 											<Disabled>
@@ -286,7 +276,7 @@ export default function EditorConfig() {
 										<EditorOptions.CursorSurroundingLines />
 										<EditorOptions.CursorSurroundingLinesStyle />
 										<EditorOptions.CursorSmoothCaretAnimation />
-									</VStack>
+									</Stack>
 								</PanelBody>
 								<PanelBody
 									className="chbe-admin-editor-config__panel"
@@ -294,17 +284,17 @@ export default function EditorConfig() {
 									initialOpen={ !! searchQuery }
 									scrollAfterOpen={ ! searchQuery }
 								>
-									<VStack spacing={ 4 }>
+									<Stack direction="column" gap="lg">
 										<EditorOptions.Folding />
 										{ ! editorOptions.folding ? (
 											<Disabled>
-												<VStack spacing={ 4 }>
+												<Stack direction="column" gap="lg">
 													<EditorOptions.ShowFoldingControls />
 													<EditorOptions.FoldingStrategy />
 													<EditorOptions.LineDecorationsWidth />
 													<EditorOptions.FoldingHighlight />
 													<EditorOptions.UnfoldOnClickAfterEndOfLine />
-												</VStack>
+												</Stack>
 											</Disabled>
 										) : (
 											<>
@@ -315,7 +305,7 @@ export default function EditorConfig() {
 												<EditorOptions.UnfoldOnClickAfterEndOfLine />
 											</>
 										) }
-									</VStack>
+									</Stack>
 								</PanelBody>
 								<PanelBody
 									className="chbe-admin-editor-config__panel"
@@ -323,15 +313,15 @@ export default function EditorConfig() {
 									initialOpen={ !! searchQuery }
 									scrollAfterOpen={ ! searchQuery }
 								>
-									<VStack spacing={ 4 }>
+									<Stack direction="column" gap="lg">
 										<EditorOptions.LineNumbers />
 										{ 'off' === editorOptions.lineNumbers ? (
 											<Disabled>
-												<VStack spacing={ 4 }>
+												<Stack direction="column" gap="lg">
 													<EditorOptions.LineNumbersMinChars />
 													<EditorOptions.SelectOnLineNumbers />
 													<EditorOptions.RenderFinalNewline />
-												</VStack>
+												</Stack>
 											</Disabled>
 										) : (
 											<>
@@ -340,7 +330,7 @@ export default function EditorConfig() {
 												<EditorOptions.RenderFinalNewline />
 											</>
 										) }
-									</VStack>
+									</Stack>
 								</PanelBody>
 								<PanelBody
 									className="chbe-admin-editor-config__panel"
@@ -348,17 +338,17 @@ export default function EditorConfig() {
 									initialOpen={ !! searchQuery }
 									scrollAfterOpen={ ! searchQuery }
 								>
-									<VStack spacing={ 4 }>
+									<Stack direction="column" gap="lg">
 										<EditorOptions.QuickSuggestions />
 										{ ! editorOptions.quickSuggestions ? (
 											<Disabled>
-												<VStack spacing={ 4 }>
+												<Stack direction="column" gap="lg">
 													<EditorOptions.AcceptSuggestionOnEnter />
 													<EditorOptions.QuickSuggestionsDelay />
 													<EditorOptions.SuggestFontSize />
 													<EditorOptions.SuggestLineHeight />
 													<EditorOptions.SuggestShowIcons />
-												</VStack>
+												</Stack>
 											</Disabled>
 										) : (
 											<>
@@ -369,7 +359,7 @@ export default function EditorConfig() {
 												<EditorOptions.SuggestShowIcons />
 											</>
 										) }
-									</VStack>
+									</Stack>
 								</PanelBody>
 								<PanelBody
 									className="chbe-admin-editor-config__panel"
@@ -377,13 +367,13 @@ export default function EditorConfig() {
 									initialOpen={ !! searchQuery }
 									scrollAfterOpen={ ! searchQuery }
 								>
-									<VStack spacing={ 4 }>
+									<Stack direction="column" gap="lg">
 										<EditorOptions.AutoIndent />
 										<EditorOptions.AutoClosingBrackets />
 										<EditorOptions.AutoClosingQuotes />
 										<EditorOptions.AutoSurround />
 										<EditorOptions.FormatOnPaste />
-									</VStack>
+									</Stack>
 								</PanelBody>
 								<PanelBody
 									className="chbe-admin-editor-config__panel"
@@ -391,7 +381,7 @@ export default function EditorConfig() {
 									initialOpen={ !! searchQuery }
 									scrollAfterOpen={ ! searchQuery }
 								>
-									<VStack spacing={ 4 }>
+									<Stack direction="column" gap="lg">
 										<EditorOptions.MouseWheelScrollSensitivity />
 										<EditorOptions.FastScrollSensitivity />
 										<EditorOptions.Hover />
@@ -402,7 +392,7 @@ export default function EditorConfig() {
 										<EditorOptions.DragAndDrop />
 										<EditorOptions.HideCursorInOverviewRuler />
 										<EditorOptions.MultiCursorModifier />
-									</VStack>
+									</Stack>
 								</PanelBody>
 								<PanelBody
 									className="chbe-admin-editor-config__panel"
@@ -410,7 +400,7 @@ export default function EditorConfig() {
 									initialOpen={ !! searchQuery }
 									scrollAfterOpen={ ! searchQuery }
 								>
-									<VStack spacing={ 4 }>
+									<Stack direction="column" gap="lg">
 										<EditorOptions.EmptySelectionClipboard />
 										<EditorOptions.RoundedSelection />
 										<EditorOptions.SelectionHighlight />
@@ -418,7 +408,7 @@ export default function EditorConfig() {
 										<EditorOptions.StickyTabStops />
 										<EditorOptions.CopyWithSyntaxHighlighting />
 										<EditorOptions.ColumnSelection />
-									</VStack>
+									</Stack>
 								</PanelBody>
 								<PanelBody
 									className="chbe-admin-editor-config__panel"
@@ -426,7 +416,7 @@ export default function EditorConfig() {
 									initialOpen={ !! searchQuery }
 									scrollAfterOpen={ ! searchQuery }
 								>
-									<VStack spacing={ 4 }>
+									<Stack direction="column" gap="lg">
 										<EditorOptions.MatchBrackets />
 										<EditorOptions.OccurrencesHighlight />
 										<EditorOptions.RenderWhitespace />
@@ -448,7 +438,7 @@ export default function EditorConfig() {
 										) }
 										<EditorOptions.RenderControlCharacters />
 										<EditorOptions.Rulers />
-									</VStack>
+									</Stack>
 								</PanelBody>
 								<PanelBody
 									className="chbe-admin-editor-config__panel"
@@ -456,11 +446,11 @@ export default function EditorConfig() {
 									initialOpen={ !! searchQuery }
 									scrollAfterOpen={ ! searchQuery }
 								>
-									<VStack spacing={ 4 }>
+									<Stack direction="column" gap="lg">
 										<EditorOptions.FindAddExtraSpaceOnTop />
 										<EditorOptions.FindSeedSearchStringFromSelection />
 										<EditorOptions.FindLoop />
-									</VStack>
+									</Stack>
 								</PanelBody>
 								<PanelBody
 									className="chbe-admin-editor-config__panel"
@@ -468,7 +458,7 @@ export default function EditorConfig() {
 									initialOpen={ !! searchQuery }
 									scrollAfterOpen={ ! searchQuery }
 								>
-									<VStack spacing={ 4 }>
+									<Stack direction="column" gap="lg">
 										<EditorOptions.ScrollbarUseShadows />
 										<EditorOptions.OverviewRulerBorder />
 										<EditorOptions.ScrollbarAlwaysConsumeMouseWheel />
@@ -476,10 +466,10 @@ export default function EditorConfig() {
 										<EditorOptions.ScrollbarHorizontal />
 										{ 'hidden' === editorOptions.scrollbar.horizontal ? (
 											<Disabled>
-												<VStack spacing={ 4 }>
+												<Stack direction="column" gap="lg">
 													<EditorOptions.ScrollbarHorizontalHasArrows />
 													<EditorOptions.ScrollbarHorizontalScrollbarSize />
-												</VStack>
+												</Stack>
 											</Disabled>
 										) : (
 											<>
@@ -490,10 +480,10 @@ export default function EditorConfig() {
 										<EditorOptions.ScrollbarVertical />
 										{ 'hidden' === editorOptions.scrollbar.vertical ? (
 											<Disabled>
-												<VStack spacing={ 4 }>
+												<Stack direction="column" gap="lg">
 													<EditorOptions.ScrollbarVerticalHasArrows />
 													<EditorOptions.ScrollbarVerticalScrollbarSize />
-												</VStack>
+												</Stack>
 											</Disabled>
 										) : (
 											<>
@@ -511,7 +501,7 @@ export default function EditorConfig() {
 										) : (
 											<EditorOptions.ScrollbarArrowSize />
 										) }
-									</VStack>
+									</Stack>
 								</PanelBody>
 								<PanelBody
 									className="chbe-admin-editor-config__panel"
@@ -519,17 +509,17 @@ export default function EditorConfig() {
 									initialOpen={ !! searchQuery }
 									scrollAfterOpen={ ! searchQuery }
 								>
-									<VStack spacing={ 4 }>
+									<Stack direction="column" gap="lg">
 										<EditorOptions.UseTabStops />
 										<EditorOptions.CommentsInsertSpace />
 										<EditorOptions.Links />
-									</VStack>
+									</Stack>
 								</PanelBody>
 							</>
 						) }
 					</EditorConfigContext.Provider>
-				</VStack>
-			</VStack>
-		</HStack>
+				</Stack>
+			</Stack>
+		</Stack>
 	);
 }

--- a/src/admin/editor-config/index.tsx
+++ b/src/admin/editor-config/index.tsx
@@ -121,8 +121,8 @@ export default function EditorConfig() {
 	}, [] );
 
 	return (
-		<Stack align="start" wrap="wrap" className="chbe-admin-editor-config" gap="2xl">
-			<Stack direction="column" className="chbe-admin-editor-config__preview" gap="2xl">
+		<Stack align="start" wrap="wrap" className="chbe-admin-editor-config" gap="xl">
+			<Stack direction="column" className="chbe-admin-editor-config__preview" gap="xl">
 				<Heading as="h2" level="3">
 					{ __( 'Preview', 'custom-html-block-extension' ) }
 				</Heading>
@@ -133,7 +133,7 @@ export default function EditorConfig() {
 					onResetOptions={ onResetOptions }
 				/>
 			</Stack>
-			<Stack direction="column" className="chbe-admin-editor-config__settings" gap="2xl">
+			<Stack direction="column" className="chbe-admin-editor-config__settings" gap="xl">
 				<Filter
 					editorMode={ editorMode }
 					setEditorMode={ setEditorMode }

--- a/src/admin/editor-config/style.scss
+++ b/src/admin/editor-config/style.scss
@@ -5,6 +5,7 @@
 @use "./components/item-help/style" as itemHelp;
 
 .chbe-admin-editor-config {
+	flex-direction: row-reverse;
 
 	.components-select-control {
 		min-width: 200px;

--- a/src/admin/options/components/permission-editor/index.tsx
+++ b/src/admin/options/components/permission-editor/index.tsx
@@ -3,7 +3,8 @@
  */
 import { __ } from '@wordpress/i18n';
 import { useContext } from '@wordpress/element';
-import { PanelBody, ToggleControl, __experimentalVStack as VStack } from '@wordpress/components';
+import { PanelBody, ToggleControl } from '@wordpress/components';
+import { Stack } from '@wordpress/ui';
 
 /**
  * Internal dependencies
@@ -38,7 +39,7 @@ export default function PermissionEditor() {
 		<PanelBody
 			title={ __( 'Editors allowed to use this extension', 'custom-html-block-extension' ) }
 		>
-			<VStack spacing={ 4 }>
+			<Stack direction="column" gap="lg">
 				<ToggleControl
 					label={ __( 'Block editor', 'custom-html-block-extension' ) }
 					checked={ options.permissionBlockEditor }
@@ -54,7 +55,7 @@ export default function PermissionEditor() {
 					checked={ options.permissionThemePluginEditor }
 					onChange={ onThemePluginEditorChange }
 				/>
-			</VStack>
+			</Stack>
 		</PanelBody>
 	);
 }

--- a/src/admin/options/components/permission-user-role/index.tsx
+++ b/src/admin/options/components/permission-user-role/index.tsx
@@ -3,7 +3,8 @@
  */
 import { __ } from '@wordpress/i18n';
 import { useContext } from '@wordpress/element';
-import { PanelBody, ToggleControl, __experimentalVStack as VStack } from '@wordpress/components';
+import { PanelBody, ToggleControl } from '@wordpress/components';
+import { Stack } from '@wordpress/ui';
 
 /**
  * Internal dependencies
@@ -32,7 +33,7 @@ export default function PermissionUserRole() {
 		<PanelBody
 			title={ __( 'User roles allowed to use this extension', 'custom-html-block-extension' ) }
 		>
-			<VStack spacing={ 4 }>
+			<Stack direction="column" gap="lg">
 				{ userRoles.map( ( role, index ) => (
 					<ToggleControl
 						key={ index }
@@ -41,7 +42,7 @@ export default function PermissionUserRole() {
 						onChange={ () => onChange( role.value ) }
 					/>
 				) ) }
-			</VStack>
+			</Stack>
 		</PanelBody>
 	);
 }

--- a/src/admin/options/index.tsx
+++ b/src/admin/options/index.tsx
@@ -4,7 +4,8 @@
 import { __ } from '@wordpress/i18n';
 import apiFetch from '@wordpress/api-fetch';
 import { useContext } from '@wordpress/element';
-import { Button, Flex, __experimentalVStack as VStack } from '@wordpress/components';
+import { Button } from '@wordpress/components';
+import { Stack } from '@wordpress/ui';
 import { useDispatch } from '@wordpress/data';
 import { store as noticesStore } from '@wordpress/notices';
 
@@ -38,10 +39,10 @@ export default function Options() {
 	};
 
 	return (
-		<VStack spacing={ 4 }>
+		<Stack direction="column" gap="lg">
 			<PermissionEditor />
 			<PermissionUserRole />
-			<Flex>
+			<Stack gap="sm">
 				<Button
 					variant="primary"
 					disabled={ isWaiting }
@@ -50,7 +51,7 @@ export default function Options() {
 				>
 					{ __( 'Save Options', 'custom-html-block-extension' ) }
 				</Button>
-			</Flex>
-		</VStack>
+			</Stack>
+		</Stack>
 	);
 }

--- a/src/admin/tools/components/export-tool/index.tsx
+++ b/src/admin/tools/components/export-tool/index.tsx
@@ -4,12 +4,8 @@
 import { __ } from '@wordpress/i18n';
 import apiFetch from '@wordpress/api-fetch';
 import { useContext } from '@wordpress/element';
-import {
-	Button,
-	PanelBody,
-	__experimentalText as Text,
-	__experimentalVStack as VStack,
-} from '@wordpress/components';
+import { Button, PanelBody } from '@wordpress/components';
+import { Stack, Text } from '@wordpress/ui';
 import { useDispatch } from '@wordpress/data';
 import { store as noticesStore } from '@wordpress/notices';
 
@@ -57,8 +53,8 @@ export default function ExportTool() {
 
 	return (
 		<PanelBody title={ __( 'Export Editor Config', 'custom-html-block-extension' ) }>
-			<VStack alignment="start">
-				<Text as="p">
+			<Stack direction="column" align="start" gap="sm">
+				<Text render={ <p /> }>
 					{ __(
 						'Use the download button to export the editor settings. You can restore the editor config by importing the exported file on another WordPress site.',
 						'custom-html-block-extension'
@@ -67,7 +63,7 @@ export default function ExportTool() {
 				<Button variant="primary" onClick={ onExportOptions } __next40pxDefaultSize>
 					{ __( 'Export', 'custom-html-block-extension' ) }
 				</Button>
-			</VStack>
+			</Stack>
 		</PanelBody>
 	);
 }

--- a/src/admin/tools/components/import-tool/index.tsx
+++ b/src/admin/tools/components/import-tool/index.tsx
@@ -9,14 +9,8 @@ import type { ChangeEvent } from 'react';
 import { __ } from '@wordpress/i18n';
 import apiFetch from '@wordpress/api-fetch';
 import { useContext, useState } from '@wordpress/element';
-import {
-	Button,
-	FormFileUpload,
-	PanelBody,
-	__experimentalText as Text,
-	__experimentalHStack as HStack,
-	__experimentalVStack as VStack,
-} from '@wordpress/components';
+import { Button, FormFileUpload, PanelBody } from '@wordpress/components';
+import { Stack, Text } from '@wordpress/ui';
 import { useDispatch } from '@wordpress/data';
 import { store as noticesStore } from '@wordpress/notices';
 
@@ -99,14 +93,14 @@ export default function ImportTool() {
 
 	return (
 		<PanelBody title={ __( 'Import editor config', 'custom-html-block-extension' ) }>
-			<VStack spacing={ 4 } alignment="start">
-				<Text as="p">
+			<Stack direction="column" align="start" gap="lg">
+				<Text render={ <p /> }>
 					{ __(
 						'Select the Custom HTML Block Extension JSON file you would like to import and click the import button below.',
 						'custom-html-block-extension'
 					) }
 				</Text>
-				<HStack spacing={ 4 } justify="start" wrap>
+				<Stack justify="start" wrap="wrap" gap="lg">
 					<FormFileUpload
 						accept="application/json"
 						onChange={ onUploadFile }
@@ -117,7 +111,7 @@ export default function ImportTool() {
 						) }
 					/>
 					{ importFile && <span>{ importFile.name }</span> }
-				</HStack>
+				</Stack>
 				<Button
 					variant="primary"
 					disabled={ ! importFile }
@@ -127,7 +121,7 @@ export default function ImportTool() {
 				>
 					{ __( 'Import', 'custom-html-block-extension' ) }
 				</Button>
-			</VStack>
+			</Stack>
 		</PanelBody>
 	);
 }

--- a/src/admin/tools/index.tsx
+++ b/src/admin/tools/index.tsx
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { __experimentalVStack as VStack } from '@wordpress/components';
+import { Stack } from '@wordpress/ui';
 
 /**
  * Internal dependencies
@@ -11,9 +11,9 @@ import ImportTool from './components/import-tool';
 
 export default function Tools() {
 	return (
-		<VStack spacing={ 4 }>
+		<Stack direction="column" gap="lg">
 			<ExportTool />
 			<ImportTool />
-		</VStack>
+		</Stack>
 	);
 }

--- a/src/block-editor/edit.tsx
+++ b/src/block-editor/edit.tsx
@@ -18,8 +18,8 @@ import {
 	ToolbarGroup,
 	Modal,
 	Notice,
-	__experimentalVStack as VStack,
 } from '@wordpress/components';
+import { Stack } from '@wordpress/ui';
 import { fullscreen } from '@wordpress/icons';
 import type { BlockEditProps } from '@wordpress/blocks';
 
@@ -144,7 +144,7 @@ export default function HTMLEdit( {
 							{ ! isSelected && <div className="block-library-html__preview-overlay"></div> }
 						</>
 					) : (
-						<VStack>
+						<Stack direction="column" gap="sm">
 							{ errorMessage && <Notice status="warning">{ errorMessage }</Notice> }
 							<ResizableBox
 								size={ { height } }
@@ -175,7 +175,7 @@ export default function HTMLEdit( {
 									onError={ onError }
 								/>
 							</ResizableBox>
-						</VStack>
+						</Stack>
 					)
 				}
 			</Disabled.Consumer>


### PR DESCRIPTION
Replaces the unstable `@wordpress/components` layout/text primitives (`__experimentalText`, `__experimentalHStack`/`VStack`, `Flex`, `FlexBlock`, `Spacer`, `ExternalLink`) with their stable `@wordpress/ui` equivalents (`Text`, `Stack`, `Link`, plus a `div` for `FlexBlock`/`Spacer`), preserving spacing sizes via `gap` tokens.
