### PR TITLE
Fix Dependabot alerts via npm audit fix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -49,20 +49,6 @@
 				"npm": ">=11.0.0"
 			}
 		},
-		"node_modules/@ampproject/remapping": {
-			"version": "2.3.0",
-			"resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.3.0.tgz",
-			"integrity": "sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@jridgewell/gen-mapping": "^0.3.5",
-				"@jridgewell/trace-mapping": "^0.3.24"
-			},
-			"engines": {
-				"node": ">=6.0.0"
-			}
-		},
 		"node_modules/@ariakit/components": {
 			"version": "0.1.7",
 			"resolved": "https://registry.npmjs.org/@ariakit/components/-/components-0.1.7.tgz",
@@ -195,9 +181,9 @@
 			}
 		},
 		"node_modules/@babel/compat-data": {
-			"version": "7.29.0",
-			"resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.0.tgz",
-			"integrity": "sha512-T1NCJqT/j9+cn8fvkt7jtwbLBfLC/1y1c7NtCeXFRgzGTsafi68MRv8yzkYSapBnFA6L3U2VSc02ciDzoAJhJg==",
+			"version": "7.29.7",
+			"resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.7.tgz",
+			"integrity": "sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -205,22 +191,22 @@
 			}
 		},
 		"node_modules/@babel/core": {
-			"version": "7.25.7",
-			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.25.7.tgz",
-			"integrity": "sha512-yJ474Zv3cwiSOO9nXJuqzvwEeM+chDuQ8GJirw+pZ91sCGCyOZ3dJkVE09fTV0VEVzXyLWhh3G/AolYTPX7Mow==",
+			"version": "7.29.7",
+			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.7.tgz",
+			"integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@ampproject/remapping": "^2.2.0",
-				"@babel/code-frame": "^7.25.7",
-				"@babel/generator": "^7.25.7",
-				"@babel/helper-compilation-targets": "^7.25.7",
-				"@babel/helper-module-transforms": "^7.25.7",
-				"@babel/helpers": "^7.25.7",
-				"@babel/parser": "^7.25.7",
-				"@babel/template": "^7.25.7",
-				"@babel/traverse": "^7.25.7",
-				"@babel/types": "^7.25.7",
+				"@babel/code-frame": "^7.29.7",
+				"@babel/generator": "^7.29.7",
+				"@babel/helper-compilation-targets": "^7.29.7",
+				"@babel/helper-module-transforms": "^7.29.7",
+				"@babel/helpers": "^7.29.7",
+				"@babel/parser": "^7.29.7",
+				"@babel/template": "^7.29.7",
+				"@babel/traverse": "^7.29.7",
+				"@babel/types": "^7.29.7",
+				"@jridgewell/remapping": "^2.3.5",
 				"convert-source-map": "^2.0.0",
 				"debug": "^4.1.0",
 				"gensync": "^1.0.0-beta.2",
@@ -303,14 +289,14 @@
 			}
 		},
 		"node_modules/@babel/helper-compilation-targets": {
-			"version": "7.28.6",
-			"resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.28.6.tgz",
-			"integrity": "sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA==",
+			"version": "7.29.7",
+			"resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.29.7.tgz",
+			"integrity": "sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@babel/compat-data": "^7.28.6",
-				"@babel/helper-validator-option": "^7.27.1",
+				"@babel/compat-data": "^7.29.7",
+				"@babel/helper-validator-option": "^7.29.7",
 				"browserslist": "^4.24.0",
 				"lru-cache": "^5.1.1",
 				"semver": "^6.3.1"
@@ -433,15 +419,15 @@
 			}
 		},
 		"node_modules/@babel/helper-module-transforms": {
-			"version": "7.28.6",
-			"resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.28.6.tgz",
-			"integrity": "sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA==",
+			"version": "7.29.7",
+			"resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.29.7.tgz",
+			"integrity": "sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@babel/helper-module-imports": "^7.28.6",
-				"@babel/helper-validator-identifier": "^7.28.5",
-				"@babel/traverse": "^7.28.6"
+				"@babel/helper-module-imports": "^7.29.7",
+				"@babel/helper-validator-identifier": "^7.29.7",
+				"@babel/traverse": "^7.29.7"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -544,9 +530,9 @@
 			}
 		},
 		"node_modules/@babel/helper-validator-option": {
-			"version": "7.27.1",
-			"resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.27.1.tgz",
-			"integrity": "sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==",
+			"version": "7.29.7",
+			"resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.29.7.tgz",
+			"integrity": "sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -569,14 +555,14 @@
 			}
 		},
 		"node_modules/@babel/helpers": {
-			"version": "7.28.6",
-			"resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.28.6.tgz",
-			"integrity": "sha512-xOBvwq86HHdB7WUDTfKfT/Vuxh7gElQ+Sfti2Cy6yIWNW05P8iUslOVcZ4/sKbE+/jQaukQAdz/gf3724kYdqw==",
+			"version": "7.29.7",
+			"resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.7.tgz",
+			"integrity": "sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@babel/template": "^7.28.6",
-				"@babel/types": "^7.28.6"
+				"@babel/template": "^7.29.7",
+				"@babel/types": "^7.29.7"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -3923,38 +3909,6 @@
 				}
 			}
 		},
-		"node_modules/@jest/core/node_modules/@babel/core": {
-			"version": "7.29.0",
-			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
-			"integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
-			"dev": true,
-			"license": "MIT",
-			"peer": true,
-			"dependencies": {
-				"@babel/code-frame": "^7.29.0",
-				"@babel/generator": "^7.29.0",
-				"@babel/helper-compilation-targets": "^7.28.6",
-				"@babel/helper-module-transforms": "^7.28.6",
-				"@babel/helpers": "^7.28.6",
-				"@babel/parser": "^7.29.0",
-				"@babel/template": "^7.28.6",
-				"@babel/traverse": "^7.29.0",
-				"@babel/types": "^7.29.0",
-				"@jridgewell/remapping": "^2.3.5",
-				"convert-source-map": "^2.0.0",
-				"debug": "^4.1.0",
-				"gensync": "^1.0.0-beta.2",
-				"json5": "^2.2.3",
-				"semver": "^6.3.1"
-			},
-			"engines": {
-				"node": ">=6.9.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/babel"
-			}
-		},
 		"node_modules/@jest/core/node_modules/@jest/schemas": {
 			"version": "30.0.5",
 			"resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-30.0.5.tgz",
@@ -4044,25 +3998,6 @@
 			},
 			"engines": {
 				"node": ">=12"
-			}
-		},
-		"node_modules/@jest/core/node_modules/debug": {
-			"version": "4.4.3",
-			"resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
-			"integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-			"dev": true,
-			"license": "MIT",
-			"peer": true,
-			"dependencies": {
-				"ms": "^2.1.3"
-			},
-			"engines": {
-				"node": ">=6.0"
-			},
-			"peerDependenciesMeta": {
-				"supports-color": {
-					"optional": true
-				}
 			}
 		},
 		"node_modules/@jest/core/node_modules/istanbul-lib-instrument": {
@@ -4726,38 +4661,6 @@
 				}
 			}
 		},
-		"node_modules/@jest/reporters/node_modules/@babel/core": {
-			"version": "7.29.0",
-			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
-			"integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
-			"dev": true,
-			"license": "MIT",
-			"peer": true,
-			"dependencies": {
-				"@babel/code-frame": "^7.29.0",
-				"@babel/generator": "^7.29.0",
-				"@babel/helper-compilation-targets": "^7.28.6",
-				"@babel/helper-module-transforms": "^7.28.6",
-				"@babel/helpers": "^7.28.6",
-				"@babel/parser": "^7.29.0",
-				"@babel/template": "^7.28.6",
-				"@babel/traverse": "^7.29.0",
-				"@babel/types": "^7.29.0",
-				"@jridgewell/remapping": "^2.3.5",
-				"convert-source-map": "^2.0.0",
-				"debug": "^4.1.0",
-				"gensync": "^1.0.0-beta.2",
-				"json5": "^2.2.3",
-				"semver": "^6.3.1"
-			},
-			"engines": {
-				"node": ">=6.9.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/babel"
-			}
-		},
 		"node_modules/@jest/reporters/node_modules/@jest/schemas": {
 			"version": "30.0.5",
 			"resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-30.0.5.tgz",
@@ -4850,33 +4753,14 @@
 			}
 		},
 		"node_modules/@jest/reporters/node_modules/brace-expansion": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-			"integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
+			"integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
 			"dev": true,
 			"license": "MIT",
 			"peer": true,
 			"dependencies": {
 				"balanced-match": "^1.0.0"
-			}
-		},
-		"node_modules/@jest/reporters/node_modules/debug": {
-			"version": "4.4.3",
-			"resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
-			"integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-			"dev": true,
-			"license": "MIT",
-			"peer": true,
-			"dependencies": {
-				"ms": "^2.1.3"
-			},
-			"engines": {
-				"node": ">=6.0"
-			},
-			"peerDependenciesMeta": {
-				"supports-color": {
-					"optional": true
-				}
 			}
 		},
 		"node_modules/@jest/reporters/node_modules/glob": {
@@ -5374,7 +5258,6 @@
 			"integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@jridgewell/gen-mapping": "^0.3.5",
 				"@jridgewell/trace-mapping": "^0.3.24"
@@ -5492,9 +5375,9 @@
 			}
 		},
 		"node_modules/@nodable/entities": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-2.1.0.tgz",
-			"integrity": "sha512-nyT7T3nbMyBI/lvr6L5TyWbFJAI9FTgVRakNoBqCD+PmID8DzFrrNdLLtHMwMszOtqZa8PAOV24ZqDnQrhQINA==",
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-3.0.0.tgz",
+			"integrity": "sha512-8L9xFeTYKhm49xfIypoe2W5wV1m/3Z58kT+7kR9A8OyFxcPduI4VmxaUMQyKYrRjUoLLSXv6EKKID5Tvj9cUVw==",
 			"dev": true,
 			"funding": [
 				{
@@ -7048,14 +6931,14 @@
 			}
 		},
 		"node_modules/@php-wasm/cli-util": {
-			"version": "3.1.2",
-			"resolved": "https://registry.npmjs.org/@php-wasm/cli-util/-/cli-util-3.1.2.tgz",
-			"integrity": "sha512-pUUbACHsrFc2QSNqKEhiFhwCD1dbroH8/14hQYW+lcgswG10sqMMgfmk7FBp61jTntXdweYhNFjcoIOMV3h0OA==",
+			"version": "3.1.45",
+			"resolved": "https://registry.npmjs.org/@php-wasm/cli-util/-/cli-util-3.1.45.tgz",
+			"integrity": "sha512-+ht22B6KPUsn5ORtApE5xYq+uIb7/Qv/NSOxYgNGSWf3O1rpxkbOMeCxtE7H3dvazJIlSF+/nsVHpHkcTZGOpA==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@php-wasm/util": "3.1.2",
-				"fast-xml-parser": "^5.3.4",
+				"@php-wasm/util": "3.1.45",
+				"fast-xml-parser": "^5.8.0",
 				"jsonc-parser": "3.3.1"
 			},
 			"engines": {
@@ -7063,68 +6946,54 @@
 				"npm": ">=10.2.3"
 			}
 		},
