### PR TITLE
Replace PanelBody with CollapsibleCard from @wordpress/ui

### DIFF
--- a/src/admin/editor-config/index.tsx
+++ b/src/admin/editor-config/index.tsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import type { ReactNode } from 'react';
 import clsx from 'clsx';
 
 /**
@@ -9,8 +10,8 @@ import clsx from 'clsx';
 import { __ } from '@wordpress/i18n';
 import apiFetch from '@wordpress/api-fetch';
 import { createContext, useCallback, useContext, useState } from '@wordpress/element';
-import { PanelBody, Disabled, __experimentalHeading as Heading } from '@wordpress/components';
-import { Stack } from '@wordpress/ui';
+import { Disabled, __experimentalHeading as Heading } from '@wordpress/components';
+import { Card, CollapsibleCard, Stack } from '@wordpress/ui';
 import { useDispatch } from '@wordpress/data';
 import { store as noticesStore } from '@wordpress/notices';
 
@@ -49,6 +50,37 @@ export function useSearchVisibility( title: string ): boolean {
 		return true;
 	}
 	return title.toLowerCase().includes( searchQuery.toLowerCase() );
+}
+
+/**
+ * A collapsible settings panel. While a search query is active, every panel is
+ * forced open so the matching settings inside it are revealed; otherwise the
+ * open state is left to the user (uncontrolled-like behavior via local state).
+ *
+ * @param {Object}    props          Component props.
+ * @param {string}    props.title    The panel's display title.
+ * @param {ReactNode} props.children The settings rendered inside the panel.
+ */
+function SettingsPanel( { title, children }: { title: string; children: ReactNode } ) {
+	const { searchQuery } = useContext( EditorConfigContext );
+	const [ isOpen, setIsOpen ] = useState( false );
+
+	return (
+		<CollapsibleCard.Root
+			className="chbe-admin-editor-config__panel"
+			open={ !! searchQuery || isOpen }
+			onOpenChange={ setIsOpen }
+		>
+			<CollapsibleCard.Header render={ <h2 /> }>
+				<Card.Title>{ title }</Card.Title>
+			</CollapsibleCard.Header>
+			<CollapsibleCard.Content>
+				<Stack direction="column" gap="lg">
+					{ children }
+				</Stack>
+			</CollapsibleCard.Content>
+		</CollapsibleCard.Root>
+	);
 }
 
 export default function EditorConfig() {
@@ -170,351 +202,250 @@ export default function EditorConfig() {
 						) }
 						{ ( 'advanced' === editorMode || searchQuery ) && (
 							<>
-								<PanelBody
-									className="chbe-admin-editor-config__panel"
-									title={ __( 'Editor', 'custom-html-block-extension' ) }
-									initialOpen={ !! searchQuery }
-									scrollAfterOpen={ ! searchQuery }
-								>
-									<Stack direction="column" gap="lg">
-										<EditorSettings.Theme />
-										<EditorSettings.TabSize />
-										<EditorSettings.InsertSpaces />
-										<EditorSettings.Emmet />
-										<EditorOptions.Contextmenu />
-										<EditorOptions.GlyphMargin />
-										<EditorOptions.PaddingTop />
-										<EditorOptions.PaddingBottom />
-									</Stack>
-								</PanelBody>
-								<PanelBody
-									className="chbe-admin-editor-config__panel"
-									title={ __( 'Font', 'custom-html-block-extension' ) }
-									initialOpen={ !! searchQuery }
-									scrollAfterOpen={ ! searchQuery }
-								>
-									<Stack direction="column" gap="lg">
-										<EditorOptions.FontFamily />
-										<EditorOptions.FontWeight fontWeights={ fontWeights } />
-										<EditorOptions.FontLigatures />
-										<EditorOptions.FontSize />
-										<EditorOptions.LineHeight />
-										<EditorOptions.LetterSpacing />
-									</Stack>
-								</PanelBody>
-								<PanelBody
-									className="chbe-admin-editor-config__panel"
-									title={ __( 'Word wrap', 'custom-html-block-extension' ) }
-									initialOpen={ !! searchQuery }
-									scrollAfterOpen={ ! searchQuery }
-								>
-									<Stack direction="column" gap="lg">
-										<EditorOptions.WordWrap />
-										{ 'on' === editorOptions.wordWrap || 'off' === editorOptions.wordWrap ? (
-											<Disabled>
-												<EditorOptions.WordWrapColumn />
-											</Disabled>
-										) : (
+								<SettingsPanel title={ __( 'Editor', 'custom-html-block-extension' ) }>
+									<EditorSettings.Theme />
+									<EditorSettings.TabSize />
+									<EditorSettings.InsertSpaces />
+									<EditorSettings.Emmet />
+									<EditorOptions.Contextmenu />
+									<EditorOptions.GlyphMargin />
+									<EditorOptions.PaddingTop />
+									<EditorOptions.PaddingBottom />
+								</SettingsPanel>
+								<SettingsPanel title={ __( 'Font', 'custom-html-block-extension' ) }>
+									<EditorOptions.FontFamily />
+									<EditorOptions.FontWeight fontWeights={ fontWeights } />
+									<EditorOptions.FontLigatures />
+									<EditorOptions.FontSize />
+									<EditorOptions.LineHeight />
+									<EditorOptions.LetterSpacing />
+								</SettingsPanel>
+								<SettingsPanel title={ __( 'Word wrap', 'custom-html-block-extension' ) }>
+									<EditorOptions.WordWrap />
+									{ 'on' === editorOptions.wordWrap || 'off' === editorOptions.wordWrap ? (
+										<Disabled>
 											<EditorOptions.WordWrapColumn />
-										) }
-										{ 'off' === editorOptions.wordWrap ? (
-											<Disabled>
-												<EditorOptions.WrappingIndent />
-											</Disabled>
-										) : (
+										</Disabled>
+									) : (
+										<EditorOptions.WordWrapColumn />
+									) }
+									{ 'off' === editorOptions.wordWrap ? (
+										<Disabled>
 											<EditorOptions.WrappingIndent />
-										) }
-									</Stack>
-								</PanelBody>
-								<PanelBody
-									className="chbe-admin-editor-config__panel"
-									title={ __( 'Minimap', 'custom-html-block-extension' ) }
-									initialOpen={ !! searchQuery }
-									scrollAfterOpen={ ! searchQuery }
-								>
-									<Stack direction="column" gap="lg">
-										<EditorOptions.MinimapEnabled />
-										{ ! editorOptions.minimap.enabled ? (
-											<Disabled>
-												<Stack direction="column" gap="lg">
-													<EditorOptions.MinimapSide />
-													<EditorOptions.MinimapMaxColumn />
-													<EditorOptions.MinimapScale />
-													<EditorOptions.MinimapShowSlider />
-													<EditorOptions.MinimapSize />
-													<EditorOptions.MinimapRenderCharacters />
-												</Stack>
-											</Disabled>
-										) : (
-											<>
+										</Disabled>
+									) : (
+										<EditorOptions.WrappingIndent />
+									) }
+								</SettingsPanel>
+								<SettingsPanel title={ __( 'Minimap', 'custom-html-block-extension' ) }>
+									<EditorOptions.MinimapEnabled />
+									{ ! editorOptions.minimap.enabled ? (
+										<Disabled>
+											<Stack direction="column" gap="lg">
 												<EditorOptions.MinimapSide />
 												<EditorOptions.MinimapMaxColumn />
 												<EditorOptions.MinimapScale />
 												<EditorOptions.MinimapShowSlider />
 												<EditorOptions.MinimapSize />
 												<EditorOptions.MinimapRenderCharacters />
-											</>
-										) }
-									</Stack>
-								</PanelBody>
-								<PanelBody
-									className="chbe-admin-editor-config__panel"
-									title={ __( 'Cursor', 'custom-html-block-extension' ) }
-									initialOpen={ !! searchQuery }
-									scrollAfterOpen={ ! searchQuery }
-								>
-									<Stack direction="column" gap="lg">
-										<EditorOptions.CursorStyle />
-										{ 'line' !== editorOptions.cursorStyle ? (
-											<Disabled>
-												<EditorOptions.CursorWidth />
-											</Disabled>
-										) : (
+											</Stack>
+										</Disabled>
+									) : (
+										<>
+											<EditorOptions.MinimapSide />
+											<EditorOptions.MinimapMaxColumn />
+											<EditorOptions.MinimapScale />
+											<EditorOptions.MinimapShowSlider />
+											<EditorOptions.MinimapSize />
+											<EditorOptions.MinimapRenderCharacters />
+										</>
+									) }
+								</SettingsPanel>
+								<SettingsPanel title={ __( 'Cursor', 'custom-html-block-extension' ) }>
+									<EditorOptions.CursorStyle />
+									{ 'line' !== editorOptions.cursorStyle ? (
+										<Disabled>
 											<EditorOptions.CursorWidth />
-										) }
-										<EditorOptions.CursorBlinking />
-										<EditorOptions.CursorSurroundingLines />
-										<EditorOptions.CursorSurroundingLinesStyle />
-										<EditorOptions.CursorSmoothCaretAnimation />
-									</Stack>
-								</PanelBody>
-								<PanelBody
-									className="chbe-admin-editor-config__panel"
-									title={ __( 'Code folding', 'custom-html-block-extension' ) }
-									initialOpen={ !! searchQuery }
-									scrollAfterOpen={ ! searchQuery }
-								>
-									<Stack direction="column" gap="lg">
-										<EditorOptions.Folding />
-										{ ! editorOptions.folding ? (
-											<Disabled>
-												<Stack direction="column" gap="lg">
-													<EditorOptions.ShowFoldingControls />
-													<EditorOptions.FoldingStrategy />
-													<EditorOptions.LineDecorationsWidth />
-													<EditorOptions.FoldingHighlight />
-													<EditorOptions.UnfoldOnClickAfterEndOfLine />
-												</Stack>
-											</Disabled>
-										) : (
-											<>
+										</Disabled>
+									) : (
+										<EditorOptions.CursorWidth />
+									) }
+									<EditorOptions.CursorBlinking />
+									<EditorOptions.CursorSurroundingLines />
+									<EditorOptions.CursorSurroundingLinesStyle />
+									<EditorOptions.CursorSmoothCaretAnimation />
+								</SettingsPanel>
+								<SettingsPanel title={ __( 'Code folding', 'custom-html-block-extension' ) }>
+									<EditorOptions.Folding />
+									{ ! editorOptions.folding ? (
+										<Disabled>
+											<Stack direction="column" gap="lg">
 												<EditorOptions.ShowFoldingControls />
 												<EditorOptions.FoldingStrategy />
 												<EditorOptions.LineDecorationsWidth />
 												<EditorOptions.FoldingHighlight />
 												<EditorOptions.UnfoldOnClickAfterEndOfLine />
-											</>
-										) }
-									</Stack>
-								</PanelBody>
-								<PanelBody
-									className="chbe-admin-editor-config__panel"
-									title={ __( 'Line number', 'custom-html-block-extension' ) }
-									initialOpen={ !! searchQuery }
-									scrollAfterOpen={ ! searchQuery }
-								>
-									<Stack direction="column" gap="lg">
-										<EditorOptions.LineNumbers />
-										{ 'off' === editorOptions.lineNumbers ? (
-											<Disabled>
-												<Stack direction="column" gap="lg">
-													<EditorOptions.LineNumbersMinChars />
-													<EditorOptions.SelectOnLineNumbers />
-													<EditorOptions.RenderFinalNewline />
-												</Stack>
-											</Disabled>
-										) : (
-											<>
+											</Stack>
+										</Disabled>
+									) : (
+										<>
+											<EditorOptions.ShowFoldingControls />
+											<EditorOptions.FoldingStrategy />
+											<EditorOptions.LineDecorationsWidth />
+											<EditorOptions.FoldingHighlight />
+											<EditorOptions.UnfoldOnClickAfterEndOfLine />
+										</>
+									) }
+								</SettingsPanel>
+								<SettingsPanel title={ __( 'Line number', 'custom-html-block-extension' ) }>
+									<EditorOptions.LineNumbers />
+									{ 'off' === editorOptions.lineNumbers ? (
+										<Disabled>
+											<Stack direction="column" gap="lg">
 												<EditorOptions.LineNumbersMinChars />
 												<EditorOptions.SelectOnLineNumbers />
 												<EditorOptions.RenderFinalNewline />
-											</>
-										) }
-									</Stack>
-								</PanelBody>
-								<PanelBody
-									className="chbe-admin-editor-config__panel"
-									title={ __( 'Suggest', 'custom-html-block-extension' ) }
-									initialOpen={ !! searchQuery }
-									scrollAfterOpen={ ! searchQuery }
-								>
-									<Stack direction="column" gap="lg">
-										<EditorOptions.QuickSuggestions />
-										{ ! editorOptions.quickSuggestions ? (
-											<Disabled>
-												<Stack direction="column" gap="lg">
-													<EditorOptions.AcceptSuggestionOnEnter />
-													<EditorOptions.QuickSuggestionsDelay />
-													<EditorOptions.SuggestFontSize />
-													<EditorOptions.SuggestLineHeight />
-													<EditorOptions.SuggestShowIcons />
-												</Stack>
-											</Disabled>
-										) : (
-											<>
+											</Stack>
+										</Disabled>
+									) : (
+										<>
+											<EditorOptions.LineNumbersMinChars />
+											<EditorOptions.SelectOnLineNumbers />
+											<EditorOptions.RenderFinalNewline />
+										</>
+									) }
+								</SettingsPanel>
+								<SettingsPanel title={ __( 'Suggest', 'custom-html-block-extension' ) }>
+									<EditorOptions.QuickSuggestions />
+									{ ! editorOptions.quickSuggestions ? (
+										<Disabled>
+											<Stack direction="column" gap="lg">
 												<EditorOptions.AcceptSuggestionOnEnter />
 												<EditorOptions.QuickSuggestionsDelay />
 												<EditorOptions.SuggestFontSize />
 												<EditorOptions.SuggestLineHeight />
 												<EditorOptions.SuggestShowIcons />
-											</>
-										) }
-									</Stack>
-								</PanelBody>
-								<PanelBody
-									className="chbe-admin-editor-config__panel"
-									title={ __( 'Auto completion', 'custom-html-block-extension' ) }
-									initialOpen={ !! searchQuery }
-									scrollAfterOpen={ ! searchQuery }
-								>
-									<Stack direction="column" gap="lg">
-										<EditorOptions.AutoIndent />
-										<EditorOptions.AutoClosingBrackets />
-										<EditorOptions.AutoClosingQuotes />
-										<EditorOptions.AutoSurround />
-										<EditorOptions.FormatOnPaste />
-									</Stack>
-								</PanelBody>
-								<PanelBody
-									className="chbe-admin-editor-config__panel"
-									title={ __( 'Mouse and scroll', 'custom-html-block-extension' ) }
-									initialOpen={ !! searchQuery }
-									scrollAfterOpen={ ! searchQuery }
-								>
-									<Stack direction="column" gap="lg">
-										<EditorOptions.MouseWheelScrollSensitivity />
-										<EditorOptions.FastScrollSensitivity />
-										<EditorOptions.Hover />
-										<EditorOptions.SmoothScrolling />
-										<EditorOptions.ScrollBeyondLastLine />
-										<EditorOptions.ScrollBeyondLastColumn />
-										<EditorOptions.MouseWheelZoom />
-										<EditorOptions.DragAndDrop />
-										<EditorOptions.HideCursorInOverviewRuler />
-										<EditorOptions.MultiCursorModifier />
-									</Stack>
-								</PanelBody>
-								<PanelBody
-									className="chbe-admin-editor-config__panel"
+											</Stack>
+										</Disabled>
+									) : (
+										<>
+											<EditorOptions.AcceptSuggestionOnEnter />
+											<EditorOptions.QuickSuggestionsDelay />
+											<EditorOptions.SuggestFontSize />
+											<EditorOptions.SuggestLineHeight />
+											<EditorOptions.SuggestShowIcons />
+										</>
+									) }
+								</SettingsPanel>
+								<SettingsPanel title={ __( 'Auto completion', 'custom-html-block-extension' ) }>
+									<EditorOptions.AutoIndent />
+									<EditorOptions.AutoClosingBrackets />
+									<EditorOptions.AutoClosingQuotes />
+									<EditorOptions.AutoSurround />
+									<EditorOptions.FormatOnPaste />
+								</SettingsPanel>
+								<SettingsPanel title={ __( 'Mouse and scroll', 'custom-html-block-extension' ) }>
+									<EditorOptions.MouseWheelScrollSensitivity />
+									<EditorOptions.FastScrollSensitivity />
+									<EditorOptions.Hover />
+									<EditorOptions.SmoothScrolling />
+									<EditorOptions.ScrollBeyondLastLine />
+									<EditorOptions.ScrollBeyondLastColumn />
+									<EditorOptions.MouseWheelZoom />
+									<EditorOptions.DragAndDrop />
+									<EditorOptions.HideCursorInOverviewRuler />
+									<EditorOptions.MultiCursorModifier />
+								</SettingsPanel>
+								<SettingsPanel
 									title={ __( 'Select, cut, copy, and paste', 'custom-html-block-extension' ) }
-									initialOpen={ !! searchQuery }
-									scrollAfterOpen={ ! searchQuery }
 								>
-									<Stack direction="column" gap="lg">
-										<EditorOptions.EmptySelectionClipboard />
-										<EditorOptions.RoundedSelection />
-										<EditorOptions.SelectionHighlight />
-										<EditorOptions.MultiCursorPaste />
-										<EditorOptions.StickyTabStops />
-										<EditorOptions.CopyWithSyntaxHighlighting />
-										<EditorOptions.ColumnSelection />
-									</Stack>
-								</PanelBody>
-								<PanelBody
-									className="chbe-admin-editor-config__panel"
+									<EditorOptions.EmptySelectionClipboard />
+									<EditorOptions.RoundedSelection />
+									<EditorOptions.SelectionHighlight />
+									<EditorOptions.MultiCursorPaste />
+									<EditorOptions.StickyTabStops />
+									<EditorOptions.CopyWithSyntaxHighlighting />
+									<EditorOptions.ColumnSelection />
+								</SettingsPanel>
+								<SettingsPanel
 									title={ __( 'Highlight and rendering', 'custom-html-block-extension' ) }
-									initialOpen={ !! searchQuery }
-									scrollAfterOpen={ ! searchQuery }
 								>
-									<Stack direction="column" gap="lg">
-										<EditorOptions.MatchBrackets />
-										<EditorOptions.OccurrencesHighlight />
-										<EditorOptions.RenderWhitespace />
-										<EditorOptions.RenderLineHighlight />
-										{ 'none' === editorOptions.renderLineHighlight ? (
-											<Disabled>
-												<EditorOptions.RenderLineHighlightOnlyWhenFocus />
-											</Disabled>
-										) : (
+									<EditorOptions.MatchBrackets />
+									<EditorOptions.OccurrencesHighlight />
+									<EditorOptions.RenderWhitespace />
+									<EditorOptions.RenderLineHighlight />
+									{ 'none' === editorOptions.renderLineHighlight ? (
+										<Disabled>
 											<EditorOptions.RenderLineHighlightOnlyWhenFocus />
-										) }
-										<EditorOptions.RenderIndentGuides />
-										{ ! editorOptions.renderIndentGuides ? (
-											<Disabled>
-												<EditorOptions.HighlightActiveIndentGuide />
-											</Disabled>
-										) : (
+										</Disabled>
+									) : (
+										<EditorOptions.RenderLineHighlightOnlyWhenFocus />
+									) }
+									<EditorOptions.RenderIndentGuides />
+									{ ! editorOptions.renderIndentGuides ? (
+										<Disabled>
 											<EditorOptions.HighlightActiveIndentGuide />
-										) }
-										<EditorOptions.RenderControlCharacters />
-										<EditorOptions.Rulers />
-									</Stack>
-								</PanelBody>
-								<PanelBody
-									className="chbe-admin-editor-config__panel"
-									title={ __( 'Find', 'custom-html-block-extension' ) }
-									initialOpen={ !! searchQuery }
-									scrollAfterOpen={ ! searchQuery }
-								>
-									<Stack direction="column" gap="lg">
-										<EditorOptions.FindAddExtraSpaceOnTop />
-										<EditorOptions.FindSeedSearchStringFromSelection />
-										<EditorOptions.FindLoop />
-									</Stack>
-								</PanelBody>
-								<PanelBody
-									className="chbe-admin-editor-config__panel"
-									title={ __( 'Scrollbar', 'custom-html-block-extension' ) }
-									initialOpen={ !! searchQuery }
-									scrollAfterOpen={ ! searchQuery }
-								>
-									<Stack direction="column" gap="lg">
-										<EditorOptions.ScrollbarUseShadows />
-										<EditorOptions.OverviewRulerBorder />
-										<EditorOptions.ScrollbarAlwaysConsumeMouseWheel />
-										<EditorOptions.ScrollbarScrollByPage />
-										<EditorOptions.ScrollbarHorizontal />
-										{ 'hidden' === editorOptions.scrollbar.horizontal ? (
-											<Disabled>
-												<Stack direction="column" gap="lg">
-													<EditorOptions.ScrollbarHorizontalHasArrows />
-													<EditorOptions.ScrollbarHorizontalScrollbarSize />
-												</Stack>
-											</Disabled>
-										) : (
-											<>
+										</Disabled>
+									) : (
+										<EditorOptions.HighlightActiveIndentGuide />
+									) }
+									<EditorOptions.RenderControlCharacters />
+									<EditorOptions.Rulers />
+								</SettingsPanel>
+								<SettingsPanel title={ __( 'Find', 'custom-html-block-extension' ) }>
+									<EditorOptions.FindAddExtraSpaceOnTop />
+									<EditorOptions.FindSeedSearchStringFromSelection />
+									<EditorOptions.FindLoop />
+								</SettingsPanel>
+								<SettingsPanel title={ __( 'Scrollbar', 'custom-html-block-extension' ) }>
+									<EditorOptions.ScrollbarUseShadows />
+									<EditorOptions.OverviewRulerBorder />
+									<EditorOptions.ScrollbarAlwaysConsumeMouseWheel />
+									<EditorOptions.ScrollbarScrollByPage />
+									<EditorOptions.ScrollbarHorizontal />
+									{ 'hidden' === editorOptions.scrollbar.horizontal ? (
+										<Disabled>
+											<Stack direction="column" gap="lg">
 												<EditorOptions.ScrollbarHorizontalHasArrows />
 												<EditorOptions.ScrollbarHorizontalScrollbarSize />
-											</>
-										) }
-										<EditorOptions.ScrollbarVertical />
-										{ 'hidden' === editorOptions.scrollbar.vertical ? (
-											<Disabled>
-												<Stack direction="column" gap="lg">
-													<EditorOptions.ScrollbarVerticalHasArrows />
-													<EditorOptions.ScrollbarVerticalScrollbarSize />
-												</Stack>
-											</Disabled>
-										) : (
-											<>
+											</Stack>
+										</Disabled>
+									) : (
+										<>
+											<EditorOptions.ScrollbarHorizontalHasArrows />
+											<EditorOptions.ScrollbarHorizontalScrollbarSize />
+										</>
+									) }
+									<EditorOptions.ScrollbarVertical />
+									{ 'hidden' === editorOptions.scrollbar.vertical ? (
+										<Disabled>
+											<Stack direction="column" gap="lg">
 												<EditorOptions.ScrollbarVerticalHasArrows />
 												<EditorOptions.ScrollbarVerticalScrollbarSize />
-											</>
-										) }
-										{ ( ! editorOptions.scrollbar.horizontalHasArrows &&
-											! editorOptions.scrollbar.verticalHasArrows ) ||
-										( 'hidden' === editorOptions.scrollbar.horizontal &&
-											'hidden' === editorOptions.scrollbar.vertical ) ? (
-											<Disabled>
-												<EditorOptions.ScrollbarArrowSize />
-											</Disabled>
-										) : (
+											</Stack>
+										</Disabled>
+									) : (
+										<>
+											<EditorOptions.ScrollbarVerticalHasArrows />
+											<EditorOptions.ScrollbarVerticalScrollbarSize />
+										</>
+									) }
+									{ ( ! editorOptions.scrollbar.horizontalHasArrows &&
+										! editorOptions.scrollbar.verticalHasArrows ) ||
+									( 'hidden' === editorOptions.scrollbar.horizontal &&
+										'hidden' === editorOptions.scrollbar.vertical ) ? (
+										<Disabled>
 											<EditorOptions.ScrollbarArrowSize />
-										) }
-									</Stack>
-								</PanelBody>
-								<PanelBody
-									className="chbe-admin-editor-config__panel"
-									title={ __( 'Other', 'custom-html-block-extension' ) }
-									initialOpen={ !! searchQuery }
-									scrollAfterOpen={ ! searchQuery }
-								>
-									<Stack direction="column" gap="lg">
-										<EditorOptions.UseTabStops />
-										<EditorOptions.CommentsInsertSpace />
-										<EditorOptions.Links />
-									</Stack>
-								</PanelBody>
+										</Disabled>
+									) : (
+										<EditorOptions.ScrollbarArrowSize />
+									) }
+								</SettingsPanel>
+								<SettingsPanel title={ __( 'Other', 'custom-html-block-extension' ) }>
+									<EditorOptions.UseTabStops />
+									<EditorOptions.CommentsInsertSpace />
+									<EditorOptions.Links />
+								</SettingsPanel>
 							</>
 						) }
 					</EditorConfigContext.Provider>

