### PR TITLE
Replace Disabled component with the inert attribute

### DIFF
--- a/src/admin/editor-config/index.tsx
+++ b/src/admin/editor-config/index.tsx
@@ -38,6 +38,18 @@ export const EditorConfigContext = createContext< EditorConfigContextType >(
 );
 
 /**
+ * Returns the value for the `inert` attribute, making a subtree
+ * non-interactive when `condition` is true. Uses the empty-string form
+ * required by React 18 (see the `inert` type augmentation in global.d.ts).
+ *
+ * @param {boolean} condition Whether the subtree should be inert.
+ * @return {''|undefined} The `inert` attribute value.
+ */
+function inertValue( condition: boolean ): '' | undefined {
+	return condition ? '' : undefined;
+}
+
+/**
  * Whether a setting with the given title should render under the current
  * search query. Settings whose title doesn't match the query are hidden.
  *
@@ -223,21 +235,19 @@ export default function EditorConfig() {
 								<SettingsPanel title={ __( 'Word wrap', 'custom-html-block-extension' ) }>
 									<EditorOptions.WordWrap />
 									<div
-										inert={
+										inert={ inertValue(
 											'on' === editorOptions.wordWrap || 'off' === editorOptions.wordWrap
-												? ''
-												: undefined
-										}
+										) }
 									>
 										<EditorOptions.WordWrapColumn />
 									</div>
-									<div inert={ 'off' === editorOptions.wordWrap ? '' : undefined }>
+									<div inert={ inertValue( 'off' === editorOptions.wordWrap ) }>
 										<EditorOptions.WrappingIndent />
 									</div>
 								</SettingsPanel>
 								<SettingsPanel title={ __( 'Minimap', 'custom-html-block-extension' ) }>
 									<EditorOptions.MinimapEnabled />
-									<div inert={ ! editorOptions.minimap.enabled ? '' : undefined }>
+									<div inert={ inertValue( ! editorOptions.minimap.enabled ) }>
 										<Stack direction="column" gap="lg">
 											<EditorOptions.MinimapSide />
 											<EditorOptions.MinimapMaxColumn />
@@ -250,7 +260,7 @@ export default function EditorConfig() {
 								</SettingsPanel>
 								<SettingsPanel title={ __( 'Cursor', 'custom-html-block-extension' ) }>
 									<EditorOptions.CursorStyle />
-									<div inert={ 'line' !== editorOptions.cursorStyle ? '' : undefined }>
+									<div inert={ inertValue( 'line' !== editorOptions.cursorStyle ) }>
 										<EditorOptions.CursorWidth />
 									</div>
 									<EditorOptions.CursorBlinking />
@@ -260,7 +270,7 @@ export default function EditorConfig() {
 								</SettingsPanel>
 								<SettingsPanel title={ __( 'Code folding', 'custom-html-block-extension' ) }>
 									<EditorOptions.Folding />
-									<div inert={ ! editorOptions.folding ? '' : undefined }>
+									<div inert={ inertValue( ! editorOptions.folding ) }>
 										<Stack direction="column" gap="lg">
 											<EditorOptions.ShowFoldingControls />
 											<EditorOptions.FoldingStrategy />
@@ -272,7 +282,7 @@ export default function EditorConfig() {
 								</SettingsPanel>
 								<SettingsPanel title={ __( 'Line number', 'custom-html-block-extension' ) }>
 									<EditorOptions.LineNumbers />
-									<div inert={ 'off' === editorOptions.lineNumbers ? '' : undefined }>
+									<div inert={ inertValue( 'off' === editorOptions.lineNumbers ) }>
 										<Stack direction="column" gap="lg">
 											<EditorOptions.LineNumbersMinChars />
 											<EditorOptions.SelectOnLineNumbers />
@@ -282,7 +292,7 @@ export default function EditorConfig() {
 								</SettingsPanel>
 								<SettingsPanel title={ __( 'Suggest', 'custom-html-block-extension' ) }>
 									<EditorOptions.QuickSuggestions />
-									<div inert={ ! editorOptions.quickSuggestions ? '' : undefined }>
+									<div inert={ inertValue( ! editorOptions.quickSuggestions ) }>
 										<Stack direction="column" gap="lg">
 											<EditorOptions.AcceptSuggestionOnEnter />
 											<EditorOptions.QuickSuggestionsDelay />
@@ -329,11 +339,11 @@ export default function EditorConfig() {
 									<EditorOptions.OccurrencesHighlight />
 									<EditorOptions.RenderWhitespace />
 									<EditorOptions.RenderLineHighlight />
-									<div inert={ 'none' === editorOptions.renderLineHighlight ? '' : undefined }>
+									<div inert={ inertValue( 'none' === editorOptions.renderLineHighlight ) }>
 										<EditorOptions.RenderLineHighlightOnlyWhenFocus />
 									</div>
 									<EditorOptions.RenderIndentGuides />
-									<div inert={ ! editorOptions.renderIndentGuides ? '' : undefined }>
+									<div inert={ inertValue( ! editorOptions.renderIndentGuides ) }>
 										<EditorOptions.HighlightActiveIndentGuide />
 									</div>
 									<EditorOptions.RenderControlCharacters />
@@ -350,28 +360,26 @@ export default function EditorConfig() {
 									<EditorOptions.ScrollbarAlwaysConsumeMouseWheel />
 									<EditorOptions.ScrollbarScrollByPage />
 									<EditorOptions.ScrollbarHorizontal />
-									<div inert={ 'hidden' === editorOptions.scrollbar.horizontal ? '' : undefined }>
+									<div inert={ inertValue( 'hidden' === editorOptions.scrollbar.horizontal ) }>
 										<Stack direction="column" gap="lg">
 											<EditorOptions.ScrollbarHorizontalHasArrows />
 											<EditorOptions.ScrollbarHorizontalScrollbarSize />
 										</Stack>
 									</div>
 									<EditorOptions.ScrollbarVertical />
-									<div inert={ 'hidden' === editorOptions.scrollbar.vertical ? '' : undefined }>
+									<div inert={ inertValue( 'hidden' === editorOptions.scrollbar.vertical ) }>
 										<Stack direction="column" gap="lg">
 											<EditorOptions.ScrollbarVerticalHasArrows />
 											<EditorOptions.ScrollbarVerticalScrollbarSize />
 										</Stack>
 									</div>
 									<div
-										inert={
+										inert={ inertValue(
 											( ! editorOptions.scrollbar.horizontalHasArrows &&
 												! editorOptions.scrollbar.verticalHasArrows ) ||
-											( 'hidden' === editorOptions.scrollbar.horizontal &&
-												'hidden' === editorOptions.scrollbar.vertical )
-												? ''
-												: undefined
-										}
+												( 'hidden' === editorOptions.scrollbar.horizontal &&
+													'hidden' === editorOptions.scrollbar.vertical )
+										) }
 									>
 										<EditorOptions.ScrollbarArrowSize />
 									</div>

--- a/src/admin/editor-config/index.tsx
+++ b/src/admin/editor-config/index.tsx
@@ -10,7 +10,7 @@ import clsx from 'clsx';
 import { __ } from '@wordpress/i18n';
 import apiFetch from '@wordpress/api-fetch';
 import { createContext, useCallback, useContext, useState } from '@wordpress/element';
-import { Disabled, __experimentalHeading as Heading } from '@wordpress/components';
+import { __experimentalHeading as Heading } from '@wordpress/components';
 import { Card, CollapsibleCard, Stack } from '@wordpress/ui';
 import { useDispatch } from '@wordpress/data';
 import { store as noticesStore } from '@wordpress/notices';
@@ -222,54 +222,37 @@ export default function EditorConfig() {
 								</SettingsPanel>
 								<SettingsPanel title={ __( 'Word wrap', 'custom-html-block-extension' ) }>
 									<EditorOptions.WordWrap />
-									{ 'on' === editorOptions.wordWrap || 'off' === editorOptions.wordWrap ? (
-										<Disabled>
-											<EditorOptions.WordWrapColumn />
-										</Disabled>
-									) : (
+									<div
+										inert={
+											'on' === editorOptions.wordWrap || 'off' === editorOptions.wordWrap
+												? ''
+												: undefined
+										}
+									>
 										<EditorOptions.WordWrapColumn />
-									) }
-									{ 'off' === editorOptions.wordWrap ? (
-										<Disabled>
-											<EditorOptions.WrappingIndent />
-										</Disabled>
-									) : (
+									</div>
+									<div inert={ 'off' === editorOptions.wordWrap ? '' : undefined }>
 										<EditorOptions.WrappingIndent />
-									) }
+									</div>
 								</SettingsPanel>
 								<SettingsPanel title={ __( 'Minimap', 'custom-html-block-extension' ) }>
 									<EditorOptions.MinimapEnabled />
-									{ ! editorOptions.minimap.enabled ? (
-										<Disabled>
-											<Stack direction="column" gap="lg">
-												<EditorOptions.MinimapSide />
-												<EditorOptions.MinimapMaxColumn />
-												<EditorOptions.MinimapScale />
-												<EditorOptions.MinimapShowSlider />
-												<EditorOptions.MinimapSize />
-												<EditorOptions.MinimapRenderCharacters />
-											</Stack>
-										</Disabled>
-									) : (
-										<>
+									<div inert={ ! editorOptions.minimap.enabled ? '' : undefined }>
+										<Stack direction="column" gap="lg">
 											<EditorOptions.MinimapSide />
 											<EditorOptions.MinimapMaxColumn />
 											<EditorOptions.MinimapScale />
 											<EditorOptions.MinimapShowSlider />
 											<EditorOptions.MinimapSize />
 											<EditorOptions.MinimapRenderCharacters />
-										</>
-									) }
+										</Stack>
+									</div>
 								</SettingsPanel>
 								<SettingsPanel title={ __( 'Cursor', 'custom-html-block-extension' ) }>
 									<EditorOptions.CursorStyle />
-									{ 'line' !== editorOptions.cursorStyle ? (
-										<Disabled>
-											<EditorOptions.CursorWidth />
-										</Disabled>
-									) : (
+									<div inert={ 'line' !== editorOptions.cursorStyle ? '' : undefined }>
 										<EditorOptions.CursorWidth />
-									) }
+									</div>
 									<EditorOptions.CursorBlinking />
 									<EditorOptions.CursorSurroundingLines />
 									<EditorOptions.CursorSurroundingLinesStyle />
@@ -277,65 +260,37 @@ export default function EditorConfig() {
 								</SettingsPanel>
 								<SettingsPanel title={ __( 'Code folding', 'custom-html-block-extension' ) }>
 									<EditorOptions.Folding />
-									{ ! editorOptions.folding ? (
-										<Disabled>
-											<Stack direction="column" gap="lg">
-												<EditorOptions.ShowFoldingControls />
-												<EditorOptions.FoldingStrategy />
-												<EditorOptions.LineDecorationsWidth />
-												<EditorOptions.FoldingHighlight />
-												<EditorOptions.UnfoldOnClickAfterEndOfLine />
-											</Stack>
-										</Disabled>
-									) : (
-										<>
+									<div inert={ ! editorOptions.folding ? '' : undefined }>
+										<Stack direction="column" gap="lg">
 											<EditorOptions.ShowFoldingControls />
 											<EditorOptions.FoldingStrategy />
 											<EditorOptions.LineDecorationsWidth />
 											<EditorOptions.FoldingHighlight />
 											<EditorOptions.UnfoldOnClickAfterEndOfLine />
-										</>
-									) }
+										</Stack>
+									</div>
 								</SettingsPanel>
 								<SettingsPanel title={ __( 'Line number', 'custom-html-block-extension' ) }>
 									<EditorOptions.LineNumbers />
-									{ 'off' === editorOptions.lineNumbers ? (
-										<Disabled>
-											<Stack direction="column" gap="lg">
-												<EditorOptions.LineNumbersMinChars />
-												<EditorOptions.SelectOnLineNumbers />
-												<EditorOptions.RenderFinalNewline />
-											</Stack>
-										</Disabled>
-									) : (
-										<>
+									<div inert={ 'off' === editorOptions.lineNumbers ? '' : undefined }>
+										<Stack direction="column" gap="lg">
 											<EditorOptions.LineNumbersMinChars />
 											<EditorOptions.SelectOnLineNumbers />
 											<EditorOptions.RenderFinalNewline />
-										</>
-									) }
+										</Stack>
+									</div>
 								</SettingsPanel>
 								<SettingsPanel title={ __( 'Suggest', 'custom-html-block-extension' ) }>
 									<EditorOptions.QuickSuggestions />
-									{ ! editorOptions.quickSuggestions ? (
-										<Disabled>
-											<Stack direction="column" gap="lg">
-												<EditorOptions.AcceptSuggestionOnEnter />
-												<EditorOptions.QuickSuggestionsDelay />
-												<EditorOptions.SuggestFontSize />
-												<EditorOptions.SuggestLineHeight />
-												<EditorOptions.SuggestShowIcons />
-											</Stack>
-										</Disabled>
-									) : (
-										<>
+									<div inert={ ! editorOptions.quickSuggestions ? '' : undefined }>
+										<Stack direction="column" gap="lg">
 											<EditorOptions.AcceptSuggestionOnEnter />
 											<EditorOptions.QuickSuggestionsDelay />
 											<EditorOptions.SuggestFontSize />
 											<EditorOptions.SuggestLineHeight />
 											<EditorOptions.SuggestShowIcons />
-										</>
-									) }
+										</Stack>
+									</div>
 								</SettingsPanel>
 								<SettingsPanel title={ __( 'Auto completion', 'custom-html-block-extension' ) }>
 									<EditorOptions.AutoIndent />
@@ -374,21 +329,13 @@ export default function EditorConfig() {
 									<EditorOptions.OccurrencesHighlight />
 									<EditorOptions.RenderWhitespace />
 									<EditorOptions.RenderLineHighlight />
-									{ 'none' === editorOptions.renderLineHighlight ? (
-										<Disabled>
-											<EditorOptions.RenderLineHighlightOnlyWhenFocus />
-										</Disabled>
-									) : (
+									<div inert={ 'none' === editorOptions.renderLineHighlight ? '' : undefined }>
 										<EditorOptions.RenderLineHighlightOnlyWhenFocus />
-									) }
+									</div>
 									<EditorOptions.RenderIndentGuides />
-									{ ! editorOptions.renderIndentGuides ? (
-										<Disabled>
-											<EditorOptions.HighlightActiveIndentGuide />
-										</Disabled>
-									) : (
+									<div inert={ ! editorOptions.renderIndentGuides ? '' : undefined }>
 										<EditorOptions.HighlightActiveIndentGuide />
-									) }
+									</div>
 									<EditorOptions.RenderControlCharacters />
 									<EditorOptions.Rulers />
 								</SettingsPanel>
@@ -403,43 +350,31 @@ export default function EditorConfig() {
 									<EditorOptions.ScrollbarAlwaysConsumeMouseWheel />
 									<EditorOptions.ScrollbarScrollByPage />
 									<EditorOptions.ScrollbarHorizontal />
-									{ 'hidden' === editorOptions.scrollbar.horizontal ? (
-										<Disabled>
-											<Stack direction="column" gap="lg">
-												<EditorOptions.ScrollbarHorizontalHasArrows />
-												<EditorOptions.ScrollbarHorizontalScrollbarSize />
-											</Stack>
-										</Disabled>
-									) : (
-										<>
+									<div inert={ 'hidden' === editorOptions.scrollbar.horizontal ? '' : undefined }>
+										<Stack direction="column" gap="lg">
 											<EditorOptions.ScrollbarHorizontalHasArrows />
 											<EditorOptions.ScrollbarHorizontalScrollbarSize />
-										</>
-									) }
+										</Stack>
+									</div>
 									<EditorOptions.ScrollbarVertical />
-									{ 'hidden' === editorOptions.scrollbar.vertical ? (
-										<Disabled>
-											<Stack direction="column" gap="lg">
-												<EditorOptions.ScrollbarVerticalHasArrows />
-												<EditorOptions.ScrollbarVerticalScrollbarSize />
-											</Stack>
-										</Disabled>
-									) : (
-										<>
+									<div inert={ 'hidden' === editorOptions.scrollbar.vertical ? '' : undefined }>
+										<Stack direction="column" gap="lg">
 											<EditorOptions.ScrollbarVerticalHasArrows />
 											<EditorOptions.ScrollbarVerticalScrollbarSize />
-										</>
-									) }
-									{ ( ! editorOptions.scrollbar.horizontalHasArrows &&
-										! editorOptions.scrollbar.verticalHasArrows ) ||
-									( 'hidden' === editorOptions.scrollbar.horizontal &&
-										'hidden' === editorOptions.scrollbar.vertical ) ? (
-										<Disabled>
-											<EditorOptions.ScrollbarArrowSize />
-										</Disabled>
-									) : (
+										</Stack>
+									</div>
+									<div
+										inert={
+											( ! editorOptions.scrollbar.horizontalHasArrows &&
+												! editorOptions.scrollbar.verticalHasArrows ) ||
+											( 'hidden' === editorOptions.scrollbar.horizontal &&
+												'hidden' === editorOptions.scrollbar.vertical )
+												? ''
+												: undefined
+										}
+									>
 										<EditorOptions.ScrollbarArrowSize />
-									) }
+									</div>
 								</SettingsPanel>
 								<SettingsPanel title={ __( 'Other', 'custom-html-block-extension' ) }>
 									<EditorOptions.UseTabStops />

--- a/src/admin/editor-config/index.tsx
+++ b/src/admin/editor-config/index.tsx
@@ -37,25 +37,12 @@ export const EditorConfigContext = createContext< EditorConfigContextType >(
 	{} as EditorConfigContextType
 );
 
-/**
- * Returns the value for the `inert` attribute, making a subtree
- * non-interactive when `condition` is true. Uses the empty-string form
- * required by React 18 (see the `inert` type augmentation in global.d.ts).
- *
- * @param {boolean} condition Whether the subtree should be inert.
- * @return {''|undefined} The `inert` attribute value.
- */
+// Value for the `inert` attribute; the empty string enables it (React 18 form).
 function inertValue( condition: boolean ): '' | undefined {
 	return condition ? '' : undefined;
 }
 