-		"node_modules/@php-wasm/fs-journal": {
-			"version": "3.1.2",
-			"resolved": "https://registry.npmjs.org/@php-wasm/fs-journal/-/fs-journal-3.1.2.tgz",
-			"integrity": "sha512-8e8lz/IG6EA8h2/lGSOijdhemaABTt45zohhMYYSjuCu5fV24p+6rGkK7I+dGqxaY4cO2IDjU4XE+HRnodW88g==",
-			"dev": true,
-			"license": "GPL-2.0-or-later",
-			"dependencies": {
-				"@php-wasm/logger": "3.1.2",
-				"@php-wasm/node": "3.1.2",
-				"@php-wasm/universal": "3.1.2",
-				"@php-wasm/util": "3.1.2",
-				"express": "4.22.0",
-				"fs-ext-extra-prebuilt": "2.2.7",
-				"ini": "4.1.2",
-				"wasm-feature-detect": "1.8.0",
-				"ws": "8.18.3",
-				"yargs": "17.7.2"
-			},
-			"engines": {
-				"node": ">=20.10.0",
-				"npm": ">=10.2.3"
-			}
-		},
 		"node_modules/@php-wasm/logger": {
-			"version": "3.1.2",
-			"resolved": "https://registry.npmjs.org/@php-wasm/logger/-/logger-3.1.2.tgz",
-			"integrity": "sha512-VD1SbuTL24LgbkPaQCijDzc9V7SSVU5hi+up4yNpHeL8pP8kabIYYSR7PgTfity1Awk6ctW5kUpOhSieD+1Btw==",
+			"version": "3.1.45",
+			"resolved": "https://registry.npmjs.org/@php-wasm/logger/-/logger-3.1.45.tgz",
+			"integrity": "sha512-FYWGxaRZTM+aiRQ6/LlnFAdsixJ7VWQpM8Fe/61yWgpBamb1w3NEDRhYVR5DNjYWJVI5ha6pVxIsHtw018iA7g==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
-			"dependencies": {
-				"@php-wasm/node-polyfills": "3.1.2"
-			},
 			"engines": {
 				"node": ">=20.10.0",
 				"npm": ">=10.2.3"
 			}
 		},
 		"node_modules/@php-wasm/node": {
-			"version": "3.1.2",
-			"resolved": "https://registry.npmjs.org/@php-wasm/node/-/node-3.1.2.tgz",
-			"integrity": "sha512-Y/I2nUjo1Aof4irF1cfAxX33Ra5xa2HQcy3HmIXXurqTBE7bZMu5TKvJW7t0cfBLohuaWY1bs8n4nLS1BetuTg==",
+			"version": "3.1.45",
+			"resolved": "https://registry.npmjs.org/@php-wasm/node/-/node-3.1.45.tgz",
+			"integrity": "sha512-IFnGdNsQ0g8RwpFzg3gAt8VckFwshQ7g2Izwt+i+wi2Rtnj54DcPZpfMwliiq+c1XU1//jtXHBdczbwR75yW7A==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@php-wasm/logger": "3.1.2",
-				"@php-wasm/node-7-4": "3.1.2",
-				"@php-wasm/node-8-0": "3.1.2",
-				"@php-wasm/node-8-1": "3.1.2",
-				"@php-wasm/node-8-2": "3.1.2",
-				"@php-wasm/node-8-3": "3.1.2",
-				"@php-wasm/node-8-4": "3.1.2",
-				"@php-wasm/node-8-5": "3.1.2",
-				"@php-wasm/node-polyfills": "3.1.2",
-				"@php-wasm/universal": "3.1.2",
-				"@php-wasm/util": "3.1.2",
-				"@wp-playground/common": "3.1.2",
-				"express": "4.22.0",
+				"@php-wasm/cli-util": "3.1.45",
+				"@php-wasm/logger": "3.1.45",
+				"@php-wasm/node-5-2": "3.1.45",
+				"@php-wasm/node-7-4": "3.1.45",
+				"@php-wasm/node-8-0": "3.1.45",
+				"@php-wasm/node-8-1": "3.1.45",
+				"@php-wasm/node-8-2": "3.1.45",
+				"@php-wasm/node-8-3": "3.1.45",
+				"@php-wasm/node-8-4": "3.1.45",
+				"@php-wasm/node-8-5": "3.1.45",
+				"@php-wasm/universal": "3.1.45",
+				"@php-wasm/util": "3.1.45",
 				"fs-ext-extra-prebuilt": "2.2.7",
-				"ini": "4.1.2",
 				"wasm-feature-detect": "1.8.0",
-				"ws": "8.18.3",
-				"yargs": "17.7.2"
+				"ws": "8.21.0"
+			},
+			"engines": {
+				"node": ">=20.10.0",
+				"npm": ">=10.2.3"
+			}
+		},
+		"node_modules/@php-wasm/node-5-2": {
+			"version": "3.1.45",
+			"resolved": "https://registry.npmjs.org/@php-wasm/node-5-2/-/node-5-2-3.1.45.tgz",
+			"integrity": "sha512-mKYOI8/eWE7Gu9wOOwtcxGrhOfCfGlIqT3Jr1RK0qCsZ/GkiW2/EalsNC5wSWbaL9qdh4JUbXUoF7mE3dc+KRQ==",
+			"dev": true,
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@php-wasm/universal": "3.1.45",
+				"wasm-feature-detect": "1.8.0"
 			},
 			"engines": {
 				"node": ">=20.10.0",
@@ -7132,16 +7001,14 @@
 			}
 		},
 		"node_modules/@php-wasm/node-7-4": {
-			"version": "3.1.2",
-			"resolved": "https://registry.npmjs.org/@php-wasm/node-7-4/-/node-7-4-3.1.2.tgz",
-			"integrity": "sha512-n8QjH2/PiJV28Ad9a4jn/3Rq1cVU3bD+8+4aDOyEbhwxl9Qvb6NvSqMER/3KqasH5cvZiZLsMy92+q+CjcIQAA==",
+			"version": "3.1.45",
+			"resolved": "https://registry.npmjs.org/@php-wasm/node-7-4/-/node-7-4-3.1.45.tgz",
+			"integrity": "sha512-3+VgXIL4y4Acb/OyNQAsIfz5I5GYlFmjw4M8l2Xx8TNBrixuOEO5vHmMoTssynZlmjoTLxBBzL2SaRHoubwi6g==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@php-wasm/universal": "3.1.2",
-				"ini": "4.1.2",
-				"wasm-feature-detect": "1.8.0",
-				"ws": "8.18.3"
+				"@php-wasm/universal": "3.1.45",
+				"wasm-feature-detect": "1.8.0"
 			},
 			"engines": {
 				"node": ">=20.10.0",
@@ -7149,16 +7016,14 @@
 			}
 		},
 		"node_modules/@php-wasm/node-8-0": {
-			"version": "3.1.2",
-			"resolved": "https://registry.npmjs.org/@php-wasm/node-8-0/-/node-8-0-3.1.2.tgz",
-			"integrity": "sha512-sNSk858peKueucrNKAKbZ094XJOsP8AcK+XLM1KjS+VNoT5aVNC5xzZnQhArxCI6lZqkUhvmGqV1DNEdmX/ayA==",
+			"version": "3.1.45",
+			"resolved": "https://registry.npmjs.org/@php-wasm/node-8-0/-/node-8-0-3.1.45.tgz",
+			"integrity": "sha512-6yJaW+mxgBWAy80IYRU41bh1LH4WsuDgqEWiHSumJcKOcNljSedUbm+YuLTY+Pnsov7u5yzkaBskslxGXcOlIQ==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@php-wasm/universal": "3.1.2",
-				"ini": "4.1.2",
-				"wasm-feature-detect": "1.8.0",
-				"ws": "8.18.3"
+				"@php-wasm/universal": "3.1.45",
+				"wasm-feature-detect": "1.8.0"
 			},
 			"engines": {
 				"node": ">=20.10.0",
@@ -7166,16 +7031,14 @@
 			}
 		},
 		"node_modules/@php-wasm/node-8-1": {
-			"version": "3.1.2",
-			"resolved": "https://registry.npmjs.org/@php-wasm/node-8-1/-/node-8-1-3.1.2.tgz",
-			"integrity": "sha512-HDfA0+uMhZEMFAeryN/kkCbcuW5Bv11liCuwxxwGdNj21NxRVFoDhYYm1FKyFPTbZWHemSJXkpZgyh4g2HfL5w==",
+			"version": "3.1.45",
+			"resolved": "https://registry.npmjs.org/@php-wasm/node-8-1/-/node-8-1-3.1.45.tgz",
+			"integrity": "sha512-/5haLrmCySu40aDGtVAOukDBNYzCJ0JTXslXs36Rh8P9V2nlctVGO+Kp1m/74yCtdoJrZsRrBnVqKBCliVQjdg==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@php-wasm/universal": "3.1.2",
-				"ini": "4.1.2",
-				"wasm-feature-detect": "1.8.0",
-				"ws": "8.18.3"
+				"@php-wasm/universal": "3.1.45",
+				"wasm-feature-detect": "1.8.0"
 			},
 			"engines": {
 				"node": ">=20.10.0",
@@ -7183,16 +7046,14 @@
 			}
 		},
 		"node_modules/@php-wasm/node-8-2": {
-			"version": "3.1.2",
-			"resolved": "https://registry.npmjs.org/@php-wasm/node-8-2/-/node-8-2-3.1.2.tgz",
-			"integrity": "sha512-+225WZUAf4foAr+DT9ahS7Rna3h7DslI9anrWShR7a8FxAaCUgi0dw4Rh2can2K0/Q+moC3l2OZC93NIhedsuw==",
+			"version": "3.1.45",
+			"resolved": "https://registry.npmjs.org/@php-wasm/node-8-2/-/node-8-2-3.1.45.tgz",
+			"integrity": "sha512-fGsSHw6OTnNyjr6k87OqV8SYqRZlDrWYVSXFkOywXUbBvyAYeuttxHffYC4VoRZdRz+Ygu+2k2aPE06jpTTBFw==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@php-wasm/universal": "3.1.2",
-				"ini": "4.1.2",
-				"wasm-feature-detect": "1.8.0",
-				"ws": "8.18.3"
+				"@php-wasm/universal": "3.1.45",
+				"wasm-feature-detect": "1.8.0"
 			},
 			"engines": {
 				"node": ">=20.10.0",
@@ -7200,16 +7061,14 @@
 			}
 		},
 		"node_modules/@php-wasm/node-8-3": {
-			"version": "3.1.2",
-			"resolved": "https://registry.npmjs.org/@php-wasm/node-8-3/-/node-8-3-3.1.2.tgz",
-			"integrity": "sha512-fRncog0ai610bhzFmSYXq5N3vaVoZNAU0GxhzcKXGsPF4x5o07wViMClyqXpxcqn+KC4RhV4YK5hCGhGvzEvkA==",
+			"version": "3.1.45",
+			"resolved": "https://registry.npmjs.org/@php-wasm/node-8-3/-/node-8-3-3.1.45.tgz",
+			"integrity": "sha512-dq22w7k6zxSgRKEjFej2k2etHpWA/f6UZFQCwi0qPFTejlVRfGqJoY+6gwtF4PCCGXGD7J36XyRuSFuZz833MA==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@php-wasm/universal": "3.1.2",
-				"ini": "4.1.2",
-				"wasm-feature-detect": "1.8.0",
-				"ws": "8.18.3"
+				"@php-wasm/universal": "3.1.45",
+				"wasm-feature-detect": "1.8.0"
 			},
 			"engines": {
 				"node": ">=20.10.0",
@@ -7217,16 +7076,14 @@
 			}
 		},
 		"node_modules/@php-wasm/node-8-4": {
-			"version": "3.1.2",
-			"resolved": "https://registry.npmjs.org/@php-wasm/node-8-4/-/node-8-4-3.1.2.tgz",
-			"integrity": "sha512-3J5tnLJwmmZrX/bHiCA/nbBhMMC58kWhX8v62B2LB+Hx7zq2agSETaga1tk4RzbIrs85noq4tuPUng9yAsSkHw==",
+			"version": "3.1.45",
+			"resolved": "https://registry.npmjs.org/@php-wasm/node-8-4/-/node-8-4-3.1.45.tgz",
+			"integrity": "sha512-QElunKrFEpVa11Fdr6Afmw/gI/bCf5rxzAuXLBYfgghJP2w8sTT0M1ku1pocPEvMGeONbQgvHA06sDdKXhHEMA==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@php-wasm/universal": "3.1.2",
-				"ini": "4.1.2",
-				"wasm-feature-detect": "1.8.0",
-				"ws": "8.18.3"
+				"@php-wasm/universal": "3.1.45",
+				"wasm-feature-detect": "1.8.0"
 			},
 			"engines": {
 				"node": ">=20.10.0",
@@ -7234,38 +7091,28 @@
 			}
 		},
 		"node_modules/@php-wasm/node-8-5": {
-			"version": "3.1.2",
-			"resolved": "https://registry.npmjs.org/@php-wasm/node-8-5/-/node-8-5-3.1.2.tgz",
-			"integrity": "sha512-JAalPcRB4VQd0Iz0BWcPp5DXNsNcw5Rq20XSz4YmlCDkGNJ46DsgGF1ZjptbacFYYGdJGm7mfMoiJuAhuVu1Cw==",
+			"version": "3.1.45",
+			"resolved": "https://registry.npmjs.org/@php-wasm/node-8-5/-/node-8-5-3.1.45.tgz",
+			"integrity": "sha512-FeKtaRMZorN1uRFbC6DILfv+Y9ImEMLjcpNVyT7zZ4WHPEf1yN0Q0Jo8VH9NNwCmkmiDAQN2gAIn3nKL8vsz+g==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@php-wasm/universal": "3.1.2",
-				"ini": "4.1.2",
-				"wasm-feature-detect": "1.8.0",
-				"ws": "8.18.3"
+				"@php-wasm/universal": "3.1.45",
+				"wasm-feature-detect": "1.8.0"
 			},
 			"engines": {
 				"node": ">=20.10.0",
 				"npm": ">=10.2.3"
 			}
 		},