--- a/src/admin/options/components/permission-editor/index.tsx
+++ b/src/admin/options/components/permission-editor/index.tsx
@@ -3,8 +3,8 @@
  */
 import { __ } from '@wordpress/i18n';
 import { useContext } from '@wordpress/element';
-import { PanelBody, ToggleControl } from '@wordpress/components';
-import { Stack } from '@wordpress/ui';
+import { ToggleControl } from '@wordpress/components';
+import { Card, CollapsibleCard, Stack } from '@wordpress/ui';
 
 /**
  * Internal dependencies
@@ -36,26 +36,31 @@ export default function PermissionEditor() {
 	};
 
 	return (
-		<PanelBody
-			title={ __( 'Editors allowed to use this extension', 'custom-html-block-extension' ) }
-		>
-			<Stack direction="column" gap="lg">
-				<ToggleControl
-					label={ __( 'Block editor', 'custom-html-block-extension' ) }
-					checked={ options.permissionBlockEditor }
-					onChange={ onBlockEditorChange }
-				/>
-				<ToggleControl
-					label={ __( 'Classic editor', 'custom-html-block-extension' ) }
-					checked={ options.permissionClassicEditor }
-					onChange={ onClassicEditorChange }
-				/>
-				<ToggleControl
-					label={ __( 'Theme and Plugin editor', 'custom-html-block-extension' ) }
-					checked={ options.permissionThemePluginEditor }
-					onChange={ onThemePluginEditorChange }
-				/>
-			</Stack>
-		</PanelBody>
+		<CollapsibleCard.Root defaultOpen>
+			<CollapsibleCard.Header render={ <h2 /> }>
+				<Card.Title>
+					{ __( 'Editors allowed to use this extension', 'custom-html-block-extension' ) }
+				</Card.Title>
+			</CollapsibleCard.Header>
+			<CollapsibleCard.Content>
+				<Stack direction="column" gap="lg">
+					<ToggleControl
+						label={ __( 'Block editor', 'custom-html-block-extension' ) }
+						checked={ options.permissionBlockEditor }
+						onChange={ onBlockEditorChange }
+					/>
+					<ToggleControl
+						label={ __( 'Classic editor', 'custom-html-block-extension' ) }
+						checked={ options.permissionClassicEditor }
+						onChange={ onClassicEditorChange }
+					/>
+					<ToggleControl
+						label={ __( 'Theme and Plugin editor', 'custom-html-block-extension' ) }
+						checked={ options.permissionThemePluginEditor }
+						onChange={ onThemePluginEditorChange }
+					/>
+				</Stack>
+			</CollapsibleCard.Content>
+		</CollapsibleCard.Root>
 	);
 }

--- a/src/admin/options/components/permission-user-role/index.tsx
+++ b/src/admin/options/components/permission-user-role/index.tsx
@@ -3,8 +3,8 @@
  */
 import { __ } from '@wordpress/i18n';
 import { useContext } from '@wordpress/element';
