### PR TITLE
Bump @wordpress/env to 11.15.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,7 @@
 				"@wordpress/dom-ready": "^4.51.0",
 				"@wordpress/e2e-test-utils": "^11.34.0",
 				"@wordpress/element": "^8.3.0",
-				"@wordpress/env": "^11.11.0",
+				"@wordpress/env": "^11.15.0",
 				"@wordpress/hooks": "^4.51.0",
 				"@wordpress/i18n": "^6.24.0",
 				"@wordpress/keycodes": "^4.51.0",
@@ -10398,15 +10398,15 @@
 			}
 		},
 		"node_modules/@wordpress/env": {
-			"version": "11.11.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/env/-/env-11.11.0.tgz",
-			"integrity": "sha512-E4Riaan41uAcm70FFTD78Z1qtObQJwRlIyXdsr04X+mrg8XkBuHSqM1iSvgqnOpVzUuF9EYANYKF0CTm9tKW5w==",
+			"version": "11.15.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/env/-/env-11.15.0.tgz",
+			"integrity": "sha512-FZq3eMDXBlZVZU8jVSX/4XoexgiBM4ZBqk69Mh23pz+1MMeQ13l7g5v7zKAAnyA3F9eHd+1sWsUpQnuS1f1T6Q==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@inquirer/prompts": "^7.2.0",
 				"@wp-playground/cli": "^3.0.48",
-				"adm-zip": "^0.5.9",
+				"adm-zip": "^0.6.0",
 				"chalk": "^4.1.1",
 				"copy-dir": "^1.3.0",
 				"cross-spawn": "^7.0.6",
@@ -10415,7 +10415,7 @@
 				"js-yaml": "^3.15.0",
 				"ora": "^4.0.2",
 				"rimraf": "^5.0.10",
-				"simple-git": "^3.24.0",
+				"simple-git": "^3.32.3",
 				"yargs": "^17.3.0"
 			},
 			"bin": {
@@ -10424,6 +10424,16 @@
 			"engines": {
 				"node": ">=18.12.0",
 				"npm": ">=8.19.2"
+			}
+		},
+		"node_modules/@wordpress/env/node_modules/adm-zip": {
+			"version": "0.6.0",
+			"resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.6.0.tgz",
+			"integrity": "sha512-XleryMhbuksdKtofnWZ9Sk+4CUTbms4Mb/EU32SZwToAyZ5RgVos/ki8n+yr0LWHOGKuakbXTuuYNHLQjhddgg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=14.0"
 			}
 		},
 		"node_modules/@wordpress/env/node_modules/brace-expansion": {

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
 		"@wordpress/dom-ready": "^4.51.0",
 		"@wordpress/e2e-test-utils": "^11.34.0",
 		"@wordpress/element": "^8.3.0",
-		"@wordpress/env": "^11.11.0",
+		"@wordpress/env": "^11.15.0",
 		"@wordpress/hooks": "^4.51.0",
 		"@wordpress/i18n": "^6.24.0",
 		"@wordpress/keycodes": "^4.51.0",


### PR DESCRIPTION
Bumps `@wordpress/env` from `^11.11.0` to `^11.15.0`, which pulls in `adm-zip@0.6.0` in place of the vulnerable `0.5.x` line. `simple-git` was already resolved at `3.36.0`, so only `adm-zip` changes in the lockfile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)