-		"node_modules/@php-wasm/node-polyfills": {
-			"version": "3.1.2",
-			"resolved": "https://registry.npmjs.org/@php-wasm/node-polyfills/-/node-polyfills-3.1.2.tgz",
-			"integrity": "sha512-fPKQVX8SEV5wWlAuO+wJeWTt4qf1eA5WVcoS3bS/dCHy437NzrnIZ/caJB8MHgjNRDh+d/QWHS3gDDs0NvYhjQ==",
-			"dev": true,
-			"license": "GPL-2.0-or-later"
-		},
 		"node_modules/@php-wasm/progress": {
-			"version": "3.1.2",
-			"resolved": "https://registry.npmjs.org/@php-wasm/progress/-/progress-3.1.2.tgz",
-			"integrity": "sha512-IND/q2zpLufURpuiQ94w4/Thx6z2I1zkfvGZ7tbThz+kyMuTOrog2Q6f8vL7xL1UI1cGTWCRiUVxzj4EtMvJag==",
+			"version": "3.1.45",
+			"resolved": "https://registry.npmjs.org/@php-wasm/progress/-/progress-3.1.45.tgz",
+			"integrity": "sha512-rc/I9MSoqAPLRmrgArpWMrSq6s7R16ulrMjG3Ti5T4hfu+j2oxfBCHbrwzR57ITsgecjKZ+G9j/w+saQj9cgpQ==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@php-wasm/logger": "3.1.2",
-				"@php-wasm/node-polyfills": "3.1.2"
+				"@php-wasm/logger": "3.1.45"
 			},
 			"engines": {
 				"node": ">=20.10.0",
@@ -7273,9 +7120,9 @@
 			}
 		},
 		"node_modules/@php-wasm/scopes": {
-			"version": "3.1.2",
-			"resolved": "https://registry.npmjs.org/@php-wasm/scopes/-/scopes-3.1.2.tgz",
-			"integrity": "sha512-M5BO27JMIS2FMifh2Eb2BjWrAmA0h26Q2Sf2gx5gOk64SleMaJNuYxpPC8WdqNru7IDmjZbRoK//OIPscaPhxA==",
+			"version": "3.1.45",
+			"resolved": "https://registry.npmjs.org/@php-wasm/scopes/-/scopes-3.1.45.tgz",
+			"integrity": "sha512-7efo3IvGLMOcUuywB40avWz1c6c7YurmRW/hM44iPlhr72x9Wpth9eHjI+Gsn+qFISmUqjW+G2KHx9BD7BTQBA==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"engines": {
@@ -7284,28 +7131,26 @@
 			}
 		},
 		"node_modules/@php-wasm/stream-compression": {
-			"version": "3.1.2",
-			"resolved": "https://registry.npmjs.org/@php-wasm/stream-compression/-/stream-compression-3.1.2.tgz",
-			"integrity": "sha512-nUM7DtBkPF1Y3v9FW1CMG7nJLIDnoH3MKfKON6R/knwDpAExQVOII3K8AZuiVyr4IAiFZwYza8H5bkM+UUmFBg==",
+			"version": "3.1.45",
+			"resolved": "https://registry.npmjs.org/@php-wasm/stream-compression/-/stream-compression-3.1.45.tgz",
+			"integrity": "sha512-zLU1AGNEg1tuwm93LHrL8OcV24LyNglTg/CXV5CVZiMPpg1wfIDHJy11qqjZM8iCIJk87qYQhkKOjTnGinAVDg==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@php-wasm/node-polyfills": "3.1.2",
-				"@php-wasm/util": "3.1.2"
+				"@php-wasm/util": "3.1.45"
 			}
 		},
 		"node_modules/@php-wasm/universal": {
-			"version": "3.1.2",
-			"resolved": "https://registry.npmjs.org/@php-wasm/universal/-/universal-3.1.2.tgz",
-			"integrity": "sha512-rgKyeqBVHZ6bDOwoYg9lUtZxgh7aB+/ryGcL1QEYyr7260bFwVgf8MWNP+211fktLa1yvuvl4dyDepaQiV0sDA==",
+			"version": "3.1.45",
+			"resolved": "https://registry.npmjs.org/@php-wasm/universal/-/universal-3.1.45.tgz",
+			"integrity": "sha512-3x0TWQg6NEeO+M/oPA3rAP0hJB2gnsqwkb2sUipz0RQQXRkWEJjdrT20UVmGN/dXILDWeQg/VGxZhCktoWZGkA==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@php-wasm/logger": "3.1.2",
-				"@php-wasm/node-polyfills": "3.1.2",
-				"@php-wasm/progress": "3.1.2",
-				"@php-wasm/stream-compression": "3.1.2",
-				"@php-wasm/util": "3.1.2",
+				"@php-wasm/logger": "3.1.45",
+				"@php-wasm/progress": "3.1.45",
+				"@php-wasm/stream-compression": "3.1.45",
+				"@php-wasm/util": "3.1.45",
 				"ini": "4.1.2"
 			},
 			"engines": {
@@ -7314,167 +7159,24 @@
 			}
 		},
 		"node_modules/@php-wasm/util": {
-			"version": "3.1.2",
-			"resolved": "https://registry.npmjs.org/@php-wasm/util/-/util-3.1.2.tgz",
-			"integrity": "sha512-g22dH4zIQ26hQHRNBfp9csy3W8tDDdyB4G8Euvj6PNxEBsTnY/A6WG1/wLZ3PUED9ULsz/lKKFSiEZo8Hj8B8g==",
+			"version": "3.1.45",
+			"resolved": "https://registry.npmjs.org/@php-wasm/util/-/util-3.1.45.tgz",
+			"integrity": "sha512-czXqXd2NJWkapV/zTr3WPSPdcgyI5KN7xSUusYpgkfljSovfvHOKKrTMQtbfPXRa9+MD8LmPQt+XStKPRp76Tg==",
 			"dev": true,
-			"engines": {
-				"node": ">=20.10.0",
-				"npm": ">=10.2.3"
-			}
-		},
-		"node_modules/@php-wasm/web": {
-			"version": "3.1.2",
-			"resolved": "https://registry.npmjs.org/@php-wasm/web/-/web-3.1.2.tgz",
-			"integrity": "sha512-HV9RKqm3DfOuMlDlC+Q0nxLv8xCf6E5yhatrimJ8fXXLRUTaBzpDbsbwi2eq8qcb6A48Yj25wY8BSpqWSYJYVw==",
-			"dev": true,
-			"license": "GPL-2.0-or-later",
-			"dependencies": {
-				"@php-wasm/fs-journal": "3.1.2",
-				"@php-wasm/logger": "3.1.2",
-				"@php-wasm/universal": "3.1.2",
-				"@php-wasm/util": "3.1.2",
-				"@php-wasm/web-7-4": "3.1.2",
-				"@php-wasm/web-8-0": "3.1.2",
-				"@php-wasm/web-8-1": "3.1.2",
-				"@php-wasm/web-8-2": "3.1.2",
-				"@php-wasm/web-8-3": "3.1.2",
-				"@php-wasm/web-8-4": "3.1.2",
-				"@php-wasm/web-8-5": "3.1.2",
-				"@php-wasm/web-service-worker": "3.1.2",
-				"@wp-playground/common": "3.1.2",
-				"express": "4.22.0",
-				"fs-ext-extra-prebuilt": "2.2.7",
-				"ini": "4.1.2",
-				"wasm-feature-detect": "1.8.0",
-				"ws": "8.18.3",
-				"yargs": "17.7.2"
-			},
-			"engines": {
-				"node": ">=20.10.0",
-				"npm": ">=10.2.3"
-			}
-		},
-		"node_modules/@php-wasm/web-7-4": {
-			"version": "3.1.2",
-			"resolved": "https://registry.npmjs.org/@php-wasm/web-7-4/-/web-7-4-3.1.2.tgz",
-			"integrity": "sha512-3Vq1yt7fqEo40PXZFRobxNLTzrDGS8I0ciIQ5XED0/TJh6bnV39T3wmecq1dbDCw/wrCdDK3kdlBUnViUpSQ5g==",
-			"dev": true,
-			"license": "GPL-2.0-or-later",
-			"dependencies": {
-				"@php-wasm/universal": "3.1.2",
-				"ini": "4.1.2",
-				"wasm-feature-detect": "1.8.0"
-			},
-			"engines": {
-				"node": ">=20.10.0",
-				"npm": ">=10.2.3"
-			}
-		},
-		"node_modules/@php-wasm/web-8-0": {
-			"version": "3.1.2",
-			"resolved": "https://registry.npmjs.org/@php-wasm/web-8-0/-/web-8-0-3.1.2.tgz",
-			"integrity": "sha512-zKL10GRajDi59Q3wB7AyWNZZaEeikM7HRpHarBBs2UhmTVS93Tyhoj4WsaN5KC3MZlxIV2g6QgXhcJHEyuve+A==",
-			"dev": true,
-			"license": "GPL-2.0-or-later",
-			"dependencies": {
-				"@php-wasm/universal": "3.1.2",
-				"ini": "4.1.2",
-				"wasm-feature-detect": "1.8.0"
-			},
-			"engines": {
-				"node": ">=20.10.0",
-				"npm": ">=10.2.3"
-			}
-		},
-		"node_modules/@php-wasm/web-8-1": {
-			"version": "3.1.2",
-			"resolved": "https://registry.npmjs.org/@php-wasm/web-8-1/-/web-8-1-3.1.2.tgz",
-			"integrity": "sha512-zXsiao1+Op0Qkgc4zmrgEzkpON547pTuQdljNlqGKdRcA8l/xhTme7fhm5GsSP/UEQbP3n7PEOjKPAQi8S9wSA==",
-			"dev": true,
-			"license": "GPL-2.0-or-later",
-			"dependencies": {
-				"@php-wasm/universal": "3.1.2",
-				"ini": "4.1.2",
-				"wasm-feature-detect": "1.8.0"
-			},
-			"engines": {
-				"node": ">=20.10.0",
-				"npm": ">=10.2.3"
-			}
-		},
-		"node_modules/@php-wasm/web-8-2": {
-			"version": "3.1.2",
-			"resolved": "https://registry.npmjs.org/@php-wasm/web-8-2/-/web-8-2-3.1.2.tgz",
-			"integrity": "sha512-tAgutFkzIwSir7HOnu4IRQLX3uTYArl3wqqlpK/GfIXwyCHSRaq1OTQfh4mq4U3ulCu97MwOHiJBqSDoE5qyrQ==",
-			"dev": true,
-			"license": "GPL-2.0-or-later",
-			"dependencies": {
-				"@php-wasm/universal": "3.1.2",
-				"ini": "4.1.2",
-				"wasm-feature-detect": "1.8.0"
-			},
-			"engines": {
-				"node": ">=20.10.0",
-				"npm": ">=10.2.3"
-			}
-		},
-		"node_modules/@php-wasm/web-8-3": {
-			"version": "3.1.2",
-			"resolved": "https://registry.npmjs.org/@php-wasm/web-8-3/-/web-8-3-3.1.2.tgz",
-			"integrity": "sha512-RZLz0XxwkdTy17ijpIPe2iZe1s5ZbEybVIw131jjgLm5bTSuTCwYod7LUNCdRy0QE651g8142Aw5W9iYFnLwfg==",
-			"dev": true,
-			"license": "GPL-2.0-or-later",
-			"dependencies": {
-				"@php-wasm/universal": "3.1.2",
-				"ini": "4.1.2",
-				"wasm-feature-detect": "1.8.0"
-			},
-			"engines": {
-				"node": ">=20.10.0",
-				"npm": ">=10.2.3"
-			}
-		},
-		"node_modules/@php-wasm/web-8-4": {
-			"version": "3.1.2",
-			"resolved": "https://registry.npmjs.org/@php-wasm/web-8-4/-/web-8-4-3.1.2.tgz",
-			"integrity": "sha512-v4ujuPNwI1eWBkB9Nzj1+hUKVZaxr/ev7LFA0hi+wOMk4ZVW2hLx1AE7jE2v7L2zADW7JJ2tGP3gK37/TAmpug==",
-			"dev": true,
-			"license": "GPL-2.0-or-later",
-			"dependencies": {
-				"@php-wasm/universal": "3.1.2",
-				"ini": "4.1.2",
-				"wasm-feature-detect": "1.8.0"
-			},
-			"engines": {
-				"node": ">=20.10.0",
-				"npm": ">=10.2.3"
-			}
-		},
-		"node_modules/@php-wasm/web-8-5": {
-			"version": "3.1.2",
-			"resolved": "https://registry.npmjs.org/@php-wasm/web-8-5/-/web-8-5-3.1.2.tgz",
-			"integrity": "sha512-XSyTybscwd7CFhTjPMUq02s5WqJE1xwjfIMMut7sT3HzD0TM5wGpbQLS53Vj5XXWUtLgsG19hW/JyREHzR05eQ==",
-			"dev": true,
-			"license": "GPL-2.0-or-later",
-			"dependencies": {
-				"@php-wasm/universal": "3.1.2",
-				"ini": "4.1.2",
-				"wasm-feature-detect": "1.8.0"
-			},
 			"engines": {
 				"node": ">=20.10.0",
 				"npm": ">=10.2.3"
 			}
 		},
 		"node_modules/@php-wasm/web-service-worker": {
-			"version": "3.1.2",
-			"resolved": "https://registry.npmjs.org/@php-wasm/web-service-worker/-/web-service-worker-3.1.2.tgz",
-			"integrity": "sha512-rZOgdjOBed9EcQwsEVDBpdQVDY30eEAQ+bxEAMB1OrcpXzFPwMdfkVZvxo6fP7DA9qg9Qr/ethRve0O5dNJALA==",
+			"version": "3.1.45",
+			"resolved": "https://registry.npmjs.org/@php-wasm/web-service-worker/-/web-service-worker-3.1.45.tgz",
+			"integrity": "sha512-L8spIluLVlaOZ8CnNPfJ5IEM/e1YouQ9kB8GJL+NVm27Pci/pxBE5Hi7nsmau/oQJ6JTA6rXMuDh3wyicFU0Xg==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@php-wasm/scopes": "3.1.2"
+				"@php-wasm/scopes": "3.1.45",
+				"@php-wasm/universal": "3.1.45"
 			},
 			"engines": {
 				"node": ">=20.10.0",
@@ -7482,21 +7184,15 @@
 			}
 		},
 		"node_modules/@php-wasm/xdebug-bridge": {
-			"version": "3.1.2",
-			"resolved": "https://registry.npmjs.org/@php-wasm/xdebug-bridge/-/xdebug-bridge-3.1.2.tgz",
-			"integrity": "sha512-oArlnqIo9YFOro8rdaAPipSfuOht//47XxvpwQbjEvOsJ54WkyNKmxOD1QFqNjj4y9cc3yCaqeYb/xUcn0tp6Q==",
+			"version": "3.1.45",
+			"resolved": "https://registry.npmjs.org/@php-wasm/xdebug-bridge/-/xdebug-bridge-3.1.45.tgz",
+			"integrity": "sha512-InIWrSl9ULFEyIYbIK+uh2TK3N7VhQuycx3tRSaRY7YNpUGS2xxfNSt4BeJgBgUNmslKsQojSjCcmvumJW1mgg==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@php-wasm/logger": "3.1.2",
-				"@php-wasm/node": "3.1.2",
-				"@php-wasm/universal": "3.1.2",
-				"@wp-playground/common": "3.1.2",
-				"express": "4.22.0",
-				"fs-ext-extra-prebuilt": "2.2.7",
-				"ini": "4.1.2",
-				"wasm-feature-detect": "1.8.0",
-				"ws": "8.18.3",
+				"@php-wasm/logger": "3.1.45",
+				"@php-wasm/universal": "3.1.45",
+				"ws": "8.21.0",
 				"xml2js": "0.6.2",
 				"yargs": "17.7.2"
 			},
