### PR TITLE
Support the innerContent-based Custom HTML block

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -34,6 +34,7 @@
 				"@wordpress/i18n": "^6.21.1",
 				"@wordpress/keycodes": "^4.34.0",
 				"@wordpress/notices": "^5.48.1",
+				"@wordpress/private-apis": "^1.49.0",
 				"@wordpress/scripts": "^32.4.1",
 				"clsx": "2.1.1",
 				"husky": "^9.1.7",

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
 		"@wordpress/i18n": "^6.21.1",
 		"@wordpress/keycodes": "^4.34.0",
 		"@wordpress/notices": "^5.48.1",
+		"@wordpress/private-apis": "^1.49.0",
 		"@wordpress/scripts": "^32.4.1",
 		"clsx": "2.1.1",
 		"husky": "^9.1.7",

--- a/src/block-editor/edit-legacy.tsx
+++ b/src/block-editor/edit-legacy.tsx
@@ -2,15 +2,14 @@
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { useEffect, useMemo, useState, useRef } from '@wordpress/element';
-import { useSelect, useDispatch, useRegistry } from '@wordpress/data';
+import { useMemo, useState, useRef } from '@wordpress/element';
+import { useSelect } from '@wordpress/data';
 import {
 	BlockControls,
 	transformStyles,
 	useBlockProps,
 	store as blockEditorStore,
 } from '@wordpress/block-editor';