-import { PanelBody, ToggleControl } from '@wordpress/components';
-import { Stack } from '@wordpress/ui';
+import { ToggleControl } from '@wordpress/components';
+import { Card, CollapsibleCard, Stack } from '@wordpress/ui';
 
 /**
  * Internal dependencies
@@ -30,19 +30,24 @@ export default function PermissionUserRole() {
 	};
 
 	return (
-		<PanelBody
-			title={ __( 'User roles allowed to use this extension', 'custom-html-block-extension' ) }
-		>
-			<Stack direction="column" gap="lg">
-				{ userRoles.map( ( role, index ) => (
-					<ToggleControl
-						key={ index }
-						label={ role.label }
-						checked={ options.permissionRoles.includes( role.value ) }
-						onChange={ () => onChange( role.value ) }
-					/>
-				) ) }
-			</Stack>
-		</PanelBody>
+		<CollapsibleCard.Root defaultOpen>
+			<CollapsibleCard.Header render={ <h2 /> }>
+				<Card.Title>
+					{ __( 'User roles allowed to use this extension', 'custom-html-block-extension' ) }
+				</Card.Title>
+			</CollapsibleCard.Header>
+			<CollapsibleCard.Content>
+				<Stack direction="column" gap="lg">
+					{ userRoles.map( ( role, index ) => (
+						<ToggleControl
+							key={ index }
+							label={ role.label }
+							checked={ options.permissionRoles.includes( role.value ) }
+							onChange={ () => onChange( role.value ) }
+						/>
+					) ) }
+				</Stack>
+			</CollapsibleCard.Content>
+		</CollapsibleCard.Root>
 	);
 }

--- a/src/admin/style.scss
+++ b/src/admin/style.scss
@@ -35,10 +35,6 @@
 	.components-disabled {
 		opacity: 0.3;
 	}
-
-	.components-panel__body {
-		background: colors.$white;
-	}
 }
 
 .chbe-admin {

--- a/src/admin/tools/components/export-tool/index.tsx
+++ b/src/admin/tools/components/export-tool/index.tsx
@@ -4,8 +4,8 @@
 import { __ } from '@wordpress/i18n';
 import apiFetch from '@wordpress/api-fetch';
 import { useContext } from '@wordpress/element';
-import { Button, PanelBody } from '@wordpress/components';
-import { Stack, Text } from '@wordpress/ui';
+import { Button } from '@wordpress/components';
+import { Card, CollapsibleCard, Stack, Text } from '@wordpress/ui';
 import { useDispatch } from '@wordpress/data';
 import { store as noticesStore } from '@wordpress/notices';
 
@@ -52,18 +52,23 @@ export default function ExportTool() {
 	};
 
 	return (
-		<PanelBody title={ __( 'Export Editor Config', 'custom-html-block-extension' ) }>
-			<Stack direction="column" align="start" gap="sm">
-				<Text render={ <p /> }>
-					{ __(
-						'Use the download button to export the editor settings. You can restore the editor config by importing the exported file on another WordPress site.',
-						'custom-html-block-extension'
-					) }
-				</Text>
-				<Button variant="primary" onClick={ onExportOptions } __next40pxDefaultSize>
-					{ __( 'Export', 'custom-html-block-extension' ) }
-				</Button>
-			</Stack>
-		</PanelBody>
+		<CollapsibleCard.Root defaultOpen>
+			<CollapsibleCard.Header render={ <h2 /> }>
+				<Card.Title>{ __( 'Export Editor Config', 'custom-html-block-extension' ) }</Card.Title>
+			</CollapsibleCard.Header>
+			<CollapsibleCard.Content>
+				<Stack direction="column" align="start" gap="sm">
+					<Text render={ <p /> }>
+						{ __(
+							'Use the download button to export the editor settings. You can restore the editor config by importing the exported file on another WordPress site.',
+							'custom-html-block-extension'
+						) }
+					</Text>
+					<Button variant="primary" onClick={ onExportOptions } __next40pxDefaultSize>
+						{ __( 'Export', 'custom-html-block-extension' ) }
+					</Button>
+				</Stack>
+			</CollapsibleCard.Content>
+		</CollapsibleCard.Root>
 	);
 }

--- a/src/admin/tools/components/import-tool/index.tsx
+++ b/src/admin/tools/components/import-tool/index.tsx
@@ -9,8 +9,8 @@ import type { ChangeEvent } from 'react';
 import { __ } from '@wordpress/i18n';
 import apiFetch from '@wordpress/api-fetch';
 import { useContext, useState } from '@wordpress/element';
-import { Button, FormFileUpload, PanelBody } from '@wordpress/components';
-import { Stack, Text } from '@wordpress/ui';
+import { Button, FormFileUpload } from '@wordpress/components';
+import { Card, CollapsibleCard, Stack, Text } from '@wordpress/ui';
 import { useDispatch } from '@wordpress/data';
 import { store as noticesStore } from '@wordpress/notices';
 
@@ -92,36 +92,41 @@ export default function ImportTool() {
 	};
 
 	return (
-		<PanelBody title={ __( 'Import editor config', 'custom-html-block-extension' ) }>
-			<Stack direction="column" align="start" gap="lg">
-				<Text render={ <p /> }>
-					{ __(
-						'Select the Custom HTML Block Extension JSON file you would like to import and click the import button below.',
-						'custom-html-block-extension'
-					) }
-				</Text>
-				<Stack justify="start" wrap="wrap" gap="lg">
-					<FormFileUpload
-						accept="application/json"
-						onChange={ onUploadFile }
-						render={ ( { openFileDialog } ) => (
-							<Button variant="secondary" onClick={ openFileDialog } __next40pxDefaultSize>
-								{ __( 'Upload file', 'custom-html-block-extension' ) }
-							</Button>
+		<CollapsibleCard.Root defaultOpen>
+			<CollapsibleCard.Header render={ <h2 /> }>
+				<Card.Title>{ __( 'Import editor config', 'custom-html-block-extension' ) }</Card.Title>
+			</CollapsibleCard.Header>
+			<CollapsibleCard.Content>
+				<Stack direction="column" align="start" gap="lg">
+					<Text render={ <p /> }>
+						{ __(
+							'Select the Custom HTML Block Extension JSON file you would like to import and click the import button below.',
+							'custom-html-block-extension'
 						) }
-					/>
-					{ importFile && <span>{ importFile.name }</span> }
+					</Text>
+					<Stack justify="start" wrap="wrap" gap="lg">
+						<FormFileUpload
+							accept="application/json"
+							onChange={ onUploadFile }
+							render={ ( { openFileDialog } ) => (
+								<Button variant="secondary" onClick={ openFileDialog } __next40pxDefaultSize>
+									{ __( 'Upload file', 'custom-html-block-extension' ) }
+								</Button>
+							) }
+						/>
+						{ importFile && <span>{ importFile.name }</span> }
+					</Stack>
+					<Button
+						variant="primary"
+						disabled={ ! importFile }
+						onClick={ onImportOptions }
+						__next40pxDefaultSize
+						__experimentalIsFocusable
+					>
+						{ __( 'Import', 'custom-html-block-extension' ) }
+					</Button>
 				</Stack>
-				<Button
-					variant="primary"
-					disabled={ ! importFile }
-					onClick={ onImportOptions }
-					__next40pxDefaultSize
-					__experimentalIsFocusable
-				>
-					{ __( 'Import', 'custom-html-block-extension' ) }
-				</Button>
-			</Stack>
-		</PanelBody>
+			</CollapsibleCard.Content>
+		</CollapsibleCard.Root>
 	);
 }


### PR DESCRIPTION
Continues the migration off unstable `@wordpress/components` primitives (#204) by replacing every `PanelBody` with the stable `@wordpress/ui` `CollapsibleCard` compound component. Panel titles now render as `Card.Title` inside a heading-semantic `Header`.

In the editor config, a shared `SettingsPanel` manages the open state in a controlled way: while a search query is active, matching panels are forced open (preserving the previous `initialOpen`-on-search behavior), otherwise the state is left to the user.
