### PR TITLE
Improve tab focus mode accessibility in the editor

### DIFF
--- a/src/components/monaco-editor/index.tsx
+++ b/src/components/monaco-editor/index.tsx
@@ -19,6 +19,8 @@ import { __, sprintf } from '@wordpress/i18n';
 import { useState, useEffect, useRef } from '@wordpress/element';
 import { useResizeObserver } from '@wordpress/compose';
 import { isAppleOS } from '@wordpress/keycodes';
+import { useDispatch } from '@wordpress/data';
+import { store as noticesStore } from '@wordpress/notices';
 
 /**
  * Internal dependencies
@@ -90,6 +92,8 @@ export default function MonacoEditor( {
 
 	const onChangeRef = useRef( onChange );
 	onChangeRef.current = onChange;
+
+	const { createNotice } = useDispatch( noticesStore );
 
 	const [ resizeListener, size ] = useResizeObserver();
 
@@ -232,6 +236,36 @@ export default function MonacoEditor( {
 			subscriptionRef.current = editor.onDidChangeModelContent( ( event ) => {
 				onChangeRef.current?.( editor.getValue(), event );
 			} );
+
+			// Toggle tab focus mode with Ctrl+M (Ctrl+Shift+M on Apple OS).
+			editor.addCommand(
+				isAppleOS()
+					? // eslint-disable-next-line no-bitwise
+					  monaco.KeyMod.WinCtrl | monaco.KeyMod.Shift | monaco.KeyCode.KeyM
+					: // eslint-disable-next-line no-bitwise
+					  monaco.KeyMod.CtrlCmd | monaco.KeyCode.KeyM,
+				() => {
+					const nextTabFocusMode = ! editor.getOption( monaco.editor.EditorOption.tabFocusMode );
+					editor.updateOptions( { tabFocusMode: nextTabFocusMode } );
+					createNotice(
+						'info',
+						nextTabFocusMode
+							? __(
+									'Pressing Tab will now move focus to the next focusable element.',
+									'custom-html-block-extension'
+							  )
+							: __(
+									'Pressing Tab will now insert the tab character.',
+									'custom-html-block-extension'
+							  ),
+						{
+							type: 'snackbar',
+							speak: true,
+							isDismissible: true,
+						}
+					);
+				}
+			);
 
 			setIsEditorReady( true );
 		}

--- a/src/components/monaco-editor/index.tsx
+++ b/src/components/monaco-editor/index.tsx
@@ -15,7 +15,7 @@ import type { CSSProperties } from 'react';
 /**
  * WordPress dependencies
  */
-import { __, sprintf } from '@wordpress/i18n';
+import { __ } from '@wordpress/i18n';
 import { useState, useEffect, useRef } from '@wordpress/element';
 import { useResizeObserver } from '@wordpress/compose';
 import { isAppleOS } from '@wordpress/keycodes';
@@ -146,14 +146,15 @@ export default function MonacoEditor( {
 			const { defaultView } = container.ownerDocument;
 
 			const editor = monaco.editor.create( container, {
-				ariaLabel: sprintf(
-					/* translators: %s: keyboard shortcut to toggle tab focus mode. */
-					__(
-						'Editor content. To change the Tab key behavior to move focus out of the editor, press %s.',
-						'custom-html-block-extension'
-					),
-					isAppleOS() ? 'Ctrl+Shift+M' : 'Ctrl+M'
-				),
+				ariaLabel: isAppleOS()
+					? __(
+							'Editor content. To change the Tab key behavior, press Ctrl+Shift+M.',
+							'custom-html-block-extension'
+					  )
+					: __(
+							'Editor content. To change the Tab key behavior, press Ctrl+M.',
+							'custom-html-block-extension'
+					  ),
 				...options,
 			} as Monaco.editor.IStandaloneEditorConstructionOptions );
 			editorRef.current = editor;

--- a/src/components/monaco-editor/index.tsx
+++ b/src/components/monaco-editor/index.tsx
@@ -15,9 +15,10 @@ import type { CSSProperties } from 'react';
 /**
  * WordPress dependencies
  */
-import { __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 import { useState, useEffect, useRef } from '@wordpress/element';
 import { useResizeObserver } from '@wordpress/compose';
+import { isAppleOS } from '@wordpress/keycodes';
 
 /**
  * Internal dependencies
@@ -140,10 +141,17 @@ export default function MonacoEditor( {
 			}
 			const { defaultView } = container.ownerDocument;
 
-			const editor = monaco.editor.create(
-				container,
-				options as Monaco.editor.IStandaloneEditorConstructionOptions
-			);
+			const editor = monaco.editor.create( container, {
+				ariaLabel: sprintf(
+					/* translators: %s: keyboard shortcut to toggle tab focus mode. */
+					__(
+						'Editor content. To change the Tab key behavior to move focus out of the editor, press %s.',
+						'custom-html-block-extension'
+					),
+					isAppleOS() ? 'Ctrl+Shift+M' : 'Ctrl+M'
+				),
+				...options,
+			} as Monaco.editor.IStandaloneEditorConstructionOptions );
 			editorRef.current = editor;
 
 			const model = editor.getModel();