@@ -8690,9 +8386,9 @@
 			}
 		},
 		"node_modules/@types/aws-lambda": {
-			"version": "8.10.161",
-			"resolved": "https://registry.npmjs.org/@types/aws-lambda/-/aws-lambda-8.10.161.tgz",
-			"integrity": "sha512-rUYdp+MQwSFocxIOcSsYSF3YYYC/uUpMbCY/mbO21vGqfrEYvNSoPyKYDj6RhXXpPfS0KstW9RwG3qXh9sL7FQ==",
+			"version": "8.10.162",
+			"resolved": "https://registry.npmjs.org/@types/aws-lambda/-/aws-lambda-8.10.162.tgz",
+			"integrity": "sha512-Fn658grtLOci1oxi1391vvDWJRKNGWRSqfxRkmN/Iy3c0tQH1USMKEXcPYHLvope+ZgTFocx9FRQJx1muBL6qw==",
 			"dev": true,
 			"license": "MIT"
 		},
@@ -10731,9 +10427,9 @@
 			}
 		},
 		"node_modules/@wordpress/env/node_modules/brace-expansion": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-			"integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
+			"integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -13184,43 +12880,21 @@
 			}
 		},
 		"node_modules/@wp-playground/blueprints": {
-			"version": "3.1.2",
-			"resolved": "https://registry.npmjs.org/@wp-playground/blueprints/-/blueprints-3.1.2.tgz",
-			"integrity": "sha512-46YYZ8FAq0G3aZ/b0d7/jTaBmjpktKz/aiYcZ6KBRQdBwpTg9ujennhlvciEHTwI6mJ4drRfBaEoAjYIIlwsWQ==",
+			"version": "3.1.45",
+			"resolved": "https://registry.npmjs.org/@wp-playground/blueprints/-/blueprints-3.1.45.tgz",
+			"integrity": "sha512-q7jEN5w6dgwpzk26mkSGLLPEsTQsRfily0wPolAwueyhq2bnY7Nil7r1k+JHTR2XpTSg3Y3rFyp3j1biOpbsDA==",
 			"dev": true,
 			"dependencies": {
-				"@php-wasm/logger": "3.1.2",
-				"@php-wasm/node": "3.1.2",
-				"@php-wasm/node-polyfills": "3.1.2",
-				"@php-wasm/progress": "3.1.2",
-				"@php-wasm/scopes": "3.1.2",
-				"@php-wasm/stream-compression": "3.1.2",
-				"@php-wasm/universal": "3.1.2",
-				"@php-wasm/util": "3.1.2",
-				"@php-wasm/web-service-worker": "3.1.2",
-				"@wp-playground/common": "3.1.2",
-				"@wp-playground/storage": "3.1.2",
-				"@wp-playground/wordpress": "3.1.2",
-				"@zip.js/zip.js": "2.7.57",
-				"ajv": "8.12.0",
-				"async-lock": "1.4.1",
-				"clean-git-ref": "2.0.1",
-				"crc-32": "1.2.2",
-				"diff3": "0.0.4",
-				"express": "4.22.0",
-				"fs-ext-extra-prebuilt": "2.2.7",
-				"ignore": "5.3.2",
-				"ini": "4.1.2",
-				"minimisted": "2.0.1",
-				"octokit": "3.1.2",
-				"pako": "1.0.10",
-				"pify": "2.3.0",
-				"readable-stream": "3.6.2",
-				"sha.js": "2.4.12",
-				"simple-get": "4.0.1",
-				"wasm-feature-detect": "1.8.0",
-				"ws": "8.18.3",
-				"yargs": "17.7.2"
+				"@php-wasm/logger": "3.1.45",
+				"@php-wasm/progress": "3.1.45",
+				"@php-wasm/stream-compression": "3.1.45",
+				"@php-wasm/universal": "3.1.45",
+				"@php-wasm/util": "3.1.45",
+				"@php-wasm/web-service-worker": "3.1.45",
+				"@wp-playground/common": "3.1.45",
+				"@wp-playground/storage": "3.1.45",
+				"@wp-playground/wordpress": "3.1.45",
+				"ajv": "8.18.0"
 			},
 			"engines": {
 				"node": ">=20.10.0",
@@ -13228,49 +12902,28 @@
 			}
 		},
 		"node_modules/@wp-playground/cli": {
-			"version": "3.1.2",
-			"resolved": "https://registry.npmjs.org/@wp-playground/cli/-/cli-3.1.2.tgz",
-			"integrity": "sha512-mk9JDUvjwXII+yVZmjYSE1TWdSqdy8MeMm/7S0KpUTgHaVTwaeKH0ImWYDyAeC0H0HSXNbfuEnqe/Rls9cwKEQ==",
+			"version": "3.1.45",
+			"resolved": "https://registry.npmjs.org/@wp-playground/cli/-/cli-3.1.45.tgz",
+			"integrity": "sha512-9cSDXOJoSdZSVrNBOraLlkiBMnvxy0EyaUrkr/8kBkNhWgNv2WhoPxMY25B0eh8nocH2mLVFHg9s4thuFghhug==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@php-wasm/cli-util": "3.1.2",
-				"@php-wasm/logger": "3.1.2",
-				"@php-wasm/node": "3.1.2",
-				"@php-wasm/progress": "3.1.2",
-				"@php-wasm/universal": "3.1.2",
-				"@php-wasm/util": "3.1.2",
-				"@php-wasm/xdebug-bridge": "3.1.2",
-				"@wp-playground/blueprints": "3.1.2",
-				"@wp-playground/common": "3.1.2",
-				"@wp-playground/storage": "3.1.2",
-				"@wp-playground/tools": "3.1.2",
-				"@wp-playground/wordpress": "3.1.2",
-				"@zip.js/zip.js": "2.7.57",
-				"ajv": "8.12.0",
-				"async-lock": "1.4.1",
-				"clean-git-ref": "2.0.1",
-				"crc-32": "1.2.2",
-				"diff3": "0.0.4",
-				"express": "4.22.0",
-				"fast-xml-parser": "^5.3.4",
-				"fs-ext-extra-prebuilt": "2.2.7",
+				"@php-wasm/cli-util": "3.1.45",
+				"@php-wasm/logger": "3.1.45",
+				"@php-wasm/node": "3.1.45",
+				"@php-wasm/progress": "3.1.45",
+				"@php-wasm/universal": "3.1.45",
+				"@php-wasm/util": "3.1.45",
+				"@php-wasm/xdebug-bridge": "3.1.45",
+				"@wp-playground/blueprints": "3.1.45",
+				"@wp-playground/common": "3.1.45",
+				"@wp-playground/storage": "3.1.45",
+				"@wp-playground/tools": "3.1.45",
+				"@wp-playground/wordpress": "3.1.45",
+				"express": "4.22.2",
 				"fs-extra": "11.1.1",
-				"ignore": "5.3.2",
-				"ini": "4.1.2",
-				"jsonc-parser": "3.3.1",
-				"minimisted": "2.0.1",
-				"octokit": "3.1.2",
-				"pako": "1.0.10",
-				"pify": "2.3.0",
-				"ps-man": "1.1.8",
-				"readable-stream": "3.6.2",
-				"sha.js": "2.4.12",
-				"simple-get": "4.0.1",
 				"tmp-promise": "3.0.3",
 				"wasm-feature-detect": "1.8.0",
-				"ws": "8.18.3",
-				"xml2js": "0.6.2",
 				"yargs": "17.7.2"
 			},
 			"bin": {
@@ -13316,15 +12969,14 @@
 			}
 		},
 		"node_modules/@wp-playground/common": {
-			"version": "3.1.2",
-			"resolved": "https://registry.npmjs.org/@wp-playground/common/-/common-3.1.2.tgz",
-			"integrity": "sha512-HSCzwIe+5EVVsbbEtwdUh4O1805Co1GCOV6WQvshjJRtIzMTbRPtPeigkZVgDOMYvmDYrgBAEw5p9DqNK6mImA==",
+			"version": "3.1.45",
+			"resolved": "https://registry.npmjs.org/@wp-playground/common/-/common-3.1.45.tgz",
+			"integrity": "sha512-dhVGdPqp4D0RhodW9sxdI3gdKPI98ue0oyXX4AeL4toLvjzKF1nz3AwniojsuHbJr0RV0QhA/Z2rYcTjynLD8A==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@php-wasm/universal": "3.1.2",
-				"@php-wasm/util": "3.1.2",
-				"ini": "4.1.2"
+				"@php-wasm/universal": "3.1.45",
+				"@php-wasm/util": "3.1.45"
 			},
 			"engines": {
 				"node": ">=20.10.0",
@@ -13332,82 +12984,30 @@
 			}
 		},
 		"node_modules/@wp-playground/storage": {
-			"version": "3.1.2",
-			"resolved": "https://registry.npmjs.org/@wp-playground/storage/-/storage-3.1.2.tgz",
-			"integrity": "sha512-TKHtLhgRG73pXm9TRXXYpfZOEbU9/icXccnyy0y45DAPKsAbLQYaLei8JGWGZTONLJr+28t5ZBkmKOQxlQQfyg==",
+			"version": "3.1.45",
+			"resolved": "https://registry.npmjs.org/@wp-playground/storage/-/storage-3.1.45.tgz",
+			"integrity": "sha512-c9iWgHHhwEElroXqWBi8B7rSsvAbSYjCDA1m5zTmg+jpscbT8zLrIohJ3WANbWljeSxG4sWA87PLqARdchyl3A==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@php-wasm/stream-compression": "3.1.2",
-				"@php-wasm/universal": "3.1.2",
-				"@php-wasm/util": "3.1.2",
-				"@php-wasm/web": "3.1.2",
+				"@php-wasm/stream-compression": "3.1.45",
+				"@php-wasm/universal": "3.1.45",
+				"@php-wasm/util": "3.1.45",
 				"@zip.js/zip.js": "2.7.57",
-				"async-lock": "^1.4.1",
-				"clean-git-ref": "^2.0.1",
-				"crc-32": "^1.2.0",
-				"diff3": "0.0.3",
-				"express": "4.22.0",
-				"fs-ext-extra-prebuilt": "2.2.7",
-				"ignore": "^5.1.4",
-				"ini": "4.1.2",
-				"minimisted": "^2.0.0",
+				"isomorphic-git": "1.37.6",
 				"octokit": "3.1.2",
 				"pako": "^1.0.10",
-				"pify": "^4.0.1",
-				"readable-stream": "^3.4.0",
-				"sha.js": "^2.4.9",
-				"simple-get": "^4.0.1",
-				"wasm-feature-detect": "1.8.0",
-				"ws": "8.18.3",
-				"yargs": "17.7.2"
-			}
-		},
-		"node_modules/@wp-playground/storage/node_modules/diff3": {
-			"version": "0.0.3",
-			"resolved": "https://registry.npmjs.org/diff3/-/diff3-0.0.3.tgz",
-			"integrity": "sha512-iSq8ngPOt0K53A6eVr4d5Kn6GNrM2nQZtC740pzIriHtn4pOQ2lyzEXQMBeVcWERN0ye7fhBsk9PbLLQOnUx/g==",
-			"dev": true,
-			"license": "MIT"
-		},
-		"node_modules/@wp-playground/storage/node_modules/pify": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
-			"integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=6"
+				"sha.js": "2.4.12"
 			}
 		},
 		"node_modules/@wp-playground/tools": {
-			"version": "3.1.2",
-			"resolved": "https://registry.npmjs.org/@wp-playground/tools/-/tools-3.1.2.tgz",
-			"integrity": "sha512-Csg/aRY7ZLOHf0Rx71Ka37dTBaec2nknLP9wDQc1mLEAkd+GuXuJQfDz8JHmmbWuPm5K2MAaVJxuQeHk4jOrig==",
+			"version": "3.1.45",
+			"resolved": "https://registry.npmjs.org/@wp-playground/tools/-/tools-3.1.45.tgz",
+			"integrity": "sha512-nhGuCsVgd0VIe+nQgrKKsVXCu2XHHSnj7+GiH4qIThYUpXLMZo/s+w1bI0ANGOCgpUTOv89Q2JOFPrn37+b3tA==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@wp-playground/blueprints": "3.1.2",
-				"@zip.js/zip.js": "2.7.57",
-				"ajv": "8.12.0",
-				"async-lock": "1.4.1",
-				"clean-git-ref": "2.0.1",
-				"crc-32": "1.2.2",
-				"diff3": "0.0.4",
-				"express": "4.22.0",
-				"fs-ext-extra-prebuilt": "2.2.7",
-				"ignore": "5.3.2",
-				"ini": "4.1.2",
-				"minimisted": "2.0.1",
-				"octokit": "3.1.2",
-				"pako": "1.0.10",
-				"pify": "2.3.0",
-				"readable-stream": "3.6.2",
-				"sha.js": "2.4.12",
-				"simple-get": "4.0.1",
-				"wasm-feature-detect": "1.8.0",
-				"ws": "8.18.3",
-				"yargs": "17.7.2"
+				"@wp-playground/blueprints": "3.1.45"
 			},
 			"engines": {
 				"node": ">=20.10.0",
@@ -13415,23 +13015,17 @@
 			}
 		},
 		"node_modules/@wp-playground/wordpress": {
-			"version": "3.1.2",
-			"resolved": "https://registry.npmjs.org/@wp-playground/wordpress/-/wordpress-3.1.2.tgz",
-			"integrity": "sha512-8R1gNGrJ2pEliMl67EF8E3aB1ZL+0oZ6FA4ZREjIhaOrqm8ZmBcXnqmrX27cvGM7aJ3FGrQurdq4jIdDd9rp0w==",
+			"version": "3.1.45",
+			"resolved": "https://registry.npmjs.org/@wp-playground/wordpress/-/wordpress-3.1.45.tgz",
+			"integrity": "sha512-kQqx7m4oKRnSmTxiwdwVnUGetJINHVULMURff2+JZ4EGLqAUVscyCQ4YvQMnIho6gASyzt8TYLr3GqxU+1n6AA==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@php-wasm/logger": "3.1.2",
-				"@php-wasm/node": "3.1.2",
-				"@php-wasm/universal": "3.1.2",
-				"@php-wasm/util": "3.1.2",
-				"@wp-playground/common": "3.1.2",
-				"express": "4.22.0",
-				"fs-ext-extra-prebuilt": "2.2.7",
-				"ini": "4.1.2",
-				"wasm-feature-detect": "1.8.0",
-				"ws": "8.18.3",
-				"yargs": "17.7.2"
+				"@php-wasm/logger": "3.1.45",
+				"@php-wasm/universal": "3.1.45",
+				"@php-wasm/util": "3.1.45",
+				"@wp-playground/common": "3.1.45",
+				"zstddec": "^0.2.0"
 			},
 			"engines": {
 				"node": ">=20.10.0",
@@ -13471,6 +13065,19 @@
 			"deprecated": "Use your platform's native atob() and btoa() methods instead",
 			"dev": true,
 			"license": "BSD-3-Clause"
+		},
+		"node_modules/abort-controller": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
+			"integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"event-target-shim": "^5.0.0"
+			},
+			"engines": {
+				"node": ">=6.5"
+			}
 		},
 		"node_modules/accepts": {
 			"version": "1.3.8",
@@ -13546,9 +13153,9 @@
 			}
 		},
 		"node_modules/adm-zip": {
-			"version": "0.5.16",
-			"resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.5.16.tgz",
-			"integrity": "sha512-TGw5yVi4saajsSEgz25grObGHEUaDrniwvA2qwSC060KfqGPdglhvPMA2lPIoxs3PQIItj2iag35fONcQqgUaQ==",
+			"version": "0.5.18",
+			"resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.5.18.tgz",
+			"integrity": "sha512-ufJnssQGbxzLNS1Ho9bCtX4rQKCCvoVuDLHoJyc3F9dOGDB4BkWs2Ci0kv53lqocAEQ/Cbi+I2XCsNYGqVYqng==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -13580,16 +13187,16 @@
 			}
 		},
 		"node_modules/ajv": {
-			"version": "8.12.0",
-			"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
-			"integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
+			"version": "8.18.0",
+			"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
+			"integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
 			"devOptional": true,
 			"license": "MIT",
 			"dependencies": {
-				"fast-deep-equal": "^3.1.1",
+				"fast-deep-equal": "^3.1.3",
+				"fast-uri": "^3.0.1",
 				"json-schema-traverse": "^1.0.0",
-				"require-from-string": "^2.0.2",
-				"uri-js": "^4.2.2"
+				"require-from-string": "^2.0.2"
 			},
 			"funding": {
 				"type": "github",
@@ -13741,6 +13348,19 @@
 			"engines": {
 				"node": ">= 8"
 			}
+		},
+		"node_modules/anynum": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/anynum/-/anynum-1.0.1.tgz",
+			"integrity": "sha512-N6//FLET/tXYNM/F6ABca1oH6fWB+KlTt909Le28WMDBk8oaT4vY17DCrwg2MvmuqUKt3Ni4N5dGJ/EoBgcO6A==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/NaturalIntelligence"
+				}
+			],
+			"license": "MIT"
 		},
 		"node_modules/are-docs-informative": {
 			"version": "0.0.2",
@@ -14424,6 +14044,27 @@
 				"bare-path": "^3.0.0"
 			}
 		},
