### PR TITLE
Add per-block setting to choose the initial mode

### DIFF
--- a/src/block-editor/edit-legacy.tsx
+++ b/src/block-editor/edit-legacy.tsx
@@ -4,8 +4,10 @@
 import { __ } from '@wordpress/i18n';
 import { useMemo, useState, useRef } from '@wordpress/element';
 import { useSelect } from '@wordpress/data';
+import { useViewportMatch } from '@wordpress/compose';
 import {
 	BlockControls,
+	InspectorControls,
 	transformStyles,
 	useBlockProps,
 	store as blockEditorStore,
@@ -18,6 +20,10 @@ import {
 	ToolbarGroup,
 	Modal,
 	Notice,
+	__experimentalToggleGroupControl as ToggleGroupControl,
+	__experimentalToggleGroupControlOption as ToggleGroupControlOption,
+	__experimentalToolsPanel as ToolsPanel,
+	__experimentalToolsPanelItem as ToolsPanelItem,
 } from '@wordpress/components';
 import { Stack } from '@wordpress/ui';
 import { fullscreen } from '@wordpress/icons';
@@ -32,6 +38,7 @@ import MonacoEditor, { type MonacoError } from '../components/monaco-editor';
 type HTMLEditProps = BlockEditProps< {
 	content: string;
 	height: number;
+	showPreviewByDefault: boolean;
 } > & {
 	// Injected by the block editor but not included in BlockEditProps.
 	toggleSelection: ( isSelectionEnabled: boolean ) => void;
@@ -55,15 +62,25 @@ export default function HTMLEdit( {
 	setAttributes,
 	toggleSelection,
 }: HTMLEditProps ) {
-	const { content, height } = attributes;
+	const { content, height, showPreviewByDefault } = attributes;
 	const { editorSettings, editorOptions } = window.chbeObj;
 
-	const [ isPreview, setIsPreview ] = useState< boolean >();
+	const [ isPreview, setIsPreview ] = useState< boolean >( showPreviewByDefault );
 	const [ isModalEditorOpen, setIsModalEditorOpen ] = useState< boolean >();
 
 	const [ errorMessage, setErrorMessage ] = useState< string >();
 
 	const ref = useRef< HTMLDivElement >( null );
+
+	const isMobile = useViewportMatch( 'medium', '<' );
+	const dropdownMenuProps = ! isMobile
+		? {
+				popoverProps: {
+					placement: 'left-start' as const,
+					offset: 259,
+				},
+		  }
+		: {};
 
 	const settingStyles = useSelect(
 		( select ) => select( blockEditorStore ).getSettings().styles,
@@ -117,6 +134,45 @@ export default function HTMLEdit( {
 
 	return (
 		<div { ...useBlockProps( { ref, className: 'block-library-html__edit' } ) }>
+			<InspectorControls>
+				<ToolsPanel
+					label={ __( 'Settings', 'custom-html-block-extension' ) }
+					resetAll={ () => setAttributes( { showPreviewByDefault: false } ) }
+					dropdownMenuProps={ dropdownMenuProps }
+				>
+					<ToolsPanelItem
+						isShownByDefault
+						label={ __( 'Default mode', 'custom-html-block-extension' ) }
+						hasValue={ () => showPreviewByDefault }
+						onDeselect={ () => setAttributes( { showPreviewByDefault: false } ) }
+					>
+						<ToggleGroupControl
+							__next40pxDefaultSize
+							isBlock
+							label={ __( 'Default mode', 'custom-html-block-extension' ) }
+							help={ __(
+								'The mode shown when the block first loads.',
+								'custom-html-block-extension'
+							) }
+							value={ showPreviewByDefault ? 'preview' : 'html' }
+							onChange={ ( value ) =>
+								setAttributes( {
+									showPreviewByDefault: value === 'preview',
+								} )
+							}
+						>
+							<ToggleGroupControlOption
+								value="html"
+								label={ __( 'HTML', 'custom-html-block-extension' ) }
+							/>
+							<ToggleGroupControlOption
+								value="preview"
+								label={ __( 'Preview', 'custom-html-block-extension' ) }
+							/>
+						</ToggleGroupControl>
+					</ToolsPanelItem>
+				</ToolsPanel>
+			</InspectorControls>
 			<BlockControls>
 				{ ! isPreview && (
 					<ToolbarGroup>

--- a/src/block-editor/edit.tsx
+++ b/src/block-editor/edit.tsx
@@ -201,7 +201,6 @@ export default function HTMLEdit( {
 					>
 						<ToggleGroupControl
 							__next40pxDefaultSize
-							__nextHasNoMarginBottom
 							isBlock
 							label={ __( 'Default mode', 'custom-html-block-extension' ) }
 							help={ __(

--- a/src/block-editor/edit.tsx
+++ b/src/block-editor/edit.tsx
@@ -4,10 +4,12 @@
 import { __ } from '@wordpress/i18n';
 import { useEffect, useState, useRef } from '@wordpress/element';
 import { useSelect, useDispatch, useRegistry } from '@wordpress/data';
+import { useViewportMatch } from '@wordpress/compose';
 import * as blockEditor from '@wordpress/block-editor';
 import {
 	BlockControls,
 	BlockIcon,
+	InspectorControls,
 	useBlockProps,
 	store as blockEditorStore,
 } from '@wordpress/block-editor';
@@ -19,6 +21,10 @@ import {
 	Modal,
 	Notice,
 	Placeholder,
+	__experimentalToggleGroupControl as ToggleGroupControl,
+	__experimentalToggleGroupControlOption as ToggleGroupControlOption,
+	__experimentalToolsPanel as ToolsPanel,
+	__experimentalToolsPanelItem as ToolsPanelItem,
 } from '@wordpress/components';
 import { Stack } from '@wordpress/ui';
 import { code, fullscreen } from '@wordpress/icons';
@@ -41,6 +47,7 @@ const { InnerContent } = __dangerousOptInToUnstableAPIsOnlyForCoreModules(
 type HTMLEditProps = BlockEditProps< {
 	content: string;
 	height: number;
+	showPreviewByDefault: boolean;
 } > & {
 	// Injected by the block editor but not included in BlockEditProps.
 	toggleSelection: ( isSelectionEnabled: boolean ) => void;
@@ -60,15 +67,26 @@ export default function HTMLEdit( {
 	setAttributes,
 	toggleSelection,
 }: HTMLEditProps ) {
-	const { height } = attributes;
+	const { height, showPreviewByDefault } = attributes;
 	const { editorSettings, editorOptions } = window.chbeObj;
 
-	const [ isPreview, setIsPreview ] = useState< boolean >();
+	const [ isPreview, setIsPreview ] = useState< boolean >( showPreviewByDefault );
 	const [ isModalEditorOpen, setIsModalEditorOpen ] = useState< boolean >();
 
 	const [ errorMessage, setErrorMessage ] = useState< string >();
 
 	const ref = useRef< HTMLDivElement >( null );
+
+	const isMobile = useViewportMatch( 'medium', '<' );
+	const dropdownMenuProps = ! isMobile
+		? {
+				popoverProps: {
+					placement: 'left-start' as const,
+					// ) - button width (24px) - border (1px) + padding (16px) + spacing (20px)
+					offset: 259,
+				},
+		  }
+		: {};
 
 	const registry = useRegistry();
 	const { updateBlock, replaceInnerBlocks } = useDispatch( blockEditorStore );
@@ -169,6 +187,46 @@ export default function HTMLEdit( {
 
 	return (
 		<div { ...useBlockProps( { ref, className: 'block-library-html__edit' } ) }>
+			<InspectorControls>
+				<ToolsPanel
+					label={ __( 'Settings', 'custom-html-block-extension' ) }
+					resetAll={ () => setAttributes( { showPreviewByDefault: false } ) }
+					dropdownMenuProps={ dropdownMenuProps }
+				>
+					<ToolsPanelItem
+						isShownByDefault
+						label={ __( 'Default mode', 'custom-html-block-extension' ) }
+						hasValue={ () => showPreviewByDefault }
+						onDeselect={ () => setAttributes( { showPreviewByDefault: false } ) }
+					>
+						<ToggleGroupControl
+							__next40pxDefaultSize
+							__nextHasNoMarginBottom
+							isBlock
+							label={ __( 'Default mode', 'custom-html-block-extension' ) }
+							help={ __(
+								'The mode shown when the block first loads.',
+								'custom-html-block-extension'
+							) }
+							value={ showPreviewByDefault ? 'preview' : 'html' }
+							onChange={ ( value ) =>
+								setAttributes( {
+									showPreviewByDefault: value === 'preview',
+								} )
+							}
+						>
+							<ToggleGroupControlOption
+								value="html"
+								label={ __( 'HTML', 'custom-html-block-extension' ) }
+							/>
+							<ToggleGroupControlOption
+								value="preview"
+								label={ __( 'Preview', 'custom-html-block-extension' ) }
+							/>
+						</ToggleGroupControl>
+					</ToolsPanelItem>
+				</ToolsPanel>
+			</InspectorControls>
 			<BlockControls>
 				{ ! isPreview && (
 					<ToolbarGroup>

--- a/src/block-editor/index.ts
+++ b/src/block-editor/index.ts
@@ -32,6 +32,10 @@ const customHtmlBlockExtension = ( settings: BlockConfiguration ): BlockConfigur
 				type: 'number',
 				default: 300,
 			},
+			showPreviewByDefault: {
+				type: 'boolean',
+				default: false,
+			},
 		},
 		edit: ( hasInnerContent ? edit : editLegacy ) as BlockConfiguration[ 'edit' ],
 	};

--- a/test/e2e/test.spec.ts
+++ b/test/e2e/test.spec.ts
@@ -3,66 +3,65 @@
  */
 import { test, expect } from '@wordpress/e2e-test-utils-playwright';
 
-test.describe( 'Custom HTML Block Extension', () => {
-	test.describe( 'Editor', () => {
-		test( 'input by Emmet should be expanded on the classic editor', async ( {
-			admin,
-			page,
-			requestUtils,
-		} ) => {
-			await admin.visitAdminPage( '' );
-			const wpPointerCloseButton = page.locator( '#wp-pointer-0 a.close' );
-			const isVisible = await wpPointerCloseButton.isVisible();
-			if ( isVisible ) {
-				await wpPointerCloseButton.click();
-			}
-			await requestUtils.activatePlugin( 'classic-editor' );
-			await admin.visitAdminPage( 'post-new.php' );
-			await page.click( '#content-tmce' );
-			await page.click( '#content-html' );
-			await page.click( '#monaco-editor .monaco-editor' );
-			await page.keyboard.type( 'p.selector' );
-			await page.keyboard.down( 'Tab' );
-			const textarea = await page.locator( '#wp-content-editor-container textarea.wp-editor-area' );
-			expect( textarea ).toHaveValue( '<p class="selector"></p>' );
-			await requestUtils.deactivatePlugin( 'classic-editor' );
-		} );
+test.describe( 'Editor', () => {
+	test( 'input by Emmet should be expanded on the classic editor', async ( {
+		admin,
+		page,
+		requestUtils,
+	} ) => {
+		await admin.visitAdminPage( '' );
+		const wpPointerCloseButton = page.locator( '#wp-pointer-0 a.close' );
+		const isVisible = await wpPointerCloseButton.isVisible();
+		if ( isVisible ) {
+			await wpPointerCloseButton.click();
+		}
+		await requestUtils.activatePlugin( 'classic-editor' );
+		await admin.visitAdminPage( 'post-new.php' );
+		await page.click( '#content-tmce' );
+		await page.click( '#content-html' );
+		await page.click( '#monaco-editor .monaco-editor' );
+		await page.keyboard.type( 'p.selector' );
+		await page.keyboard.down( 'Tab' );
+		const textarea = await page.locator( '#wp-content-editor-container textarea.wp-editor-area' );
+		expect( textarea ).toHaveValue( '<p class="selector"></p>' );
+		await requestUtils.deactivatePlugin( 'classic-editor' );
+	} );
 
-		test( 'input by Emmet should be expanded on the theme editor', async ( { admin, page } ) => {
-			await admin.visitAdminPage( 'theme-editor.php' );
-			// Hide file editor warning modal.
-			const dismissButton = page.locator( '.file-editor-warning-dismiss' );
-			const isVisible = await dismissButton.isVisible();
-			if ( isVisible ) {
-				await dismissButton.click();
-			}
-			await page.click( '#monaco-editor .monaco-editor' );
-			// Monaco maps its Ctrl/Cmd modifier from navigator.userAgent, so a
-			// "Macintosh" UA (e.g. Playwright's WebKit) needs Meta+A to select all.
-			const shortcut = await page.evaluate( () =>
-				window.navigator.userAgent.includes( 'Macintosh' ) ? 'Meta+a' : 'Control+a'
-			);
-			await page.keyboard.press( shortcut );
-			await page.keyboard.type( '.selector{fz100', { delay: 50 } );
-			await page.keyboard.press( 'Tab' );
-			const textarea = await page.locator( '#newcontent' );
-			expect( textarea ).toHaveValue( '.selector{font-size: 100px;}' );
-		} );
+	test( 'input by Emmet should be expanded on the theme editor', async ( { admin, page } ) => {
+		await admin.visitAdminPage( 'theme-editor.php' );
+		// Hide file editor warning modal.
+		const dismissButton = page.locator( '.file-editor-warning-dismiss' );
+		const isVisible = await dismissButton.isVisible();
+		if ( isVisible ) {
+			await dismissButton.click();
+		}
+		await page.click( '#monaco-editor .monaco-editor' );
+		// Monaco maps its Ctrl/Cmd modifier from navigator.userAgent, so a
+		// "Macintosh" UA (e.g. Playwright's WebKit) needs Meta+A to select all.
+		const shortcut = await page.evaluate( () =>
+			window.navigator.userAgent.includes( 'Macintosh' ) ? 'Meta+a' : 'Control+a'
+		);
+		await page.keyboard.press( shortcut );
+		await page.keyboard.type( '.selector{fz100', { delay: 50 } );
+		await page.keyboard.press( 'Tab' );
+		const textarea = await page.locator( '#newcontent' );
+		expect( textarea ).toHaveValue( '.selector{font-size: 100px;}' );
+	} );
 
-		test( 'input by Emmet should be expanded on the block editor', async ( {
-			admin,
-			page,
-			editor,
-		} ) => {
-			await admin.createNewPost();
-			await editor.insertBlock( { name: 'core/html' } );
-			await editor.canvas.locator( '[data-type="core/html"] .monaco-editor' ).click();
-			await page.keyboard.type( 'ul.list>li.item*5' );
-			await page.keyboard.down( 'Tab' );
-			const postContent = await editor.getEditedPostContent();
-			const replacedPostContent = postContent.replace( /\r\n/g, '\n' );
+	test( 'input by Emmet should be expanded on the block editor', async ( {
+		admin,
+		page,
+		editor,
+	} ) => {
+		await admin.createNewPost();
+		await editor.insertBlock( { name: 'core/html' } );
+		await editor.canvas.locator( '[data-type="core/html"] .monaco-editor' ).click();
+		await page.keyboard.type( 'ul.list>li.item*5' );
+		await page.keyboard.down( 'Tab' );
+		const postContent = await editor.getEditedPostContent();
+		const replacedPostContent = postContent.replace( /\r\n/g, '\n' );
 
-			expect( replacedPostContent ).toBe( `<!-- wp:html -->
+		expect( replacedPostContent ).toBe( `<!-- wp:html -->
 <ul class="list">
   <li class="item"></li>
   <li class="item"></li>
@@ -71,120 +70,119 @@ test.describe( 'Custom HTML Block Extension', () => {
   <li class="item"></li>
 </ul>
 <!-- /wp:html -->` );
-		} );
-
-		test( 'block should render in the default mode selected in the settings', async ( {
-			admin,
-			page,
-			editor,
-		} ) => {
-			await admin.createNewPost();
-			await editor.insertBlock( { name: 'core/html' } );
-
-			// A block starts in the HTML editing mode.
-			await expect(
-				page.getByRole( 'button', { name: 'HTML', exact: true, pressed: true } )
-			).toBeVisible();
-
-			// Switch the default mode to Preview.
-			// TODO: Always click the Settings tab once the minimum supported version
-			// is 7.1, where the block always has inner blocks and thus the tab.
-			await editor.openDocumentSettingsSidebar();
-			const settingsTab = page.getByRole( 'tab', { name: 'Settings' } );
-			if ( await settingsTab.isVisible() ) {
-				await settingsTab.click();
-			}
-			await page
-				.getByRole( 'radiogroup', { name: 'Default mode' } )
-				.getByRole( 'radio', { name: 'Preview' } )
-				.click();
-
-			// The default mode is only applied when the block mounts, so re-render
-			// it by switching the editor to the code mode and back.
-			await page.evaluate( () =>
-				( window.wp as any ).data.dispatch( 'core/editor' ).switchEditorMode( 'text' )
-			);
-			await page.evaluate( () =>
-				( window.wp as any ).data.dispatch( 'core/editor' ).switchEditorMode( 'visual' )
-			);
-
-			// Select the re-rendered block to reveal its toolbar.
-			await editor.canvas.getByRole( 'document', { name: 'Block: Custom HTML' } ).click();
-
-			// The block now starts in the Preview mode.
-			await expect(
-				page.getByRole( 'button', { name: 'Preview', exact: true, pressed: true } )
-			).toBeVisible();
-		} );
 	} );
 
-	test.describe( 'Settings page', () => {
-		test( 'should be rendered', async ( { admin, page } ) => {
-			await admin.visitAdminPage( 'options-general.php?page=custom-html-block-extension' );
-			// Hide welcome guide.
-			const welcomeGuide = page.getByRole( 'dialog', {
-				name: 'About Custom HTML Block Extension',
-			} );
-			const isVisible = await welcomeGuide.isVisible();
-			if ( isVisible ) {
-				await welcomeGuide.getByRole( 'button', { name: 'Close' } ).click();
-			}
+	test( 'block should render in the default mode selected in the settings', async ( {
+		admin,
+		page,
+		editor,
+	} ) => {
+		await admin.createNewPost();
+		await editor.insertBlock( { name: 'core/html' } );
 
-			// Editsor config tab
-			await expect( page.getByRole( 'button', { name: 'Save settings' } ) ).toBeVisible();
-			// Tools tab
-			await page.getByRole( 'tab', { name: 'Tools' } ).click();
-			await expect( page.getByRole( 'button', { name: 'Export', exact: true } ) ).toBeVisible();
-			// Options tab
-			await page.getByRole( 'tab', { name: 'Options' } ).click();
-			await expect( page.getByRole( 'button', { name: 'Save Options' } ) ).toBeVisible();
+		// A block starts in the HTML editing mode.
+		await expect(
+			page.getByRole( 'button', { name: 'HTML', exact: true, pressed: true } )
+		).toBeVisible();
+
+		// Switch the default mode to Preview.
+		// TODO: Always click the Settings tab once the minimum supported version
+		// is 7.1, where the block always has inner blocks and thus the tab.
+		await editor.openDocumentSettingsSidebar();
+		const settingsTab = page.getByRole( 'tab', { name: 'Settings' } );
+		if ( await settingsTab.isVisible() ) {
+			await settingsTab.click();
+		}
+		await page
+			.getByRole( 'radiogroup', { name: 'Default mode' } )
+			.getByRole( 'radio', { name: 'Preview' } )
+			.click();
+
+		// The default mode is only applied when the block mounts, so re-render
+		// it by switching the editor to the code mode and back.
+		await page.evaluate( () =>
+			( window.wp as any ).data.dispatch( 'core/editor' ).switchEditorMode( 'text' )
+		);
+		await page.evaluate( () =>
+			( window.wp as any ).data.dispatch( 'core/editor' ).switchEditorMode( 'visual' )
+		);
+
+		// Select the re-rendered block to reveal its toolbar.
+		await editor.canvas.getByRole( 'document', { name: 'Block: Custom HTML' } ).click();
+
+		// The block now starts in the Preview mode.
+		await expect(
+			page.getByRole( 'button', { name: 'Preview', exact: true, pressed: true } )
+		).toBeVisible();
+	} );
+} );
+
+test.describe( 'Settings page', () => {
+	test( 'should be rendered', async ( { admin, page } ) => {
+		await admin.visitAdminPage( 'options-general.php?page=custom-html-block-extension' );
+		// Hide welcome guide.
+		const welcomeGuide = page.getByRole( 'dialog', {
+			name: 'About Custom HTML Block Extension',
+		} );
+		const isVisible = await welcomeGuide.isVisible();
+		if ( isVisible ) {
+			await welcomeGuide.getByRole( 'button', { name: 'Close' } ).click();
+		}
+
+		// Editsor config tab
+		await expect( page.getByRole( 'button', { name: 'Save settings' } ) ).toBeVisible();
+		// Tools tab
+		await page.getByRole( 'tab', { name: 'Tools' } ).click();
+		await expect( page.getByRole( 'button', { name: 'Export', exact: true } ) ).toBeVisible();
+		// Options tab
+		await page.getByRole( 'tab', { name: 'Options' } ).click();
+		await expect( page.getByRole( 'button', { name: 'Save Options' } ) ).toBeVisible();
+	} );
+
+	test( 'tab focus mode should move focus out of the code editor', async ( { admin, page } ) => {
+		await admin.visitAdminPage( 'options-general.php?page=custom-html-block-extension' );
+		// Hide welcome guide.
+		const welcomeGuide = page.getByRole( 'dialog', {
+			name: 'About Custom HTML Block Extension',
+		} );
+		if ( await welcomeGuide.isVisible() ) {
+			await welcomeGuide.getByRole( 'button', { name: 'Close' } ).click();
+		}
+
+		const editor = page.locator( '.chbe-admin-editor-config-editor-preview .monaco-editor' );
+		const textbox = editor.getByRole( 'textbox', {
+			name: /^Editor content\. To change the Tab key behavior, press Ctrl\+(Shift\+)?M\.$/,
 		} );
 
-		test( 'tab focus mode should move focus out of the code editor', async ( { admin, page } ) => {
-			await admin.visitAdminPage( 'options-general.php?page=custom-html-block-extension' );
-			// Hide welcome guide.
-			const welcomeGuide = page.getByRole( 'dialog', {
-				name: 'About Custom HTML Block Extension',
-			} );
-			if ( await welcomeGuide.isVisible() ) {
-				await welcomeGuide.getByRole( 'button', { name: 'Close' } ).click();
+		await editor.click();
+		await expect( textbox ).toBeFocused();
+
+		// While tab focus mode is disabled, Tab stays inside the editor.
+		await page.keyboard.press( 'Tab' );
+		await expect( textbox ).toBeFocused();
+
+		// The plugin picks the combo from navigator.platform (isAppleOS), while
+		// Monaco maps Ctrl/Cmd from navigator.userAgent ("Macintosh" => Meta).
+		const shortcut = await page.evaluate( () => {
+			const { platform, userAgent } = window.navigator;
+			const isAppleOS =
+				platform.indexOf( 'Mac' ) !== -1 || [ 'iPad', 'iPhone' ].includes( platform );
+			if ( isAppleOS ) {
+				return 'Control+Shift+m';
 			}
-
-			const editor = page.locator( '.chbe-admin-editor-config-editor-preview .monaco-editor' );
-			const textbox = editor.getByRole( 'textbox', {
-				name: /^Editor content\. To change the Tab key behavior, press Ctrl\+(Shift\+)?M\.$/,
-			} );
-
-			await editor.click();
-			await expect( textbox ).toBeFocused();
-
-			// While tab focus mode is disabled, Tab stays inside the editor.
-			await page.keyboard.press( 'Tab' );
-			await expect( textbox ).toBeFocused();
-
-			// The plugin picks the combo from navigator.platform (isAppleOS), while
-			// Monaco maps Ctrl/Cmd from navigator.userAgent ("Macintosh" => Meta).
-			const shortcut = await page.evaluate( () => {
-				const { platform, userAgent } = window.navigator;
-				const isAppleOS =
-					platform.indexOf( 'Mac' ) !== -1 || [ 'iPad', 'iPhone' ].includes( platform );
-				if ( isAppleOS ) {
-					return 'Control+Shift+m';
-				}
-				return userAgent.includes( 'Macintosh' ) ? 'Meta+m' : 'Control+m';
-			} );
-
-			// Toggle tab focus mode.
-			await page.keyboard.press( shortcut );
-
-			// The change should be announced to screen readers.
-			await expect( page.getByRole( 'button', { name: 'Dismiss this notice' } ) ).toContainText(
-				'Pressing Tab will now move focus to the next focusable element.'
-			);
-
-			// Tab should move focus out of the editor to the Save settings button.
-			await page.keyboard.press( 'Tab' );
-			await expect( page.getByRole( 'button', { name: 'Save settings' } ) ).toBeFocused();
+			return userAgent.includes( 'Macintosh' ) ? 'Meta+m' : 'Control+m';
 		} );
+
+		// Toggle tab focus mode.
+		await page.keyboard.press( shortcut );
+
+		// The change should be announced to screen readers.
+		await expect( page.getByRole( 'button', { name: 'Dismiss this notice' } ) ).toContainText(
+			'Pressing Tab will now move focus to the next focusable element.'
+		);
+
+		// Tab should move focus out of the editor to the Save settings button.
+		await page.keyboard.press( 'Tab' );
+		await expect( page.getByRole( 'button', { name: 'Save settings' } ) ).toBeFocused();
 	} );
 } );

--- a/test/e2e/test.spec.ts
+++ b/test/e2e/test.spec.ts
@@ -72,6 +72,50 @@ test.describe( 'Custom HTML Block Extension', () => {
 </ul>
 <!-- /wp:html -->` );
 		} );
+
+		test( 'block should render in the default mode selected in the settings', async ( {
+			admin,
+			page,
+			editor,
+		} ) => {
+			await admin.createNewPost();
+			await editor.insertBlock( { name: 'core/html' } );
+
+			// A block starts in the HTML editing mode.
+			await expect(
+				page.getByRole( 'button', { name: 'HTML', exact: true, pressed: true } )
+			).toBeVisible();
+
+			// Switch the default mode to Preview.
+			// TODO: Always click the Settings tab once the minimum supported version
+			// is 7.1, where the block always has inner blocks and thus the tab.
+			await editor.openDocumentSettingsSidebar();
+			const settingsTab = page.getByRole( 'tab', { name: 'Settings' } );
+			if ( await settingsTab.isVisible() ) {
+				await settingsTab.click();
+			}
+			await page
+				.getByRole( 'radiogroup', { name: 'Default mode' } )
+				.getByRole( 'radio', { name: 'Preview' } )
+				.click();
+
+			// The default mode is only applied when the block mounts, so re-render
+			// it by switching the editor to the code mode and back.
+			await page.evaluate( () =>
+				( window.wp as any ).data.dispatch( 'core/editor' ).switchEditorMode( 'text' )
+			);
+			await page.evaluate( () =>
+				( window.wp as any ).data.dispatch( 'core/editor' ).switchEditorMode( 'visual' )
+			);
+
+			// Select the re-rendered block to reveal its toolbar.
+			await editor.canvas.getByRole( 'document', { name: 'Block: Custom HTML' } ).click();
+
+			// The block now starts in the Preview mode.
+			await expect(
+				page.getByRole( 'button', { name: 'Preview', exact: true, pressed: true } )
+			).toBeVisible();
+		} );
 	} );
 
 	test.describe( 'Settings page', () => {


### PR DESCRIPTION
Fixes #183

The Custom HTML block always opens in HTML editing mode. Some users prefer to see the rendered result as soon as the block loads, so this adds a per-block setting to choose the initial mode.

A new "Default mode" control in the inspector (`ToolsPanel` / `ToolsPanelItem` with a `ToggleGroupControl`) lets each block start in either HTML or Preview mode. It is backed by a `showPreviewByDefault` attribute (default `false`) that initializes the block's preview state on load, and is wired into both the current and legacy Edit implementations.