--- a/test/e2e/test.spec.ts
+++ b/test/e2e/test.spec.ts
@@ -82,7 +82,9 @@ test.describe( 'Custom HTML Block Extension', () => {
 		test( 'should be rendered', async ( { admin, page } ) => {
 			await admin.visitAdminPage( 'options-general.php?page=custom-html-block-extension' );
 			// Hide welcome guide.
-			const welcomeGuide = page.locator( 'role=dialog[name="About Custom HTML Block Extension"i]' );
+			const welcomeGuide = page.getByRole( 'dialog', {
+				name: 'About Custom HTML Block Extension',
+			} );
 			const isVisible = await welcomeGuide.isVisible();
 			if ( isVisible ) {
 				await welcomeGuide.getByRole( 'button', { name: 'Close' } ).click();
@@ -96,6 +98,41 @@ test.describe( 'Custom HTML Block Extension', () => {
 			// Options tab
 			await page.getByRole( 'tab', { name: 'Options' } ).click();
 			await expect( page.getByRole( 'button', { name: 'Save Options' } ) ).toBeVisible();
+		} );
+
+		test( 'tab focus mode should move focus out of the code editor', async ( { admin, page } ) => {
+			await admin.visitAdminPage( 'options-general.php?page=custom-html-block-extension' );
+			// Hide welcome guide.
+			const welcomeGuide = page.getByRole( 'dialog', {
+				name: 'About Custom HTML Block Extension',
+			} );
+			if ( await welcomeGuide.isVisible() ) {
+				await welcomeGuide.getByRole( 'button', { name: 'Close' } ).click();
+			}
+
+			const editor = page.locator( '.chbe-admin-editor-config-editor-preview .monaco-editor' );
+			const textbox = editor.getByRole( 'textbox', {
+				name: 'Editor content. To change the Tab key behavior, press Ctrl+M.',
+			} );
+
+			await editor.click();
+			await expect( textbox ).toBeFocused();
+
+			// While tab focus mode is disabled, Tab stays inside the editor.
+			await page.keyboard.press( 'Tab' );
+			await expect( textbox ).toBeFocused();
+
+			// Toggle tab focus mode.
+			await page.keyboard.press( 'Control+m' );
+
+			// The change should be announced to screen readers.
+			await expect( page.getByRole( 'button', { name: 'Dismiss this notice' } ) ).toContainText(
+				'Pressing Tab will now move focus to the next focusable element.'
+			);
+
+			// Tab should move focus out of the editor to the Save settings button.
+			await page.keyboard.press( 'Tab' );
+			await expect( page.getByRole( 'button', { name: 'Save settings' } ) ).toBeFocused();
 		} );
 	} );
 } );

--- a/test/e2e/test.spec.ts
+++ b/test/e2e/test.spec.ts
@@ -28,16 +28,7 @@ test.describe( 'Custom HTML Block Extension', () => {
 			await requestUtils.deactivatePlugin( 'classic-editor' );
 		} );
 
-		test( 'input by Emmet should be expanded on the theme editor', async ( {
-			admin,
-			page,
-			pageUtils,
-			browserName,
-		} ) => {
-			test.skip(
-				browserName === 'webkit',
-				"FIXME: For some reason, the Select All shortcut doesn't work in Webkit browser"
-			);
+		test( 'input by Emmet should be expanded on the theme editor', async ( { admin, page } ) => {
 			await admin.visitAdminPage( 'theme-editor.php' );
 			// Hide file editor warning modal.
 			const dismissButton = page.locator( '.file-editor-warning-dismiss' );
@@ -46,7 +37,12 @@ test.describe( 'Custom HTML Block Extension', () => {
 				await dismissButton.click();
 			}
 			await page.click( '#monaco-editor .monaco-editor' );
-			await pageUtils.pressKeys( 'primary+a' );
+			// Monaco maps its Ctrl/Cmd modifier from navigator.userAgent, so a
+			// "Macintosh" UA (e.g. Playwright's WebKit) needs Meta+A to select all.
+			const shortcut = await page.evaluate( () =>
+				window.navigator.userAgent.includes( 'Macintosh' ) ? 'Meta+a' : 'Control+a'
+			);
+			await page.keyboard.press( shortcut );
 			await page.keyboard.type( '.selector{fz100', { delay: 50 } );
 			await page.keyboard.press( 'Tab' );
 			const textarea = await page.locator( '#newcontent' );
@@ -112,7 +108,7 @@ test.describe( 'Custom HTML Block Extension', () => {
 
 			const editor = page.locator( '.chbe-admin-editor-config-editor-preview .monaco-editor' );
 			const textbox = editor.getByRole( 'textbox', {
-				name: 'Editor content. To change the Tab key behavior, press Ctrl+M.',
+				name: /^Editor content\. To change the Tab key behavior, press Ctrl\+(Shift\+)?M\.$/,
 			} );
 
 			await editor.click();
@@ -122,8 +118,20 @@ test.describe( 'Custom HTML Block Extension', () => {
 			await page.keyboard.press( 'Tab' );
 			await expect( textbox ).toBeFocused();
 
+			// The plugin picks the combo from navigator.platform (isAppleOS), while
+			// Monaco maps Ctrl/Cmd from navigator.userAgent ("Macintosh" => Meta).
+			const shortcut = await page.evaluate( () => {
+				const { platform, userAgent } = window.navigator;
+				const isAppleOS =
+					platform.indexOf( 'Mac' ) !== -1 || [ 'iPad', 'iPhone' ].includes( platform );
+				if ( isAppleOS ) {
+					return 'Control+Shift+m';
+				}
+				return userAgent.includes( 'Macintosh' ) ? 'Meta+m' : 'Control+m';
+			} );
+
 			// Toggle tab focus mode.
-			await page.keyboard.press( 'Control+m' );
+			await page.keyboard.press( shortcut );
 
 			// The change should be announced to screen readers.
 			await expect( page.getByRole( 'button', { name: 'Dismiss this notice' } ) ).toContainText(


### PR DESCRIPTION
Improves keyboard and screen reader accessibility around the editor's Tab trap. Standalone Monaco no longer surfaces the accessibility help dialog, so there is no discoverable way to move focus out of the editor once the Tab key is trapped, and toggling tab focus mode gives sighted keyboard users no feedback.

Two changes address this:

- The editor's `ariaLabel` now announces the toggle shortcut (`Ctrl+M`, or `Ctrl+Shift+M` on Apple OS via `isAppleOS`), so screen reader users can discover how to escape the trap.
- `Ctrl+M` is overridden to flip the `tabFocusMode` option directly and show a snackbar notice. The built-in toggle command only mutates a global singleton and never fires `onDidChangeConfiguration`, so driving the option instead keeps the actual Tab behavior and `getOption` consistent, while the snackbar gives sighted users the same feedback screen readers already receive from Monaco's aria-live message.