+		"node_modules/base64-js": {
+			"version": "1.5.1",
+			"resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+			"integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/feross"
+				},
+				{
+					"type": "patreon",
+					"url": "https://www.patreon.com/feross"
+				},
+				{
+					"type": "consulting",
+					"url": "https://feross.org/support"
+				}
+			],
+			"license": "MIT"
+		},
 		"node_modules/baseline-browser-mapping": {
 			"version": "2.10.43",
 			"resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.43.tgz",
@@ -14438,9 +14079,9 @@
 			}
 		},
 		"node_modules/basic-ftp": {
-			"version": "5.2.2",
-			"resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.2.2.tgz",
-			"integrity": "sha512-1tDrzKsdCg70WGvbFss/ulVAxupNauGnOlgpyjKzeQxzyllBLS0CGLV7tjIXTK3ZQA9/FBEm9qyFFN1bciA6pw==",
+			"version": "5.3.1",
+			"resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.3.1.tgz",
+			"integrity": "sha512-bopVNp6ugyA150DDuZfPFdt1KZ5a94ZDiwX4hMgZDzF+GttD80lEy8kj98kbyhLXnPvhtIo93mdnLIjpCAeeOw==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -14485,9 +14126,9 @@
 			}
 		},
 		"node_modules/body-parser": {
-			"version": "1.20.4",
-			"resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.4.tgz",
-			"integrity": "sha512-ZTgYYLMOXY9qKU/57FAo8F+HA2dGX7bqGc71txDRC1rS4frdFI5R7NhluHxH6M0YItAP0sHB4uqAOcYKxO6uGA==",
+			"version": "1.20.6",
+			"resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.6.tgz",
+			"integrity": "sha512-p5tAzS57i5MV9fZFDj9LeIiTZEufbSe2eDozP+ElheSUq1m74CRq1jI4mYNDdVs9vQztXFLuk/Gd6BWTdwRJ5g==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -14499,7 +14140,7 @@
 				"http-errors": "~2.0.1",
 				"iconv-lite": "~0.4.24",
 				"on-finished": "~2.4.1",
-				"qs": "~6.14.0",
+				"qs": "~6.15.1",
 				"raw-body": "~2.5.3",
 				"type-is": "~1.6.18",
 				"unpipe": "~1.0.0"
@@ -14565,9 +14206,9 @@
 			"license": "MIT"
 		},
 		"node_modules/brace-expansion": {
-			"version": "1.1.12",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-			"integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+			"version": "1.1.16",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+			"integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -14638,6 +14279,31 @@
 			"integrity": "sha512-gvW7InbIyF8AicrqWoptdW08pUxuhq8BEgowNajy9RhiE86fmGAGl+bLKo6oB8QP0CkqHLowfN0oJdKC/J6LbA==",
 			"dev": true,
 			"license": "MIT"
+		},
+		"node_modules/buffer": {
+			"version": "6.0.3",
+			"resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+			"integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/feross"
+				},
+				{
+					"type": "patreon",
+					"url": "https://www.patreon.com/feross"
+				},
+				{
+					"type": "consulting",
+					"url": "https://feross.org/support"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"base64-js": "^1.3.1",
+				"ieee754": "^1.2.1"
+			}
 		},
 		"node_modules/buffer-crc32": {
 			"version": "0.2.13",
@@ -15635,10 +15301,20 @@
 			"license": "Python-2.0"
 		},
 		"node_modules/cosmiconfig/node_modules/js-yaml": {
-			"version": "4.1.1",
-			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-			"integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+			"integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
 			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/puzrin"
+				},
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/nodeca"
+				}
+			],
 			"license": "MIT",
 			"dependencies": {
 				"argparse": "^2.0.1"
@@ -16994,9 +16670,9 @@
 			}
 		},
 		"node_modules/diff3": {
-			"version": "0.0.4",
-			"resolved": "https://registry.npmjs.org/diff3/-/diff3-0.0.4.tgz",
-			"integrity": "sha512-f1rQ7jXDn/3i37hdwRk9ohqcvLRH3+gEIgmA6qEM280WUOh7cOr3GXV8Jm5sPwUs46Nzl48SE8YNLGJoaLuodg==",
+			"version": "0.0.3",
+			"resolved": "https://registry.npmjs.org/diff3/-/diff3-0.0.3.tgz",
+			"integrity": "sha512-iSq8ngPOt0K53A6eVr4d5Kn6GNrM2nQZtC740pzIriHtn4pOQ2lyzEXQMBeVcWERN0ye7fhBsk9PbLLQOnUx/g==",
 			"dev": true,
 			"license": "MIT"
 		},