-import { parse, serialize, getBlockContent } from '@wordpress/blocks';
 import {
 	ResizableBox,
 	ToolbarButton,
@@ -22,7 +21,7 @@ import {
 } from '@wordpress/components';
 import { Stack } from '@wordpress/ui';
 import { fullscreen } from '@wordpress/icons';
-import type { Block, BlockEditProps } from '@wordpress/blocks';
+import type { BlockEditProps } from '@wordpress/blocks';
 
 /**
  * Internal dependencies
@@ -38,13 +37,6 @@ type HTMLEditProps = BlockEditProps< {
 	toggleSelection: ( isSelectionEnabled: boolean ) => void;
 };
 
-// The parsed block carries `innerContent` (static HTML fragments interleaved
-// with `null` markers for inner block positions), which the installed
-// `@wordpress/blocks` types don't yet expose on `Block`.
-type BlockWithInnerContent = Block & {
-	innerContent?: Array< string | null >;
-};
-
 const MIN_HEIGHT = 100;
 const MAX_HEIGHT = 1000;
 
@@ -58,13 +50,12 @@ const DEFAULT_STYLES = `
 `;
 
 export default function HTMLEdit( {
-	clientId,
 	attributes,
 	isSelected,
 	setAttributes,
 	toggleSelection,
 }: HTMLEditProps ) {
-	const { height } = attributes;
+	const { content, height } = attributes;
 	const { editorSettings, editorOptions } = window.chbeObj;
 
 	const [ isPreview, setIsPreview ] = useState< boolean >();
@@ -73,17 +64,6 @@ export default function HTMLEdit( {
 	const [ errorMessage, setErrorMessage ] = useState< string >();
 
 	const ref = useRef< HTMLDivElement >( null );
-
-	const registry = useRegistry();
-	const { updateBlock, replaceInnerBlocks } = useDispatch( blockEditorStore );
-
-	const content = useSelect(
-		( select ) => {
-			const block = select( blockEditorStore ).getBlock( clientId );
-			return block ? getBlockContent( block ) : '';
-		},
-		[ clientId ]
-	);
 
 	const settingStyles = useSelect(
 		( select ) => select( blockEditorStore ).getSettings().styles,
@@ -117,54 +97,9 @@ export default function HTMLEdit( {
 		setAttributes( { height: newHeight } );
 	};
 
-	// Re-parse the edited content: static HTML becomes the block's
-	// `innerContent` fragments and `<!-- wp:* -->` delimited segments become
-	// inner blocks mounted at their positions within the static markup.
-	const onChange = ( nextContent: string ) => {
-		if ( nextContent === content ) {
-			return;
-		}
-
-		const [ parsedBlock ] = parse(
-			`<!-- wp:html -->\n${ nextContent }\n<!-- /wp:html -->`
-		) as BlockWithInnerContent[];
-		const nextInnerBlocks = parsedBlock?.innerBlocks ?? [];
-		const prevInnerBlocks = registry.select( blockEditorStore ).getBlocks( clientId );
-		// Keep the existing inner blocks, and thereby their client IDs and
-		// selection, when their markup is unchanged — e.g. when only the
-		// surrounding static HTML was edited.
-		const innerBlocksUnchanged =
-			prevInnerBlocks.length === nextInnerBlocks.length &&
-			prevInnerBlocks.every(
-				( block: Block, index: number ) =>
-					serialize( block ) === serialize( nextInnerBlocks[ index ] )
-			);
-
-		registry.batch( () => {
-			updateBlock( clientId, {
-				innerContent: parsedBlock?.innerContent ?? ( nextContent ? [ nextContent ] : [] ),
-			} as Partial< Block > );
-			if ( ! innerBlocksUnchanged ) {
-				replaceInnerBlocks( clientId, nextInnerBlocks, false );
-			}
-		} );
+	const onChange = ( value: string ) => {
+		setAttributes( { content: value } );
 	};
-
-	// Migrate the deprecated `content` attribute. The block's markup now lives
-	// in its inner content, but a block created via `createBlock( 'core/html',
-	// { content } )` still arrives with a `content` attribute. As soon as it
-	// loads, move that markup into the block's inner content and clear the
-	// attribute.
-	useEffect( () => {
-		if ( ! attributes.content ) {
-			return;
-		}
-
-		updateBlock( clientId, {
-			attributes: { content: undefined },
-			innerContent: [ attributes.content ],
-		} as Partial< Block > );
-	}, [ attributes.content ] );
 
 	const onError = ( error: MonacoError ) => {
 		if ( ( error.type === 'timeout' || error.type === 'scripterror' ) && error.msg ) {

--- a/src/block-editor/edit.tsx
+++ b/src/block-editor/edit.tsx
@@ -16,7 +16,6 @@ import { parse, serialize, getBlockContent } from '@wordpress/blocks';
 import {
 	ResizableBox,
 	ToolbarButton,
-	Disabled,
 	SandBox,
 	ToolbarGroup,
 	Modal,
@@ -106,10 +105,13 @@ export default function HTMLEdit( {
 		[ clientId ]
 	);
 
-	const settingStyles = useSelect(
-		( select ) => select( blockEditorStore ).getSettings().styles,
-		[]
-	);
+	const { settingStyles, isPreviewMode } = useSelect( ( select ) => {
+		const settings = select( blockEditorStore ).getSettings();
+		return {
+			settingStyles: settings.styles,
+			isPreviewMode: ( settings as { isPreviewMode?: boolean } ).isPreviewMode,
+		};
+	}, [] );
 
 	const styles = useMemo(
 		() => [
@@ -185,8 +187,7 @@ export default function HTMLEdit( {
 			attributes: { content: undefined },
 			innerContent: [ attributes.content ],
 		} as Partial< Block > );
-		// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, [ attributes.content ] );
+	}, [ clientId, updateBlock, attributes.content ] );
 
 	const onError = ( error: MonacoError ) => {
 		if ( ( error.type === 'timeout' || error.type === 'scripterror' ) && error.msg ) {
@@ -200,6 +201,33 @@ export default function HTMLEdit( {
 
 	function switchToHTML() {
 		setIsPreview( false );
+	}
+
+	function renderPreview() {
+		if ( ! content?.trim() ) {
+			return (
+				<Placeholder
+					icon={ <BlockIcon icon={ code } /> }
+					label={ __( 'Custom HTML', 'custom-html-block-extension' ) }
+					instructions={ __(
+						'Add custom HTML code and preview how it looks.',
+						'custom-html-block-extension'
+					) }
+				/>
+			);
+		}
+		// Render editable inner blocks in place, but only in the user-toggled
+		// preview — not in the read-only preview mode, where nothing should be
+		// interactive.
+		if ( hasInnerBlocks && isPreview && ! isPreviewMode ) {
+			return <InnerContent clientId={ clientId } />;
+		}
+		return (
+			<>
+				<SandBox html={ content } styles={ styles } />
+				{ ! isSelected && <div className="block-library-html__preview-overlay"></div> }
+			</>
+		);
 	}
 
 	return (
@@ -223,67 +251,42 @@ export default function HTMLEdit( {
 					</ToolbarButton>
 				</ToolbarGroup>
 			</BlockControls>
-			<Disabled.Consumer>
-				{ ( isDisabled ) => {
-					if ( isPreview || isDisabled ) {
-						if ( ! content?.trim() ) {
-							return (
-								<Placeholder
-									icon={ <BlockIcon icon={ code } /> }
-									label={ __( 'Custom HTML', 'custom-html-block-extension' ) }
-									instructions={ __(
-										'Add custom HTML code and preview how it looks.',
-										'custom-html-block-extension'
-									) }
-								/>
-							);
-						}
-						if ( hasInnerBlocks && isPreview && ! isDisabled ) {
-							return <InnerContent clientId={ clientId } />;
-						}
-						return (
-							<>
-								<SandBox html={ content } styles={ styles } />
-								{ ! isSelected && <div className="block-library-html__preview-overlay"></div> }
-							</>
-						);
-					}
-					return (
-						<Stack direction="column" gap="sm">
-							{ errorMessage && <Notice status="warning">{ errorMessage }</Notice> }
-							<ResizableBox
-								size={ { height } }
-								minHeight={ MIN_HEIGHT }
-								enable={ {
-									top: false,
-									right: false,
-									bottom: true,
-									left: false,
-									topRight: false,
-									bottomRight: false,
-									bottomLeft: false,
-									topLeft: false,
-								} }
-								onResizeStart={ onResizeStart }
-								onResizeStop={ onResizeStop }
-								showHandle={ isSelected }
-							>
-								<MonacoEditor
-									language="html"
-									theme={ editorSettings.theme }
-									options={ editorOptions }
-									value={ content }
-									useEmmet={ editorSettings.emmet }
-									tabSize={ editorSettings.tabSize }
-									insertSpaces={ editorSettings.insertSpaces }
-									onChange={ onChange }
-									onError={ onError }
-								/>
-							</ResizableBox>
-						</Stack>
-					);
-				} }
-			</Disabled.Consumer>
+			{ isPreview || isPreviewMode ? (
+				renderPreview()
+			) : (
+				<Stack direction="column" gap="sm">
+					{ errorMessage && <Notice status="warning">{ errorMessage }</Notice> }
+					<ResizableBox
+						size={ { height } }
+						minHeight={ MIN_HEIGHT }
+						enable={ {
+							top: false,
+							right: false,
+							bottom: true,
+							left: false,
+							topRight: false,
+							bottomRight: false,
+							bottomLeft: false,
+							topLeft: false,
+						} }
+						onResizeStart={ onResizeStart }
+						onResizeStop={ onResizeStop }
+						showHandle={ isSelected }
+					>
+						<MonacoEditor
+							language="html"
+							theme={ editorSettings.theme }
+							options={ editorOptions }
+							value={ content }
+							useEmmet={ editorSettings.emmet }
+							tabSize={ editorSettings.tabSize }
+							insertSpaces={ editorSettings.insertSpaces }
+							onChange={ onChange }
+							onError={ onError }
+						/>
+					</ResizableBox>
+				</Stack>
+			) }
 			{ isModalEditorOpen && (
 				<Modal
 					title={ __( 'HTML editor', 'custom-html-block-extension' ) }

--- a/src/block-editor/edit.tsx
+++ b/src/block-editor/edit.tsx
@@ -34,7 +34,7 @@ import MonacoEditor, { type MonacoError } from '../components/monaco-editor';
 const { InnerContent } = __dangerousOptInToUnstableAPIsOnlyForCoreModules(
 	'I acknowledge private features are not for use in themes or plugins and doing so will break in the next version of WordPress.',
 	'@wordpress/block-editor'
-).unlock( ( blockEditor as unknown as { privateApis: unknown } ).privateApis ) as {
+).unlock( blockEditor.privateApis ) as {
 	InnerContent: React.ComponentType< { clientId: string } >;
 };
 

--- a/src/block-editor/edit.tsx
+++ b/src/block-editor/edit.tsx
@@ -4,8 +4,10 @@
 import { __ } from '@wordpress/i18n';
 import { useEffect, useMemo, useState, useRef } from '@wordpress/element';
 import { useSelect, useDispatch, useRegistry } from '@wordpress/data';
+import * as blockEditor from '@wordpress/block-editor';
 import {
 	BlockControls,
+	BlockIcon,
 	transformStyles,
 	useBlockProps,
 	store as blockEditorStore,
@@ -19,9 +21,11 @@ import {
 	ToolbarGroup,
 	Modal,
 	Notice,
+	Placeholder,
 } from '@wordpress/components';
 import { Stack } from '@wordpress/ui';
-import { fullscreen } from '@wordpress/icons';
+import { code, fullscreen } from '@wordpress/icons';
+import { __dangerousOptInToUnstableAPIsOnlyForCoreModules } from '@wordpress/private-apis';
 import type { Block, BlockEditProps } from '@wordpress/blocks';
 
 /**
@@ -29,6 +33,20 @@ import type { Block, BlockEditProps } from '@wordpress/blocks';
  */
 import './style.scss';
 import MonacoEditor, { type MonacoError } from '../components/monaco-editor';
+
+// Opt in to the `@wordpress/block-editor` private APIs to access `InnerContent`,
+// which renders a Custom HTML block's embedded inner blocks as editable blocks.
+// This is a private API with no backward-compatibility guarantee: the consent
+// string and `InnerContent` itself may change or be removed in any WordPress
+// release.
+const { unlock } = __dangerousOptInToUnstableAPIsOnlyForCoreModules(
+	'I acknowledge private features are not for use in themes or plugins and doing so will break in the next version of WordPress.',
+	'@wordpress/block-editor'
+);
+
+const { InnerContent } = unlock(
+	( blockEditor as unknown as { privateApis: unknown } ).privateApis
+) as { InnerContent: React.ComponentType< { clientId: string } > };
 
 type HTMLEditProps = BlockEditProps< {
 	content: string;
@@ -77,10 +95,13 @@ export default function HTMLEdit( {
 	const registry = useRegistry();
 	const { updateBlock, replaceInnerBlocks } = useDispatch( blockEditorStore );
 
-	const content = useSelect(
+	const { content, hasInnerBlocks } = useSelect(
 		( select ) => {
 			const block = select( blockEditorStore ).getBlock( clientId );
-			return block ? getBlockContent( block ) : '';
+			return {
+				content: block ? getBlockContent( block ) : '',
+				hasInnerBlocks: ( block?.innerBlocks?.length ?? 0 ) > 0,
+			};
 		},
 		[ clientId ]
 	);
@@ -164,6 +185,7 @@ export default function HTMLEdit( {
 			attributes: { content: undefined },
 			innerContent: [ attributes.content ],
 		} as Partial< Block > );
+		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [ attributes.content ] );
 
 	const onError = ( error: MonacoError ) => {
@@ -202,13 +224,31 @@ export default function HTMLEdit( {
 				</ToolbarGroup>
 			</BlockControls>
 			<Disabled.Consumer>
-				{ ( isDisabled ) =>
-					isPreview || isDisabled ? (
-						<>
-							<SandBox html={ content } styles={ styles } />
-							{ ! isSelected && <div className="block-library-html__preview-overlay"></div> }
-						</>
-					) : (
+				{ ( isDisabled ) => {
+					if ( isPreview || isDisabled ) {
+						if ( ! content?.trim() ) {
+							return (
+								<Placeholder
+									icon={ <BlockIcon icon={ code } /> }
+									label={ __( 'Custom HTML', 'custom-html-block-extension' ) }
+									instructions={ __(
+										'Add custom HTML code and preview how it looks.',
+										'custom-html-block-extension'
+									) }
+								/>
+							);
+						}
+						if ( hasInnerBlocks && isPreview && ! isDisabled ) {
+							return <InnerContent clientId={ clientId } />;
+						}
+						return (
+							<>
+								<SandBox html={ content } styles={ styles } />
+								{ ! isSelected && <div className="block-library-html__preview-overlay"></div> }
+							</>
+						);
+					}
+					return (
 						<Stack direction="column" gap="sm">
 							{ errorMessage && <Notice status="warning">{ errorMessage }</Notice> }
 							<ResizableBox
@@ -241,8 +281,8 @@ export default function HTMLEdit( {
 								/>
 							</ResizableBox>
 						</Stack>
-					)
-				}
+					);
+				} }
 			</Disabled.Consumer>
 			{ isModalEditorOpen && (
 				<Modal

--- a/src/block-editor/edit.tsx
+++ b/src/block-editor/edit.tsx
@@ -2,13 +2,12 @@
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { useEffect, useMemo, useState, useRef } from '@wordpress/element';
+import { useEffect, useState, useRef } from '@wordpress/element';
 import { useSelect, useDispatch, useRegistry } from '@wordpress/data';
 import * as blockEditor from '@wordpress/block-editor';
 import {
 	BlockControls,
 	BlockIcon,
-	transformStyles,
 	useBlockProps,
 	store as blockEditorStore,
 } from '@wordpress/block-editor';
@@ -16,7 +15,6 @@ import { parse, serialize, getBlockContent } from '@wordpress/blocks';
 import {
 	ResizableBox,
 	ToolbarButton,
-	SandBox,
 	ToolbarGroup,
 	Modal,
 	Notice,
@@ -33,19 +31,12 @@ import type { Block, BlockEditProps } from '@wordpress/blocks';
 import './style.scss';
 import MonacoEditor, { type MonacoError } from '../components/monaco-editor';
 
-// Opt in to the `@wordpress/block-editor` private APIs to access `InnerContent`,
-// which renders a Custom HTML block's embedded inner blocks as editable blocks.
-// This is a private API with no backward-compatibility guarantee: the consent
-// string and `InnerContent` itself may change or be removed in any WordPress
-// release.
-const { unlock } = __dangerousOptInToUnstableAPIsOnlyForCoreModules(
+const { InnerContent } = __dangerousOptInToUnstableAPIsOnlyForCoreModules(
 	'I acknowledge private features are not for use in themes or plugins and doing so will break in the next version of WordPress.',
 	'@wordpress/block-editor'
-);
-
-const { InnerContent } = unlock(
-	( blockEditor as unknown as { privateApis: unknown } ).privateApis
-) as { InnerContent: React.ComponentType< { clientId: string } > };
+).unlock( ( blockEditor as unknown as { privateApis: unknown } ).privateApis ) as {
+	InnerContent: React.ComponentType< { clientId: string } >;
+};
 
 type HTMLEditProps = BlockEditProps< {
 	content: string;
@@ -55,24 +46,12 @@ type HTMLEditProps = BlockEditProps< {
 	toggleSelection: ( isSelectionEnabled: boolean ) => void;
 };
 
-// The parsed block carries `innerContent` (static HTML fragments interleaved
-// with `null` markers for inner block positions), which the installed
-// `@wordpress/blocks` types don't yet expose on `Block`.
 type BlockWithInnerContent = Block & {
 	innerContent?: Array< string | null >;
 };
 
 const MIN_HEIGHT = 100;
 const MAX_HEIGHT = 1000;
-
-const DEFAULT_STYLES = `
-	html,body,:root {
-		margin: 0 !important;
-		padding: 0 !important;
-		overflow: visible !important;
-		min-height: auto !important;
-	}
-`;
 
 export default function HTMLEdit( {
 	clientId,
@@ -94,34 +73,19 @@ export default function HTMLEdit( {
 	const registry = useRegistry();
 	const { updateBlock, replaceInnerBlocks } = useDispatch( blockEditorStore );
 
-	const { content, hasInnerBlocks } = useSelect(
+	const { content, isPreviewMode } = useSelect(
 		( select ) => {
-			const block = select( blockEditorStore ).getBlock( clientId );
+			const { getBlock, getSettings } = select( blockEditorStore );
+			const block = getBlock( clientId );
 			return {
 				content: block ? getBlockContent( block ) : '',
-				hasInnerBlocks: ( block?.innerBlocks?.length ?? 0 ) > 0,
+				isPreviewMode: ( getSettings() as { isPreviewMode?: boolean } ).isPreviewMode,
 			};
 		},
 		[ clientId ]
 	);
 
-	const { settingStyles, isPreviewMode } = useSelect( ( select ) => {
-		const settings = select( blockEditorStore ).getSettings();
-		return {
-			settingStyles: settings.styles,
-			isPreviewMode: ( settings as { isPreviewMode?: boolean } ).isPreviewMode,
-		};
-	}, [] );
-
-	const styles = useMemo(
-		() => [
-			DEFAULT_STYLES,
-			...transformStyles(
-				( settingStyles ?? [] ).filter( ( style: { css?: string } ) => style.css )
-			),
-		],
-		[ settingStyles ]
-	);
+	const hasContent = !! content.trim();
 
 	const onResizeStart = () => {
 		toggleSelection( false );
@@ -203,33 +167,6 @@ export default function HTMLEdit( {
 		setIsPreview( false );
 	}
 
-	function renderPreview() {
-		if ( ! content?.trim() ) {
-			return (
-				<Placeholder
-					icon={ <BlockIcon icon={ code } /> }
-					label={ __( 'Custom HTML', 'custom-html-block-extension' ) }
-					instructions={ __(
-						'Add custom HTML code and preview how it looks.',
-						'custom-html-block-extension'
-					) }
-				/>
-			);
-		}
-		// Render editable inner blocks in place, but only in the user-toggled
-		// preview — not in the read-only preview mode, where nothing should be
-		// interactive.
-		if ( hasInnerBlocks && isPreview && ! isPreviewMode ) {
-			return <InnerContent clientId={ clientId } />;
-		}
-		return (
-			<>
-				<SandBox html={ content } styles={ styles } />
-				{ ! isSelected && <div className="block-library-html__preview-overlay"></div> }
-			</>
-		);
-	}
-
 	return (
 		<div { ...useBlockProps( { ref, className: 'block-library-html__edit' } ) }>
 			<BlockControls>
@@ -252,7 +189,19 @@ export default function HTMLEdit( {
 				</ToolbarGroup>
 			</BlockControls>
 			{ isPreview || isPreviewMode ? (
-				renderPreview()
+				<>
+					{ ! hasContent && (
+						<Placeholder
+							icon={ <BlockIcon icon={ code } /> }
+							label={ __( 'Custom HTML', 'custom-html-block-extension' ) }
+							instructions={ __(
+								'Add custom HTML code and preview how it looks.',
+								'custom-html-block-extension'
+							) }
+						/>
+					) }
+					{ hasContent && <InnerContent clientId={ clientId } /> }
+				</>
 			) : (
 				<Stack direction="column" gap="sm">
 					{ errorMessage && <Notice status="warning">{ errorMessage }</Notice> }

--- a/src/block-editor/index.ts
+++ b/src/block-editor/index.ts
@@ -9,11 +9,19 @@ import type { BlockConfiguration } from '@wordpress/blocks';
  */
 import icon from '../components/block-icon';
 import edit from './edit';
+import editLegacy from './edit-legacy';
 
 const customHtmlBlockExtension = ( settings: BlockConfiguration ): BlockConfiguration => {
 	if ( 'core/html' !== settings.name ) {
 		return settings;
 	}
+
+	// Since WordPress 7.1 the Custom HTML block stores its markup in
+	// `innerContent` instead of the `content` attribute, so its `content`
+	// attribute definition drops `source: 'raw'` in favor of `role: 'local'`.
+	// Use that to pick the matching Edit implementation.
+	// TODO: Remove `editLegacy` once the minimum supported version is 7.1.
+	const hasInnerContent = settings.attributes?.content?.role === 'local';
 
 	const newSettings: BlockConfiguration = {
 		...settings,
@@ -25,7 +33,7 @@ const customHtmlBlockExtension = ( settings: BlockConfiguration ): BlockConfigur
 				default: 300,
 			},
 		},
-		edit: edit as BlockConfiguration[ 'edit' ],
+		edit: ( hasInnerContent ? edit : editLegacy ) as BlockConfiguration[ 'edit' ],
 	};
 	return newSettings;
 };

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -51,4 +51,9 @@ declare module 'react' {
 	}
 }
 
+// `privateApis` is exported at runtime but missing from the package types.
+declare module '@wordpress/block-editor' {
+	export const privateApis: unknown;
+}
+
 export {};


### PR DESCRIPTION
Fixes #210

Since Gutenberg [#79115](https://github.com/WordPress/gutenberg/pull/79115) (WordPress 7.1), the core Custom HTML block stores its markup in `innerContent` instead of the `content` attribute, and `save()` returns `null`. Because this plugin fully overrides the block's Edit component and still read/wrote `attributes.content` via `setAttributes`, the block content could no longer be updated on 7.1.

The plugin needs to keep supporting WordPress 7.0, so the Edit component is split in two and selected at registration time by inspecting the `content` attribute definition.

Once the minimum supported version reaches 7.1, `edit-legacy.tsx` can be removed.