-/**
- * Whether a setting with the given title should render under the current
- * search query. Settings whose title doesn't match the query are hidden.
- *
- * @param {string} title The setting's display title.
- * @return {boolean} True when the setting should render.
- */
+// Whether a setting with the given title matches the current search query.
 export function useSearchVisibility( title: string ): boolean {
 	const { searchQuery } = useContext( EditorConfigContext );
 	if ( ! searchQuery ) {
@@ -64,15 +51,8 @@ export function useSearchVisibility( title: string ): boolean {
 	return title.toLowerCase().includes( searchQuery.toLowerCase() );
 }
 
-/**
- * A collapsible settings panel. While a search query is active, every panel is
- * forced open so the matching settings inside it are revealed; otherwise the
- * open state is left to the user (uncontrolled-like behavior via local state).
- *
- * @param {Object}    props          Component props.
- * @param {string}    props.title    The panel's display title.
- * @param {ReactNode} props.children The settings rendered inside the panel.
- */
+// Collapsible panel, forced open while a search query is active and otherwise
+// toggled by the user.
 function SettingsPanel( { title, children }: { title: string; children: ReactNode } ) {
 	const { searchQuery } = useContext( EditorConfigContext );
 	const [ isOpen, setIsOpen ] = useState( false );

--- a/src/admin/style.scss
+++ b/src/admin/style.scss
@@ -31,8 +31,7 @@
 		margin: 0 auto;
 	}
 
-	// Dim non-interactive (inert) settings, mirroring the previous
-	// `Disabled` component styling.
+	// Non-interactive (inert) settings
 	[inert] {
 		opacity: 0.3;
 	}

--- a/src/admin/style.scss
+++ b/src/admin/style.scss
@@ -31,8 +31,9 @@
 		margin: 0 auto;
 	}
 
-	// Gutenberg component styles
-	.components-disabled {
+	// Dim non-interactive (inert) settings, mirroring the previous
+	// `Disabled` component styling.
+	[inert] {
 		opacity: 0.3;
 	}
 }

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -45,4 +45,18 @@ declare global {
 	}
 }
 