@@ -18402,6 +18078,16 @@
 				"node": ">= 0.6"
 			}
 		},
+		"node_modules/event-target-shim": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
+			"integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=6"
+			}
+		},
 		"node_modules/events": {
 			"version": "3.3.0",
 			"resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
@@ -18631,15 +18317,15 @@
 			}
 		},
 		"node_modules/express": {
-			"version": "4.22.0",
-			"resolved": "https://registry.npmjs.org/express/-/express-4.22.0.tgz",
-			"integrity": "sha512-c2iPh3xp5vvCLgaHK03+mWLFPhox7j1LwyxcZwFVApEv5i0X+IjPpbT50SJJwwLpdBVfp45AkK/v+AFgv/XlfQ==",
+			"version": "4.22.2",
+			"resolved": "https://registry.npmjs.org/express/-/express-4.22.2.tgz",
+			"integrity": "sha512-IuL+Elrou2ZvCFHs18/CIzy2Nzvo25nZ1/D2eIZlz7c+QUayAcYoiM2BthCjs+EBHVpjYjcuLDAiCWgeIX3X1Q==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"accepts": "~1.3.8",
 				"array-flatten": "1.1.1",
-				"body-parser": "~1.20.3",
+				"body-parser": "~1.20.5",
 				"content-disposition": "~0.5.4",
 				"content-type": "~1.0.4",
 				"cookie": "~0.7.1",
@@ -18658,7 +18344,7 @@
 				"parseurl": "~1.3.3",
 				"path-to-regexp": "~0.1.12",
 				"proxy-addr": "~2.0.7",
-				"qs": "~6.14.0",
+				"qs": "~6.15.1",
 				"range-parser": "~1.2.1",
 				"safe-buffer": "5.2.1",
 				"send": "~0.19.0",
@@ -18759,10 +18445,27 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/fast-uri": {
+			"version": "3.1.4",
+			"resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
+			"integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
+			"devOptional": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/fastify"
+				},
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/fastify"
+				}
+			],
+			"license": "BSD-3-Clause"
+		},
 		"node_modules/fast-xml-builder": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.2.0.tgz",
-			"integrity": "sha512-00aAWieqff+ZJhsXA4g1g7M8k+7AYoMUUHF+/zFb5U6Uv/P0Vl4QZo84/IcufzYalLuEj9928bXN9PbbFzMF0Q==",
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.3.0.tgz",
+			"integrity": "sha512-F74cZEdCvuw9P41GAC3rod4X04jjWGM1JPEv/GWSqFTWLsdyMSBMBMlm9Hk3GLBgLBbdBNY8yee0pQh2RBVESQ==",
 			"dev": true,
 			"funding": [
 				{
@@ -18772,14 +18475,14 @@
 			],
 			"license": "MIT",
 			"dependencies": {
-				"path-expression-matcher": "^1.5.0",
-				"xml-naming": "^0.1.0"
+				"path-expression-matcher": "^1.6.2",
+				"xml-naming": "^0.3.0"
 			}
 		},
 		"node_modules/fast-xml-parser": {
-			"version": "5.7.1",
-			"resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.7.1.tgz",
-			"integrity": "sha512-8Cc3f8GUGUULg34pBch/KGyPLglS+OFs05deyOlY7fL2MTagYPKrVQNmR1fLF/yJ9PH5ZSTd3YDF6pnmeZU+zA==",
+			"version": "5.10.1",
+			"resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.10.1.tgz",
+			"integrity": "sha512-IEMIf7298kXuZSRFoGfMYrl7is8LpavODgbNz1cwIudv7KwVFnuU+UsMporfq6PD6aXSlawZlARiA3UywCTfMw==",
 			"dev": true,
 			"funding": [
 				{
@@ -18789,10 +18492,12 @@
 			],
 			"license": "MIT",
 			"dependencies": {
-				"@nodable/entities": "^2.1.0",
-				"fast-xml-builder": "^1.1.5",
-				"path-expression-matcher": "^1.5.0",
-				"strnum": "^2.2.3"
+				"@nodable/entities": "^3.0.0",
+				"fast-xml-builder": "^1.2.0",
+				"is-unsafe": "^2.0.0",
+				"path-expression-matcher": "^1.6.2",
+				"strnum": "^2.4.1",
+				"xml-naming": "^0.3.0"
 			},
 			"bin": {
 				"fxparser": "src/cli/cli.js"
@@ -20041,9 +19746,9 @@
 			}
 		},
 		"node_modules/http-proxy-middleware": {
-			"version": "2.0.9",
-			"resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-2.0.9.tgz",
-			"integrity": "sha512-c1IyJYLYppU574+YI7R4QyX2ystMtVXZwIdzazUIPIJsHuWNd+mho2j+bKoHftndicGj9yh+xjd+l0yj7VeT1Q==",
+			"version": "2.0.10",
+			"resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-2.0.10.tgz",
+			"integrity": "sha512-RKzRWNPxUZqbuk3BC5mGVJbBnWgr+diEnjJexIOytFbBzDy88Fbh/YvBr3DsNrl1jYAfjWfpATEv0NO35FDuPQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -20173,6 +19878,27 @@
 			"peerDependencies": {
 				"postcss": "^8.1.0"
 			}
+		},
+		"node_modules/ieee754": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+			"integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/feross"
+				},
+				{
+					"type": "patreon",
+					"url": "https://www.patreon.com/feross"
+				},
+				{
+					"type": "consulting",
+					"url": "https://feross.org/support"
+				}
+			],
+			"license": "BSD-3-Clause"
 		},
 		"node_modules/ignore": {
 			"version": "5.3.2",
@@ -20911,6 +20637,19 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
+		"node_modules/is-unsafe": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/is-unsafe/-/is-unsafe-2.0.0.tgz",
+			"integrity": "sha512-2LdV822R+wmI86unXA93WCFpL6g+av8ynWk0nrHyJqGop5VoocYsSLFgN8jrfalT6iGeLNM4KXuVSsULP53kEA==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/NaturalIntelligence"
+				}
+			],
+			"license": "MIT"
+		},
 		"node_modules/is-weakmap": {
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/is-weakmap/-/is-weakmap-2.0.2.tgz",
@@ -20992,6 +20731,59 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/isomorphic-git": {
+			"version": "1.37.6",
+			"resolved": "https://registry.npmjs.org/isomorphic-git/-/isomorphic-git-1.37.6.tgz",
+			"integrity": "sha512-qr1NFCPsVTZ6YGqTXw0CzamnsHyH9QQ1OTEfeXIweSljRUMzuHFCJdUn0wc6OcjtTDns6knxjPb7N6LmJeftOA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"async-lock": "^1.4.1",
+				"clean-git-ref": "^2.0.1",
+				"crc-32": "^1.2.0",
+				"diff3": "0.0.3",
+				"ignore": "^5.1.4",
+				"minimisted": "^2.0.0",
+				"pako": "^1.0.10",
+				"pify": "^4.0.1",
+				"readable-stream": "^4.0.0",
+				"sha.js": "^2.4.12",
+				"simple-get": "^4.0.1"
+			},
+			"bin": {
+				"isogit": "cli.cjs"
+			},
+			"engines": {
+				"node": ">=14.17"
+			}
+		},
+		"node_modules/isomorphic-git/node_modules/pify": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
+			"integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/isomorphic-git/node_modules/readable-stream": {
+			"version": "4.7.0",
+			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.7.0.tgz",
+			"integrity": "sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"abort-controller": "^3.0.0",
+				"buffer": "^6.0.3",
+				"events": "^3.3.0",
+				"process": "^0.11.10",
+				"string_decoder": "^1.3.0"
+			},
+			"engines": {
+				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
 			}
 		},
 		"node_modules/istanbul-lib-coverage": {
@@ -21542,38 +21334,6 @@
 				}
 			}
 		},
