### PR TITLE
Update WPCS to 3.4 and use the default WordPress-Core ruleset

### DIFF
--- a/classes/class-admin.php
+++ b/classes/class-admin.php
@@ -160,7 +160,7 @@ class Admin {
 				'type' => $value['type'],
 			);
 
-			if ( $value['type'] === 'object' ) {
+			if ( 'object' === $value['type'] ) {
 				$properties_editor_options[ $key ]['properties'] = array();
 
 				$default_editor_options[ $key ] = array();

--- a/classes/class-block-editor.php
+++ b/classes/class-block-editor.php
@@ -7,7 +7,7 @@
 
 namespace Custom_Html_Block_Extension;
 
-class BlockEditor {
+class Block_Editor {
 
 	/**
 	 * Constructor
@@ -85,4 +85,4 @@ class BlockEditor {
 	}
 }
 
-new BlockEditor();
+new Block_Editor();

--- a/classes/class-classic-editor.php
+++ b/classes/class-classic-editor.php
@@ -7,7 +7,7 @@
 
 namespace Custom_Html_Block_Extension;
 
-class ClassicEditor {
+class Classic_Editor {
 
 	/**
 	 * Constructor
@@ -85,4 +85,4 @@ class ClassicEditor {
 	}
 }
 
-new ClassicEditor();
+new Classic_Editor();

--- a/classes/class-settings.php
+++ b/classes/class-settings.php
@@ -529,7 +529,7 @@ class Settings {
 		$default_editor_options = array();
 
 		foreach ( self::DEFAULT_EDITOR_OPTIONS as $key => $value ) {
-			if ( $value['type'] === 'object' ) {
+			if ( 'object' === $value['type'] ) {
 				$default_editor_options[ $key ] = array();
 
 				foreach ( $value['items'] as $sub_key => $sub_value ) {

--- a/classes/class-theme-plugin-editor.php
+++ b/classes/class-theme-plugin-editor.php
@@ -7,7 +7,7 @@
 
 namespace Custom_Html_Block_Extension;
 
-class ThemePluginEditor {
+class Theme_Plugin_Editor {
 
 	/**
 	 * Constructor
@@ -131,4 +131,4 @@ class ThemePluginEditor {
 	}
 }
 
-new ThemePluginEditor();
+new Theme_Plugin_Editor();

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
 	],
 	"require-dev": {
 		"squizlabs/php_codesniffer": "*",
-		"wp-coding-standards/wpcs": "^3.3"
+		"wp-coding-standards/wpcs": "^3.4"
 	},
 	"scripts": {
 		"phpcs": "phpcs --config-set installed_paths vendor/wp-coding-standards/wpcs,vendor/phpcsstandards/phpcsextra,vendor/phpcsstandards/phpcsutils",

--- a/composer.lock
+++ b/composer.lock
@@ -4,21 +4,21 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "c6d31675081aaa6dca323417f4a03837",
+    "content-hash": "c872e9afbfe83735ab41d1810210cec5",
     "packages": [],
     "packages-dev": [
         {
             "name": "dealerdirect/phpcodesniffer-composer-installer",
-            "version": "v1.2.0",
+            "version": "v1.2.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHPCSStandards/composer-installer.git",
-                "reference": "845eb62303d2ca9b289ef216356568ccc075ffd1"
+                "reference": "963f0c67bffde0eac41b56be71ac0e8ba132f0bd"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHPCSStandards/composer-installer/zipball/845eb62303d2ca9b289ef216356568ccc075ffd1",
-                "reference": "845eb62303d2ca9b289ef216356568ccc075ffd1",
+                "url": "https://api.github.com/repos/PHPCSStandards/composer-installer/zipball/963f0c67bffde0eac41b56be71ac0e8ba132f0bd",
+                "reference": "963f0c67bffde0eac41b56be71ac0e8ba132f0bd",
                 "shasum": ""
             },
             "require": {
@@ -101,7 +101,7 @@
                     "type": "thanks_dev"
                 }
             ],
-            "time": "2025-11-11T04:32:07+00:00"
+            "time": "2026-05-06T08:26:05+00:00"
         },
         {
             "name": "phpcsstandards/phpcsextra",
@@ -359,16 +359,16 @@
         },
         {
             "name": "wp-coding-standards/wpcs",
-            "version": "3.3.0",
+            "version": "3.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/WordPress/WordPress-Coding-Standards.git",
-                "reference": "7795ec6fa05663d716a549d0b44e47ffc8b0d4a6"
+                "reference": "469c18ceab4d642b15bad4c65ebf3b307bfd55ab"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/WordPress/WordPress-Coding-Standards/zipball/7795ec6fa05663d716a549d0b44e47ffc8b0d4a6",
-                "reference": "7795ec6fa05663d716a549d0b44e47ffc8b0d4a6",
+                "url": "https://api.github.com/repos/WordPress/WordPress-Coding-Standards/zipball/469c18ceab4d642b15bad4c65ebf3b307bfd55ab",
+                "reference": "469c18ceab4d642b15bad4c65ebf3b307bfd55ab",
                 "shasum": ""
             },
             "require": {
@@ -378,8 +378,8 @@
                 "ext-xmlreader": "*",
                 "php": ">=7.2",
                 "phpcsstandards/phpcsextra": "^1.5.0",
-                "phpcsstandards/phpcsutils": "^1.1.0",
-                "squizlabs/php_codesniffer": "^3.13.4"
+                "phpcsstandards/phpcsutils": "^1.2.2",
+                "squizlabs/php_codesniffer": "^3.13.5"
             },
             "require-dev": {
                 "php-parallel-lint/php-console-highlighter": "^1.0.0",
@@ -421,7 +421,7 @@
                     "type": "custom"
                 }
             ],
-            "time": "2025-11-25T12:08:04+00:00"
+            "time": "2026-07-16T13:05:29+00:00"
         }
     ],
     "aliases": [],

--- a/phpcs.ruleset.xml
+++ b/phpcs.ruleset.xml
@@ -1,10 +1,7 @@
 <?xml version="1.0"?>
 <ruleset name="WordPress Theme Coding Standards">
 	<description>A custom set of code standard rules to check for WordPress themes.</description>
-	<rule ref="WordPress-Core">
-		<exclude name="WordPress.PHP.YodaConditions" />
-		<exclude name="WordPress.Files.FileName.InvalidClassFileName" />
-	</rule>
+	<rule ref="WordPress-Core" />
 	<exclude-pattern>*/node_modules/*</exclude-pattern>
 	<exclude-pattern>*/vendor/*</exclude-pattern>
 	<exclude-pattern>*/build/*</exclude-pattern>


### PR DESCRIPTION
## Summary

Updates WordPress Coding Standards to 3.4 and removes the custom rule exclusions so the default `WordPress-Core` ruleset is used as-is.

## Changes

- Bump `wp-coding-standards/wpcs` to `^3.4`
- Drop the `YodaConditions` and `InvalidClassFileName` exclusions from `phpcs.ruleset.xml`
- Apply Yoda conditions and rename editor classes to underscore-separated names to satisfy the now-enabled rules