+/**
+ * The `inert` global attribute is not present in the React 18 type
+ * definitions (it was added natively in React 19). Declare it here so it can
+ * be used as a lighter, markup-only alternative to the `Disabled` component.
+ * Use the empty-string form (`inert={ condition ? '' : undefined }`) to avoid
+ * React 18's warning about boolean values on unknown attributes.
+ */
+declare module 'react' {
+	// eslint-disable-next-line @typescript-eslint/no-unused-vars
+	interface HTMLAttributes< T > {
+		inert?: '' | undefined;
+	}
+}
+
 export {};

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -9,9 +9,7 @@ import type * as Monaco from 'monaco-editor';
 import type { EditorSettings, EditorOptions, Options, FontFamily } from './types';
 
 declare global {
-	/**
-	 * Data localized from PHP via `wp_localize_script`.
-	 */
+	// Data localized from PHP via `wp_localize_script`.
 	interface ChbeObj {
 		pluginUrl: string;
 		version: string;
@@ -24,9 +22,7 @@ declare global {
 		language?: string;
 	}
 
-	/**
-	 * The AMD loader exposed by the monaco `loader.js` script.
-	 */
+	// The AMD loader exposed by the monaco `loader.js` script.
 	interface MonacoAmdRequire {
 		( modules: string[], onLoad: () => void ): void;
 		config: ( config: { paths: Record< string, string > } ) => void;
@@ -45,13 +41,9 @@ declare global {
 	}
 }
 
-/**
- * The `inert` global attribute is not present in the React 18 type
- * definitions (it was added natively in React 19). Declare it here so it can
- * be used as a lighter, markup-only alternative to the `Disabled` component.
- * Use the empty-string form (`inert={ condition ? '' : undefined }`) to avoid
- * React 18's warning about boolean values on unknown attributes.
- */
+// The `inert` attribute is missing from the React 18 types (added natively in
+// React 19); declare it here. Use the empty-string form to avoid React 18's
+// non-boolean attribute warning.
 declare module 'react' {
 	// eslint-disable-next-line @typescript-eslint/no-unused-vars
 	interface HTMLAttributes< T > {


### PR DESCRIPTION
Replaces the `Disabled` component in the editor config with the native `inert` attribute. `Disabled` forced each conditionally-disabled group to be written twice — once wrapped in `<Disabled>`, once bare — so all 12 occurrences carried duplicated markup. A single `<div inert>` wrapper removes that duplication.

Because `@types/react` 18 predates the native `inert` prop (added in React 19), it is declared via module augmentation in `global.d.ts`, and the empty-string form (`inert={ condition ? '' : undefined }`) is used to avoid React 18's non-boolean attribute warning. The former `.components-disabled` dimming is replaced with an `[inert]` style rule.