-		"node_modules/jest-config/node_modules/@babel/core": {
-			"version": "7.29.0",
-			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
-			"integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
-			"dev": true,
-			"license": "MIT",
-			"peer": true,
-			"dependencies": {
-				"@babel/code-frame": "^7.29.0",
-				"@babel/generator": "^7.29.0",
-				"@babel/helper-compilation-targets": "^7.28.6",
-				"@babel/helper-module-transforms": "^7.28.6",
-				"@babel/helpers": "^7.28.6",
-				"@babel/parser": "^7.29.0",
-				"@babel/template": "^7.28.6",
-				"@babel/traverse": "^7.29.0",
-				"@babel/types": "^7.29.0",
-				"@jridgewell/remapping": "^2.3.5",
-				"convert-source-map": "^2.0.0",
-				"debug": "^4.1.0",
-				"gensync": "^1.0.0-beta.2",
-				"json5": "^2.2.3",
-				"semver": "^6.3.1"
-			},
-			"engines": {
-				"node": ">=6.9.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/babel"
-			}
-		},
 		"node_modules/jest-config/node_modules/@jest/schemas": {
 			"version": "30.0.5",
 			"resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-30.0.5.tgz",
@@ -21721,33 +21481,14 @@
 			}
 		},
 		"node_modules/jest-config/node_modules/brace-expansion": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-			"integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
+			"integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
 			"dev": true,
 			"license": "MIT",
 			"peer": true,
 			"dependencies": {
 				"balanced-match": "^1.0.0"
-			}
-		},
-		"node_modules/jest-config/node_modules/debug": {
-			"version": "4.4.3",
-			"resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
-			"integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-			"dev": true,
-			"license": "MIT",
-			"peer": true,
-			"dependencies": {
-				"ms": "^2.1.3"
-			},
-			"engines": {
-				"node": ">=6.0"
-			},
-			"peerDependenciesMeta": {
-				"supports-color": {
-					"optional": true
-				}
 			}
 		},
 		"node_modules/jest-config/node_modules/glob": {
@@ -22654,38 +22395,6 @@
 				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
 			}
 		},
-		"node_modules/jest-runner/node_modules/@babel/core": {
-			"version": "7.29.0",
-			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
-			"integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
-			"dev": true,
-			"license": "MIT",
-			"peer": true,
-			"dependencies": {
-				"@babel/code-frame": "^7.29.0",
-				"@babel/generator": "^7.29.0",
-				"@babel/helper-compilation-targets": "^7.28.6",
-				"@babel/helper-module-transforms": "^7.28.6",
-				"@babel/helpers": "^7.28.6",
-				"@babel/parser": "^7.29.0",
-				"@babel/template": "^7.28.6",
-				"@babel/traverse": "^7.29.0",
-				"@babel/types": "^7.29.0",
-				"@jridgewell/remapping": "^2.3.5",
-				"convert-source-map": "^2.0.0",
-				"debug": "^4.1.0",
-				"gensync": "^1.0.0-beta.2",
-				"json5": "^2.2.3",
-				"semver": "^6.3.1"
-			},
-			"engines": {
-				"node": ">=6.9.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/babel"
-			}
-		},
 		"node_modules/jest-runner/node_modules/@jest/schemas": {
 			"version": "30.0.5",
 			"resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-30.0.5.tgz",
@@ -22775,25 +22484,6 @@
 			},
 			"engines": {
 				"node": ">=12"
-			}
-		},
-		"node_modules/jest-runner/node_modules/debug": {
-			"version": "4.4.3",
-			"resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
-			"integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-			"dev": true,
-			"license": "MIT",
-			"peer": true,
-			"dependencies": {
-				"ms": "^2.1.3"
-			},
-			"engines": {
-				"node": ">=6.0"
-			},
-			"peerDependenciesMeta": {
-				"supports-color": {
-					"optional": true
-				}
 			}
 		},
 		"node_modules/jest-runner/node_modules/istanbul-lib-instrument": {
@@ -22984,38 +22674,6 @@
 				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
 			}
 		},
-		"node_modules/jest-runtime/node_modules/@babel/core": {
-			"version": "7.29.0",
-			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
-			"integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
-			"dev": true,
-			"license": "MIT",
-			"peer": true,
-			"dependencies": {
-				"@babel/code-frame": "^7.29.0",
-				"@babel/generator": "^7.29.0",
-				"@babel/helper-compilation-targets": "^7.28.6",
-				"@babel/helper-module-transforms": "^7.28.6",
-				"@babel/helpers": "^7.28.6",
-				"@babel/parser": "^7.29.0",
-				"@babel/template": "^7.28.6",
-				"@babel/traverse": "^7.29.0",
-				"@babel/types": "^7.29.0",
-				"@jridgewell/remapping": "^2.3.5",
-				"convert-source-map": "^2.0.0",
-				"debug": "^4.1.0",
-				"gensync": "^1.0.0-beta.2",
-				"json5": "^2.2.3",
-				"semver": "^6.3.1"
-			},
-			"engines": {
-				"node": ">=6.9.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/babel"
-			}
-		},
 		"node_modules/jest-runtime/node_modules/@jest/schemas": {
 			"version": "30.0.5",
 			"resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-30.0.5.tgz",
@@ -23108,33 +22766,14 @@
 			}
 		},
 		"node_modules/jest-runtime/node_modules/brace-expansion": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-			"integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
+			"integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
 			"dev": true,
 			"license": "MIT",
 			"peer": true,
 			"dependencies": {
 				"balanced-match": "^1.0.0"
-			}
-		},
-		"node_modules/jest-runtime/node_modules/debug": {
-			"version": "4.4.3",
-			"resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
-			"integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-			"dev": true,
-			"license": "MIT",
-			"peer": true,
-			"dependencies": {
-				"ms": "^2.1.3"
-			},
-			"engines": {
-				"node": ">=6.0"
-			},
-			"peerDependenciesMeta": {
-				"supports-color": {
-					"optional": true
-				}
 			}
 		},
 		"node_modules/jest-runtime/node_modules/glob": {
@@ -23344,49 +22983,6 @@
 				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
 			}
 		},
-		"node_modules/jest-snapshot/node_modules/@babel/core": {
-			"version": "7.29.0",
-			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
-			"integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
-			"dev": true,
-			"license": "MIT",
-			"peer": true,
-			"dependencies": {
-				"@babel/code-frame": "^7.29.0",
-				"@babel/generator": "^7.29.0",
-				"@babel/helper-compilation-targets": "^7.28.6",
-				"@babel/helper-module-transforms": "^7.28.6",
-				"@babel/helpers": "^7.28.6",
-				"@babel/parser": "^7.29.0",
-				"@babel/template": "^7.28.6",
-				"@babel/traverse": "^7.29.0",
-				"@babel/types": "^7.29.0",
-				"@jridgewell/remapping": "^2.3.5",
-				"convert-source-map": "^2.0.0",
-				"debug": "^4.1.0",
-				"gensync": "^1.0.0-beta.2",
-				"json5": "^2.2.3",
-				"semver": "^6.3.1"
-			},
-			"engines": {
-				"node": ">=6.9.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/babel"
-			}
-		},
-		"node_modules/jest-snapshot/node_modules/@babel/core/node_modules/semver": {
-			"version": "6.3.1",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
-			"integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-			"dev": true,
-			"license": "ISC",
-			"peer": true,
-			"bin": {
-				"semver": "bin/semver.js"
-			}
-		},
 		"node_modules/jest-snapshot/node_modules/@jest/schemas": {
 			"version": "30.0.5",
 			"resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-30.0.5.tgz",
@@ -23476,25 +23072,6 @@
 			},
 			"engines": {
 				"node": ">=12"
-			}
-		},
-		"node_modules/jest-snapshot/node_modules/debug": {
-			"version": "4.4.3",
-			"resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
-			"integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-			"dev": true,
-			"license": "MIT",
-			"peer": true,
-			"dependencies": {
-				"ms": "^2.1.3"
-			},
-			"engines": {
-				"node": ">=6.0"
-			},
-			"peerDependenciesMeta": {
-				"supports-color": {
-					"optional": true
-				}
 			}
 		},
 		"node_modules/jest-snapshot/node_modules/istanbul-lib-instrument": {
@@ -24180,9 +23757,9 @@
 			}
 		},
 		"node_modules/jsonwebtoken/node_modules/semver": {
-			"version": "7.7.4",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
-			"integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+			"version": "7.8.5",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+			"integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
 			"dev": true,
 			"license": "ISC",
 			"bin": {
@@ -24520,23 +24097,6 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/jonschlinkert"
-			}
-		},
-		"node_modules/lint-staged/node_modules/yaml": {
-			"version": "2.9.0",
-			"resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
-			"integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
-			"dev": true,
-			"license": "ISC",
-			"optional": true,
-			"bin": {
-				"yaml": "bin.mjs"
-			},
-			"engines": {
-				"node": ">= 14.6"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/eemeli"
 			}
 		},
 		"node_modules/loader-runner": {
@@ -24897,10 +24457,20 @@
 			}
 		},
 		"node_modules/markdownlint-cli/node_modules/js-yaml": {
-			"version": "4.1.1",
-			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-			"integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+			"integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
 			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/puzrin"
+				},
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/nodeca"
+				}
+			],
 			"license": "MIT",
 			"dependencies": {
 				"argparse": "^2.0.1"
@@ -25512,9 +25082,9 @@
 			}
 		},
 		"node_modules/nan": {
-			"version": "2.25.0",
-			"resolved": "https://registry.npmjs.org/nan/-/nan-2.25.0.tgz",
-			"integrity": "sha512-0M90Ag7Xn5KMLLZ7zliPWP3rT90P6PN+IzVFS0VqmnPktBk3700xUVv8Ikm9EUaUE5SDWdp/BIxdENzVznpm1g==",
+			"version": "2.28.0",
+			"resolved": "https://registry.npmjs.org/nan/-/nan-2.28.0.tgz",
+			"integrity": "sha512-fTsDz99OTq2sVePhGdp4qQhggZFtKr64ZNVyVajRKtMOkJxYekplBh577PiJB12v/D3s2E5cGtOI45LWp6rnLQ==",
 			"dev": true,
 			"license": "MIT"
 		},
@@ -26506,9 +26076,9 @@
 			"license": "BlueOak-1.0.0"
 		},
 		"node_modules/pako": {
-			"version": "1.0.10",
-			"resolved": "https://registry.npmjs.org/pako/-/pako-1.0.10.tgz",
-			"integrity": "sha512-0DTvPVU3ed8+HNXOu5Bs+o//Mbdj9VNQMUOe9oKCwh8l0GNwpTDMKCWbRjgtD291AWnkAgkqA/LOnQS8AmS1tw==",
+			"version": "1.0.11",
+			"resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+			"integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
 			"dev": true,
 			"license": "(MIT AND Zlib)"
 		},
@@ -26661,9 +26231,9 @@
 			}
 		},
 		"node_modules/path-expression-matcher": {
-			"version": "1.5.0",
-			"resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.5.0.tgz",
-			"integrity": "sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ==",
+			"version": "1.6.2",
+			"resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.6.2.tgz",
+			"integrity": "sha512-enSlaiat05iasnzmgNxRj8reFdj3puY2QpNgP1aPIaVfT6nn9ICuPoFlKHk8EN22HcwewshO+mN2DGbkCEOtqQ==",
 			"dev": true,
 			"funding": [
 				{
@@ -26728,9 +26298,9 @@
 			"license": "ISC"
 		},
 		"node_modules/path-to-regexp": {
-			"version": "0.1.12",
-			"resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.12.tgz",
-			"integrity": "sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ==",
+			"version": "0.1.13",
+			"resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.13.tgz",
+			"integrity": "sha512-A/AGNMFN3c8bOlvV9RreMdrv7jsmF9XIfDeCd87+I8RNg6s78BhJxMu69NEMHBSJFxKidViTEdruRwEk/WIKqA==",
 			"dev": true,
 			"license": "MIT"
 		},
@@ -27211,9 +26781,9 @@
 			}
 		},
 		"node_modules/postcss-loader/node_modules/yaml": {
-			"version": "1.10.2",
-			"resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
-			"integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==",
+			"version": "1.10.3",
+			"resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.3.tgz",
+			"integrity": "sha512-vIYeF1u3CjlhAFekPPAk2h/Kv4T3mAkMox5OymRiJQB0spDP10LHvt+K7G9Ny6NuuMAb25/6n1qyUjAcGNf/AA==",
 			"dev": true,
 			"license": "ISC",
 			"engines": {
@@ -27902,6 +27472,16 @@
 				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
 			}
 		},
+		"node_modules/process": {
+			"version": "0.11.10",
+			"resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
+			"integrity": "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.6.0"
+			}
+		},
 		"node_modules/process-nextick-args": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
@@ -28021,13 +27601,6 @@
 			"dev": true,
 			"license": "MIT"
 		},
-		"node_modules/ps-man": {
-			"version": "1.1.8",
-			"resolved": "https://registry.npmjs.org/ps-man/-/ps-man-1.1.8.tgz",
-			"integrity": "sha512-ZKDPZwHLYVWIk/Q75N7jCFbuQyokSg2+3WBlt8l35S/uBvxoc+LiRUbb3RUt83pwW82dzwiCpoQIHd9PAxUzHg==",
-			"dev": true,
-			"license": "MIT"
-		},
 		"node_modules/pump": {
 			"version": "3.0.3",
 			"resolved": "https://registry.npmjs.org/pump/-/pump-3.0.3.tgz",
@@ -28043,7 +27616,7 @@
 			"version": "2.3.1",
 			"resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
 			"integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
-			"devOptional": true,
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=6"
@@ -28093,28 +27666,6 @@
 			"dev": true,
 			"license": "BSD-3-Clause"
 		},
-		"node_modules/puppeteer-core/node_modules/ws": {
-			"version": "8.19.0",
-			"resolved": "https://registry.npmjs.org/ws/-/ws-8.19.0.tgz",
-			"integrity": "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=10.0.0"
-			},
-			"peerDependencies": {
-				"bufferutil": "^4.0.1",
-				"utf-8-validate": ">=5.0.2"
-			},
-			"peerDependenciesMeta": {
-				"bufferutil": {
-					"optional": true
-				},
-				"utf-8-validate": {
-					"optional": true
-				}
-			}
-		},
 		"node_modules/pure-rand": {
 			"version": "7.0.1",
 			"resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-7.0.1.tgz",
@@ -28154,13 +27705,14 @@
 			"license": "MIT"
 		},
 		"node_modules/qs": {
-			"version": "6.14.2",
-			"resolved": "https://registry.npmjs.org/qs/-/qs-6.14.2.tgz",
-			"integrity": "sha512-V/yCWTTF7VJ9hIh18Ugr2zhJMP01MY7c5kh4J870L7imm6/DIzBsNLTXzMwUA3yZ5b/KBqLx8Kp3uRvd7xSe3Q==",
+			"version": "6.15.3",
+			"resolved": "https://registry.npmjs.org/qs/-/qs-6.15.3.tgz",
+			"integrity": "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==",
 			"dev": true,
 			"license": "BSD-3-Clause",
 			"dependencies": {
-				"side-channel": "^1.1.0"
+				"es-define-property": "^1.0.1",
+				"side-channel": "^1.1.1"
 			},
 			"engines": {
 				"node": ">=0.6"
@@ -28943,9 +28495,9 @@
 			}
 		},
 		"node_modules/rimraf/node_modules/brace-expansion": {
-			"version": "5.0.4",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.4.tgz",
-			"integrity": "sha512-h+DEnpVvxmfVefa4jFbCf5HdH5YMDXRsmKflpf1pILZWRFlTbJpxeU55nJl4Smt5HQaGzg1o6RHFPJaOqnmBDg==",
+			"version": "5.0.7",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
+			"integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -29625,15 +29177,15 @@
 			"license": "BSD-2-Clause"
 		},
 		"node_modules/side-channel": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
-			"integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
+			"integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"es-errors": "^1.3.0",
-				"object-inspect": "^1.13.3",
-				"side-channel-list": "^1.0.0",
+				"object-inspect": "^1.13.4",
+				"side-channel-list": "^1.0.1",
 				"side-channel-map": "^1.0.1",
 				"side-channel-weakmap": "^1.0.2"
 			},
@@ -29645,14 +29197,14 @@
 			}
 		},
 		"node_modules/side-channel-list": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
-			"integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+			"integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"es-errors": "^1.3.0",
-				"object-inspect": "^1.13.3"
+				"object-inspect": "^1.13.4"
 			},
 			"engines": {
 				"node": ">= 0.4"
@@ -30460,9 +30012,9 @@
 			}
 		},
 		"node_modules/strnum": {
-			"version": "2.2.3",
-			"resolved": "https://registry.npmjs.org/strnum/-/strnum-2.2.3.tgz",
-			"integrity": "sha512-oKx6RUCuHfT3oyVjtnrmn19H1SiCqgJSg+54XqURKp5aCMbrXrhLjRN9TjuwMjiYstZ0MzDrHqkGZ5dFTKd+zg==",
+			"version": "2.4.1",
+			"resolved": "https://registry.npmjs.org/strnum/-/strnum-2.4.1.tgz",
+			"integrity": "sha512-M9eUSMT2dCB2cTNPG7UYj6KuK7RJR2SN2+yCV/fTW3xzTCS6EaGZ5pSMgDIjB7r8zSfTGk+dvvn9rTjpVS9Mwg==",
 			"dev": true,
 			"funding": [
 				{
@@ -30470,7 +30022,10 @@
 					"url": "https://github.com/sponsors/NaturalIntelligence"
 				}
 			],
-			"license": "MIT"
+			"license": "MIT",
+			"dependencies": {
+				"anynum": "^1.0.1"
+			}
 		},
 		"node_modules/stubborn-fs": {
 			"version": "2.0.0",
@@ -31265,16 +30820,15 @@
 			}
 		},
 		"node_modules/terser-webpack-plugin": {
-			"version": "5.3.16",
-			"resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.3.16.tgz",
-			"integrity": "sha512-h9oBFCWrq78NyWWVcSwZarJkZ01c2AyGrzs1crmHZO3QUg9D61Wu4NPjBy69n7JqylFF5y+CsUZYmYEIZ3mR+Q==",
+			"version": "5.6.1",
+			"resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.6.1.tgz",
+			"integrity": "sha512-201R5j+sJpK8nFWwKVyNfZot8FaJbLZDq5evriVzbV1wDtSXDjRUDRfJzHpAaxFDMEhsZL1QkeqM61wgsS3KaQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@jridgewell/trace-mapping": "^0.3.25",
 				"jest-worker": "^27.4.5",
 				"schema-utils": "^4.3.0",
-				"serialize-javascript": "^6.0.2",
 				"terser": "^5.31.1"
 			},
 			"engines": {
@@ -31288,10 +30842,37 @@
 				"webpack": "^5.1.0"
 			},
 			"peerDependenciesMeta": {
+				"@minify-html/node": {
+					"optional": true
+				},
 				"@swc/core": {
 					"optional": true
 				},
+				"@swc/css": {
+					"optional": true
+				},
+				"@swc/html": {
+					"optional": true
+				},
+				"clean-css": {
+					"optional": true
+				},
+				"cssnano": {
+					"optional": true
+				},
+				"csso": {
+					"optional": true
+				},
 				"esbuild": {
+					"optional": true
+				},
+				"html-minifier-terser": {
+					"optional": true
+				},
+				"lightningcss": {
+					"optional": true
+				},
+				"postcss": {
 					"optional": true
 				},
 				"uglify-js": {
@@ -32025,7 +31606,7 @@
 			"version": "4.4.1",
 			"resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
 			"integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
-			"devOptional": true,
+			"dev": true,
 			"license": "BSD-2-Clause",
 			"dependencies": {
 				"punycode": "^2.1.0"
@@ -32446,9 +32027,9 @@
 			}
 		},
 		"node_modules/webpack-bundle-analyzer/node_modules/ws": {
-			"version": "7.5.10",
-			"resolved": "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz",
-			"integrity": "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==",
+			"version": "7.5.13",
+			"resolved": "https://registry.npmjs.org/ws/-/ws-7.5.13.tgz",
+			"integrity": "sha512-rsKI6xDBFVf4r/x8XyChGK04QR/XHroxs/jUcoWvtEZM8TPU/X/uIY9B1CsSzYws9ZJb/6bbBu7dPhFW00CAoA==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -33093,9 +32674,9 @@
 			"license": "ISC"
 		},
 		"node_modules/ws": {
-			"version": "8.18.3",
-			"resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
-			"integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
+			"version": "8.21.0",
+			"resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+			"integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -33138,9 +32719,9 @@
 			}
 		},
 		"node_modules/xml-naming": {
-			"version": "0.1.0",
-			"resolved": "https://registry.npmjs.org/xml-naming/-/xml-naming-0.1.0.tgz",
-			"integrity": "sha512-k8KO9hrMyNk6tUWqUfkTEZbezRRpONVOzUTnc97VnCvyj6Tf9lyUR9EDAIeiVLv56jsMcoXEwjW8Kv5yPY52lw==",
+			"version": "0.3.0",
+			"resolved": "https://registry.npmjs.org/xml-naming/-/xml-naming-0.3.0.tgz",
+			"integrity": "sha512-ghig2TBE/H11aOVgmahA3MhimvkBr6JIYknH/Dhdk10nXwdbIqBJsbfMxpvFPG8bAw77gN29aQWvKpmVoPlvPQ==",
 			"dev": true,
 			"funding": [
 				{
@@ -33212,9 +32793,9 @@
 			"license": "ISC"
 		},
 		"node_modules/yaml": {
-			"version": "2.8.2",
-			"resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.2.tgz",
-			"integrity": "sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A==",
+			"version": "2.9.0",
+			"resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+			"integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
 			"dev": true,
 			"license": "ISC",
 			"bin": {
@@ -33347,6 +32928,13 @@
 			"peerDependencies": {
 				"zod": "^3.25.0 || ^4.0.0"
 			}
+		},
+		"node_modules/zstddec": {
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/zstddec/-/zstddec-0.2.0.tgz",
+			"integrity": "sha512-oyPnDa1X5c13+Y7mA/FDMNJrn4S8UNBe0KCqtDmor40Re7ALrPN6npFwyYVRRh+PqozZQdeg23QtbcamZnG5rA==",
+			"dev": true,
+			"license": "MIT AND BSD-3-Clause"
 		}
 	}
 }


### PR DESCRIPTION
## Why

The repository has multiple open Dependabot alerts for vulnerabilities in transitive dependencies.

## What

Applied `npm audit fix` (without `--force`, non-breaking) to resolve everything safely fixable.

- Only `package-lock.json` changed; no direct dependency ranges in `package.json` were touched.
- Reduces `npm audit` from 63 to 34 vulnerabilities.

## Remaining

The remaining 34 are transitive dependencies pinned deep inside the `@wordpress` toolchain. Resolving them requires either breaking upgrades (`npm audit fix --force`) or `overrides`, so they are out of scope here. This includes `dompurify` (bundled via `monaco-editor`), the only alert affecting shipped code.

## Verification

- `npm run build` — success
- `npm run lint:types` — success
- `npm run lint:js` — success
